### PR TITLE
bugfix: Sort file paths for more consistent type output

### DIFF
--- a/lib/graphql-types.loader.ts
+++ b/lib/graphql-types.loader.ts
@@ -25,7 +25,7 @@ export class GraphQLTypesLoader {
     const filePaths = await glob.async(paths, {
       ignore: ['node_modules'],
     });
-    const fileContentsPromises = filePaths.map(filePath => {
+    const fileContentsPromises = filePaths.sort().map(filePath => {
       return readFile(filePath.toString(), 'utf8');
     });
 


### PR DESCRIPTION
Ever since this repo's switch to fast-glob (in February/March), I've noticed that the generated type files were not consistent between runs. This was particularly problematic when a project had a GraphQL schema split across multiple .graphql files

I suspected it because fast-glob's return value is not deterministic. By sorting the return from fast-glob, the generated type files should have the generated types in a consistent order.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The generated graphql.schema.ts file had interface members (fields) in different orders between runs, even if nothing had changed.

Issue Number: N/A


## What is the new behavior?
The generated graphql.schema.ts file remain the same between runs

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information