### PR TITLE
feat: implement ResolverPrefix decorator

### DIFF
--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -7,6 +7,7 @@ export * from './parent.decorator';
 export * from './query.decorator';
 export * from './resolve-property.decorator';
 export * from './resolver.decorator';
+export * from './resolver-prefix.decorator';
 export * from './root.decorator';
 export * from './scalar.decorator';
 export * from './subscription.decorator';

--- a/lib/decorators/resolver-prefix.decorator.ts
+++ b/lib/decorators/resolver-prefix.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+import { RESOLVER_PREFIX_METADATA, } from '../graphql.constants';
+
+export function ResolverPrefix(name: string): ClassDecorator {
+  return (target, key?, descriptor?) => {
+    SetMetadata(RESOLVER_PREFIX_METADATA, name)(target, key, descriptor);
+  };
+}

--- a/lib/graphql.constants.ts
+++ b/lib/graphql.constants.ts
@@ -1,5 +1,6 @@
 export const RESOLVER_TYPE_METADATA = 'graphql:resolver_type';
 export const RESOLVER_NAME_METADATA = 'graphql:resolver_name';
+export const RESOLVER_PREFIX_METADATA = 'graphql:resolver_prefix';
 export const RESOLVER_PROPERTY_METADATA = 'graphql:resolve_property';
 export const RESOLVER_DELEGATE_METADATA = 'graphql:delegate_property';
 export const SCALAR_NAME_METADATA = 'graphql:scalar_name';

--- a/lib/utils/extract-metadata.util.ts
+++ b/lib/utils/extract-metadata.util.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
   RESOLVER_DELEGATE_METADATA,
   RESOLVER_NAME_METADATA,
+  RESOLVER_PREFIX_METADATA,
   RESOLVER_PROPERTY_METADATA,
   RESOLVER_TYPE_METADATA,
 } from '../graphql.constants';
@@ -27,6 +28,10 @@ export function extractMetadata(
     callback,
   );
   const resolverName = Reflect.getMetadata(RESOLVER_NAME_METADATA, callback);
+  const resolverPrefix = Reflect.getMetadata(
+    RESOLVER_PREFIX_METADATA,
+    instance.constructor,
+  );
   const isDelegated = !!Reflect.getMetadata(
     RESOLVER_DELEGATE_METADATA,
     callback,
@@ -35,7 +40,11 @@ export function extractMetadata(
     return null;
   }
   return {
-    name: resolverName || methodName,
+    name:
+      resolverName ||
+      (resolverPrefix && !isPropertyResolver
+        ? `${resolverPrefix}${methodName}`
+        : methodName),
     type: resolverType,
     methodName,
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features) **(no tests in GraphQL package)**
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


There is no way to automatically prefix all the resolvers.

## What is the new behavior?

Add a simple way to prefix every resolvers while still letting a per-method override possibility.
This is something needed on very large application when there could be some collision on resolvers or just if you want to enforce a naming convention.

Until GraphQL implements namespaces, this is the only way to achieve this, nested operations are not an option since the order is not guaranteed in a multi-query, this is only done at the root level.

See https://github.com/facebook/graphql/issues/163 for more context on the subject.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Documentation PR is available here : https://github.com/nestjs/docs.nestjs.com/pull/241