### PR TITLE
refactor: improve types merging performance

### DIFF
--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -123,13 +123,9 @@ export class GraphQLModule implements OnModuleInit {
     } = this.options;
     const app = httpServer.getInstance();
 
-    const typePathsExists =
-      this.options.typePaths && !isEmpty(this.options.typePaths);
-    const typeDefs = typePathsExists
-      ? this.graphqlTypesLoader.mergeTypesByPaths(
-          ...(this.options.typePaths || []),
-        )
-      : [];
+    const typeDefs = await this.graphqlTypesLoader.mergeTypesByPaths(
+      this.options.typePaths,
+    );
 
     const mergedTypeDefs = extend(typeDefs, this.options.typeDefs);
     const apolloOptions = await this.graphQLFactory.mergeOptions({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/graphql",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1577,27 +1577,6 @@
         "is-glob": "^4.0.0",
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        }
       }
     },
     "fast-json-stable-stringify": {
@@ -4098,41 +4077,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        }
-      }
-    },
-    "ts-simple-ast": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/ts-simple-ast/-/ts-simple-ast-21.0.0.tgz",
-      "integrity": "sha512-pEDK5I1KC/fqtxdoeJYYmgFzfkdfZNoO/hFUBWLWRxXwQm4HpDYk/0VHd5ZbLf5wOXRMcUxJreEL7RPNv2oX7A==",
-      "requires": {
-        "@dsherret/to-absolute-glob": "^2.0.2",
-        "code-block-writer": "^7.2.2",
-        "fs-extra": "^7.0.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^8.0.1",
-        "is-negated-glob": "^1.0.0",
-        "multimatch": "^2.1.0",
-        "tslib": "^1.9.0",
-        "typescript": "^3.0.1"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "glob": "^7.1.3",
+    "fast-glob": "^2.2.6",
     "graphql-tools": "^4.0.3",
     "lodash": "^4.17.11",
     "merge-graphql-schemas": "^1.5.8",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
I've noticed that, after adding the GraphQL module, the time to boot the application increased significantly (about 2000-2300ms in a 4 GHz i7). After some benchmarks, i've noticed that almost all the time was being spent in `graphql-types.loader.ts`.

The current behavior uses the package `glob`, without ignoring `node_modules`, and it reads the types using the function `readFileSync` from `fs`.

Issue Number: N/A

## What is the new behavior?
After some changes, i was able to improve the time to boot the module by up to 24x. It was taking 2153ms initially, and now it's taking about 90ms.

Here are the changes:
* Replace [glob](https://github.com/isaacs/node-glob) with [fast-glob](https://github.com/mrmlnc/fast-glob).
* Add option to ignore `node_modules` in fast-glob.
* Replace `readFileSync` with `util.promisify(fs.readFile)` + `Promise.all`
* Simplify `mergeTypesByPaths` function implementation 🙂

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information