### PR TITLE
chore(deps): move type-graphql to optional deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "@nestjs/core": "^6.0.0",
     "apollo-server-express": "^2.3.1",
     "graphql": "^14.1.1",
-    "type-graphql": "^0.17.0",
     "reflect-metadata": "^0.1.12"
+  },
+  "optionalDependencies": {
+    "type-graphql": "^0.17.0"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: move deps
```

## What is the new behavior?
Remove warning:
```
@nestjs/graphql@6.0.5 requires a peer of type-graphql@^0.17.0 but none is installed. You must install peer dependencies yourself.
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->