### PR TITLE
bugfix() Sort lookup parameters

### DIFF
--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -154,6 +154,13 @@ export class GraphQLAstExplorer {
         return this.lookupField(item, parentRef, mode);
     }
   }
+  
+  private sortGraphqlArguments(first: any, second:any): number {
+    if (first.hasQuestionToken && second.hasQuestionToken || !(first.hasQuestionToken || second.hasQuestionToken)) {
+      return first.name === second.name : 0 ? first.name > second.name ? 1 : -1;
+    }
+    return first.hasQuestionToken ? 1 : -1;
+  }
 
   lookupField(
     item: FieldDefinitionNode | InputValueDefinitionNode,
@@ -184,21 +191,7 @@ export class GraphQLAstExplorer {
       returnType: `${type} | Promise<${type}>`,
       parameters: this.getFunctionParameters(
         (item as FieldDefinitionNode).arguments,
-      ).sort((a, b) => {
-        if (a.hasQuestionToken && b.hasQuestionToken || !(a.hasQuestionToken || b.hasQuestionToken)) {
-          if (a.name < b.name) {
-            return -1;
-          } else if (a.name > b.name) {
-            return 1;
-          } else {
-            return 0;
-          }
-        } else if (a.hasQuestionToken) {
-          return 1;
-        } else {
-          return -1;
-        }
-      }),
+      ).sort(this.sortGraphqlArguments),
     });
   }
 

--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -184,7 +184,21 @@ export class GraphQLAstExplorer {
       returnType: `${type} | Promise<${type}>`,
       parameters: this.getFunctionParameters(
         (item as FieldDefinitionNode).arguments,
-      ),
+      ).sort((a, b) => {
+        if (a.hasQuestionToken && b.hasQuestionToken || !(a.hasQuestionToken || b.hasQuestionToken)) {
+          if (a.name < b.name) {
+            return -1;
+          } else if (a.name > b.name) {
+            return 1;
+          } else {
+            return 0;
+          }
+        } else if (a.hasQuestionToken) {
+          return 1;
+        } else {
+          return -1;
+        }
+      }),
     });
   }
 


### PR DESCRIPTION
Required lookup parameters were not generated at the beginning of the
methods. This caused the generated files to be invalid.
This change makes sure that all required fields are at the beginning of
the parameter list followed by all optional parameters.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When generating schema types, the required function parameters were not in the beginning.


## What is the new behavior?
Generated function parameters are now sorted based on them being required and then based on the name.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information