### PR TITLE
fix(@nestjs/graphql): fix array type output of generated properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ npm-debug.log
 /coverage
 /.nyc_output
 test-schema.graphql
+*.test-definitions.ts
 
 # dist
 /dist

--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -200,9 +200,7 @@ export class GraphQLAstExplorer {
 
     const isArray = type.kind === 'ListType';
     if (isArray) {
-      const { required, type: nestedType } = this.getNestedType(
-        get(type, 'type'),
-      );
+      const { type: nestedType } = this.getNestedType(get(type, 'type'));
       type = nestedType;
 
       const typeName = get(type, 'name.value');

--- a/tests/e2e/generated-definitions.spec.ts
+++ b/tests/e2e/generated-definitions.spec.ts
@@ -1,0 +1,167 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as util from 'util';
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { GraphQLFactory } from '../../lib';
+import { ApplicationModule } from '../type-graphql/app.module';
+
+const readFile = util.promisify(fs.readFile);
+
+const generatedDefinitions = fileName =>
+  path.join(__dirname, '..', 'generated-definitions', fileName);
+
+describe('Generated Definitions', () => {
+  let app: INestApplication;
+  let graphqlFactory: GraphQLFactory;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    graphqlFactory = app.get<GraphQLFactory>(GraphQLFactory);
+  });
+
+  it('should generate interface definitions for types', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('simple-type.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions('simple-type.test-definitions.ts');
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('simple-type.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate properties referencing other interfaces', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('interface-property.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'interface-property.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(
+        generatedDefinitions('interface-property.fixture.ts'),
+        'utf8',
+      ),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate array properties with correct optionality', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('array-property.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'array-property.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('array-property.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate queries', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('query.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions('query.test-definitions.ts');
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('query.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate mutations', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('mutation.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions('mutation.test-definitions.ts');
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('mutation.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate enums', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('enum.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions('enum.test-definitions.ts');
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('enum.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate custom scalars', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('custom-scalar.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'custom-scalar.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('custom-scalar.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/generated-definitions/array-property.fixture.ts
+++ b/tests/generated-definitions/array-property.fixture.ts
@@ -1,0 +1,12 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export interface Foo {
+  a: string[];
+  b?: string[];
+  c: string[];
+  d?: string[];
+}

--- a/tests/generated-definitions/array-property.graphql
+++ b/tests/generated-definitions/array-property.graphql
@@ -1,0 +1,6 @@
+type Foo {
+  a: [String!]!
+  b: [String!]
+  c: [String]!
+  d: [String]
+}

--- a/tests/generated-definitions/custom-scalar.fixture.ts
+++ b/tests/generated-definitions/custom-scalar.fixture.ts
@@ -1,0 +1,7 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export type Date = any;

--- a/tests/generated-definitions/custom-scalar.graphql
+++ b/tests/generated-definitions/custom-scalar.graphql
@@ -1,0 +1,1 @@
+scalar Date

--- a/tests/generated-definitions/enum.fixture.ts
+++ b/tests/generated-definitions/enum.fixture.ts
@@ -1,0 +1,11 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export enum Foobar {
+  Foo = 'Foo',
+  Bar = 'Bar',
+  Baz = 'Baz',
+}

--- a/tests/generated-definitions/enum.graphql
+++ b/tests/generated-definitions/enum.graphql
@@ -1,0 +1,5 @@
+enum Foobar {
+  Foo
+  Bar
+  Baz
+}

--- a/tests/generated-definitions/interface-property.fixture.ts
+++ b/tests/generated-definitions/interface-property.fixture.ts
@@ -1,0 +1,14 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export interface Bar {
+  id: number;
+}
+
+export interface Foo {
+  a: Bar;
+  b?: Bar;
+}

--- a/tests/generated-definitions/interface-property.graphql
+++ b/tests/generated-definitions/interface-property.graphql
@@ -1,0 +1,8 @@
+type Bar {
+  id: Int!
+}
+
+type Foo {
+  a: Bar!
+  b: Bar
+}

--- a/tests/generated-definitions/mutation.fixture.ts
+++ b/tests/generated-definitions/mutation.fixture.ts
@@ -1,0 +1,13 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export interface Cat {
+  id: number;
+}
+
+export interface IMutation {
+  createCat(name?: string): Cat | Promise<Cat>;
+}

--- a/tests/generated-definitions/mutation.graphql
+++ b/tests/generated-definitions/mutation.graphql
@@ -1,0 +1,7 @@
+type Cat {
+  id: Int!
+}
+
+type Mutation {
+  createCat(name: String): Cat
+}

--- a/tests/generated-definitions/query.fixture.ts
+++ b/tests/generated-definitions/query.fixture.ts
@@ -1,0 +1,13 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export interface Cat {
+  id: number;
+}
+
+export interface IQuery {
+  cat(id: string): Cat | Promise<Cat>;
+}

--- a/tests/generated-definitions/query.graphql
+++ b/tests/generated-definitions/query.graphql
@@ -1,0 +1,7 @@
+type Cat {
+  id: Int!
+}
+
+type Query {
+  cat(id: ID!): Cat
+}

--- a/tests/generated-definitions/simple-type.fixture.ts
+++ b/tests/generated-definitions/simple-type.fixture.ts
@@ -1,0 +1,13 @@
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+export interface Cat {
+  id: number;
+  name: string;
+  age?: number;
+  color?: string;
+  weight?: number;
+}

--- a/tests/generated-definitions/simple-type.graphql
+++ b/tests/generated-definitions/simple-type.graphql
@@ -1,0 +1,7 @@
+type Cat {
+  id: Int!
+  name: String!
+  age: Int
+  color: String
+  weight: Int
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`prop: [String!]` currently outputs `prop: string[]` because of the `String!`, which is incorrect because whether `prop` is required is based on whether there is a `!` outside the brackets, not inside.

## What is the new behavior?

`prop: [String!]` now outputs `prop?: string[]` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Technically this is a breaking change, if there is any `propName: [Foo!]` within a project's graphql schema the outputted definitions will change from `propName: Foo[]` to `propName?: Foo[]`.

"Technically" this update could break something in an edge case were someone has written a bad schema based on this behaviour or . But these edge cases should be simple one-character or arg reordering fixes.

For most people they should just update, let the schema auto-update any `?`s (if there are even any that are affected by this change), and just run their app to make sure it runs. Anything requiring fixes would show up as immediately obvious syntax errors.

It's very unlikely that any methods actually rely on this because the interface method types are incompatible with resolver functions.

## Other information

In query/mutation/subscriber definitions this bug can actually have the result of generating code with an error about required args not being allowed after optional args, even when all your args are optional but an array arg has been incorrectly declared as required.

e.g. `createMessage(authorId: Int!, body: String, attachments: [Attachment!]): Message` will incorrectly result in `createMessage(authorId: number, body?: string, attachments: AttachmentInput[]): Message | Promise<Message>;` instead of `createMessage(authorId: number, body?: string, attachments?: AttachmentInput[]): Message | Promise<Message>;` resulting in a syntax error because `attachments` is declared as required even though in the GQL schema is was declared as optional and in the argument order it's after another optional arg.