### PR TITLE
Fixed undefined instance error when combined with Angular Universal

### DIFF
--- a/lib/resolvers-explorer.service.ts
+++ b/lib/resolvers-explorer.service.ts
@@ -32,7 +32,7 @@ export class ResolversExplorerService {
     );
     const resolvers = this.flatMap(modules, instance =>
       this.filterResolvers(instance),
-    );
+    ).filter(r => r);
     return this.groupMetadata(resolvers);
   }
 
@@ -42,7 +42,7 @@ export class ResolversExplorerService {
   ) {
     return flattenDeep(
       modules.map(module =>
-        [...module.values()].map(({ instance }) => callback(instance)),
+        [...module.values()].map(({ instance }) => instance && callback(instance)),
       ),
     );
   }


### PR DESCRIPTION
I integrated grapql in my project (https://github.com/bojidaryovchev/nest-angular/tree/master/src/server/modules) following this example https://github.com/nestjs/nest/tree/master/sample/12-graphql-apollo.. But I also have Angular Universal from the angular universal example.. And I found out that when we have both our GraphqlModule and AngularUniversalModule, an undefined instance appears in the modules instances in the explore and flapMap functions in resolvers-explorer.service.. Follow the images for further information:

https://ibb.co/hhX5RT
https://ibb.co/fujKmT
https://ibb.co/cafs6T

I found this fix to make things work however I am not completely sure that it is sufficient.. It seems to be, but I cannot determine.. Anyway, I shall make a pull request