### PR TITLE
Added missing context to subscription filter method

### DIFF
--- a/lib/decorators/resolvers.decorators.ts
+++ b/lib/decorators/resolvers.decorators.ts
@@ -148,9 +148,10 @@ export function Mutation(
 }
 
 export interface SubscriptionOptions {
-  filter?: <TPayload = any, TVariables = any>(
+  filter?: <TPayload = any, TVariables = any, TContext = any>(
     payload: TPayload,
     variables: TVariables,
+    context: TContext,
   ) => boolean;
   resolve?: <
     TPayload = any,


### PR DESCRIPTION
Added missing context to subscription filter method

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #165


## What is the new behavior?

Subscription filter parameters receive context too.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information