### PR TITLE
fix(graphql.factory): prevent typing generation from causing a restart loop with nodemon

### DIFF
--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -81,7 +81,7 @@ export class GraphQLFactory {
     if (
       !existsSync(options.definitions.path) ||
       !lstatSync(options.definitions.path).isFile() ||
-      readFileSync(options.definitions.path, 'utf8') !== tsFile.getText()
+      readFileSync(options.definitions.path, 'utf8') !== tsFile.getFullText()
     ) {
       await tsFile.save();
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
TS typing generation causes a restart loop with nodemon.

Issue Number: Fixes #136


## What is the new behavior?
TS typing generation does not cause a restart loop with nodemon. (Generated file is overwritten only if the content has changed.)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information