### PR TITLE
feat(subscription.decorator) added promise type to filter&resolver

### DIFF
--- a/lib/decorators/subscription.decorator.ts
+++ b/lib/decorators/subscription.decorator.ts
@@ -14,8 +14,17 @@ const { Subscription: TypeGqlSubscription } =
   optional('type-graphql') || ({} as any);
 
 export interface SubscriptionOptions {
-  filter?: (payload: any, variables: any, context: any) => boolean;
-  resolve?: (payload: any, args: any, context: any, info: any) => any;
+  filter?: (
+    payload: any,
+    variables: any,
+    context: any,
+  ) => boolean | Promise<boolean>;
+  resolve?: (
+    payload: any,
+    args: any,
+    context: any,
+    info: any,
+  ) => any | Promise<any>;
 }
 
 export function Subscription(): MethodDecorator;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the new behavior?
I added Promise types to subscription decorator because in the docs of [type-graphql](https://typegraphql.ml/docs/subscriptions.html) has support promises.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->