### PR TITLE
bugfix() generate types with method only if parent is root

### DIFF
--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -163,13 +163,9 @@ export class GraphQLAstExplorer {
     if (!propertyName) {
       return;
     }
-    const isFunction =
-      ((item as FieldDefinitionNode).arguments &&
-        !isEmpty((item as FieldDefinitionNode).arguments)) ||
-      this.isRoot(parentRef.getName());
 
     const { name: type, required } = this.getFieldTypeDefinition(item.type);
-    if (!isFunction) {
+    if (!this.isRoot(parentRef.getName())) {
       (parentRef as InterfaceDeclaration).addProperty({
         name: propertyName,
         type,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Define GraphQL schemas below

```graphql
type Query {
  parent: [Parent]
}

type Parent {
  children(limit: Int): [Children]
}
```

See the generated type defs be like

```ts
export abstract class Parent {
  abstract children(limit?: number): Children[] | Promise<Children[]>;
}
```

Which causes wrong typing for frontend project using the type defs
```ts
const parent = await client.query<Parent>(gql`
    {
        parent { children(limit: 10) { ... } }
     }
`)

parent.children // Expected array of data instead of function defined as `children(limit?): Children[] | Promise<Children[]>`
```

## What is the new behavior?

Only fields right under root(Query, Mutation, Subscription) will be typed with methods

```graphql
type Query {
  parent: [Parent]
}

type Parent {
  children(limit: Int): [Children]
}
```

Will generate

```ts
export abstract class Parent {
  children: Children[]
}
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information

Not sure if the current behavior was intended