### PR TITLE
perf: Lazy load ts-morph

### DIFF
--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -15,7 +15,7 @@ import {
   UnionTypeDefinitionNode,
 } from 'graphql';
 import { get, map, sortBy, upperFirst } from 'lodash';
-import TypeScriptAst, {
+import {
   ClassDeclaration,
   ClassDeclarationStructure,
   InterfaceDeclaration,
@@ -29,15 +29,16 @@ import { DEFINITIONS_FILE_HEADER } from './graphql.constants';
 export class GraphQLAstExplorer {
   private readonly root = ['Query', 'Mutation', 'Subscription'];
 
-  explore(
+  async explore(
     documentNode: DocumentNode,
     outputPath: string,
     mode: 'class' | 'interface',
-  ): SourceFile {
+  ): Promise<SourceFile> {
     if (!documentNode) {
       return;
     }
-    const tsAstHelper = new TypeScriptAst();
+    const tsMorphLib = await import('ts-morph');
+    const tsAstHelper = new tsMorphLib.default();
     const tsFile = tsAstHelper.createSourceFile(outputPath, '', {
       overwrite: true,
     });

--- a/lib/graphql-definitions.factory.ts
+++ b/lib/graphql-definitions.factory.ts
@@ -66,7 +66,7 @@ export class GraphQLDefinitionsFactory {
       resolverValidationOptions: { allowResolversNotInSchema: true },
     });
     schema = removeTempField(schema);
-    const tsFile = this.gqlAstExplorer.explore(
+    const tsFile = await this.gqlAstExplorer.explore(
       gql`
         ${printSchema(schema)}
       `,

--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -170,7 +170,7 @@ export class GraphQLFactory {
     if (isEmpty(typeDefs) || !options.definitions) {
       return;
     }
-    const tsFile = this.graphqlAstExplorer.explore(
+    const tsFile = await this.graphqlAstExplorer.explore(
       gql`
         ${typeDefs}
       `,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Performance improvement
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ts-morph` library is being always loaded, even if type definitions are generated beforehand.


## What is the new behavior?

`ts-morph` library will be loaded on demand. If the developer decides to generate typescript definitions beforehand, this change will reduce memory footprint by ~17 MB and will also slightly increase startup performance.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information