### PR TITLE
fix(GraphQLFactory): avoid unnecessary overwrites

### DIFF
--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -1,3 +1,4 @@
+import { existsSync, lstatSync, readFileSync } from 'fs';
 import { Injectable } from '@nestjs/common';
 import { gql, makeExecutableSchema, mergeSchemas } from 'apollo-server-express';
 import { MergeInfo } from 'graphql-tools/dist/Interfaces';
@@ -75,6 +76,12 @@ export class GraphQLFactory {
       options.definitions.path,
       options.definitions.outputAs,
     );
-    await tsFile.save();
+    if (
+      !existsSync(options.definitions.path) ||
+      !lstatSync(options.definitions.path).isFile() ||
+      readFileSync(options.definitions.path, 'utf8') !== tsFile.getText()
+    ) {
+      await tsFile.save();
+    }
   }
 }


### PR DESCRIPTION
Do not overwrite the TS file if it already exists with the same text (source). This prevents restart loops with tools like `nodemon`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
A minor change in behavior

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: A minor change in behavior
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The output TS file is always overwritten.

Issue Number: N/A


## What is the new behavior?
The output TS file is overwritten only if the text (source) has changed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information