### PR TITLE
fix(types-loader): Remove query `temp__: Boolean` when schema is already described

### DIFF
--- a/lib/graphql-types.loader.ts
+++ b/lib/graphql-types.loader.ts
@@ -16,9 +16,11 @@ export class GraphQLTypesLoader {
 
     const types = await this.getTypesFromPaths(paths);
     const flatTypes = flatten(types);
-    const tempType = `type Query { temp__: Boolean }`; // Temporary workaround: https://github.com/okgrow/merge-graphql-schemas/issues/155
+    if (flatTypes.length === 0) {
+      flatTypes.push('type Query { temp__: Boolean }'); // Temporary workaround: https://github.com/okgrow/merge-graphql-schemas/issues/155
+    }
 
-    return mergeTypes([...flatTypes, tempType], { all: true });
+    return mergeTypes(flatTypes, { all: true });
   }
 
   private async getTypesFromPaths(paths: string | string[]): Promise<string[]> {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
Merge schemas behavior changes

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #120


## What is the new behavior?
Remove query `temp__: Boolean` when schema is already described

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->