### PR TITLE
bugfix(@nestjs/graphql): fix windows path

### DIFF
--- a/lib/graphql-types.loader.ts
+++ b/lib/graphql-types.loader.ts
@@ -3,6 +3,7 @@ import * as glob from 'fast-glob';
 import * as fs from 'fs';
 import { flatten } from 'lodash';
 import { mergeTypes } from 'merge-graphql-schemas';
+const normalize = require('normalize-path');
 import * as util from 'util';
 
 const readFile = util.promisify(fs.readFile);
@@ -22,6 +23,11 @@ export class GraphQLTypesLoader {
   }
 
   private async getTypesFromPaths(paths: string | string[]): Promise<string[]> {
+    if (util.isArray(paths)) {
+      paths = paths.map(path => normalize(path));
+    } else {
+      paths = normalize(paths);
+    }
     const filePaths = await glob(paths, {
       ignore: ['node_modules'],
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/graphql",
-  "version": "6.3.1",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -818,6 +818,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==",
       "dev": true
     },
     "@types/range-parser": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/graphql": "14.2.2",
     "@types/jest": "24.0.15",
     "@types/node": "12.6.2",
+    "@types/normalize-path": "^3.0.0",
     "apollo-server-express": "2.6.9",
     "apollo-server-fastify": "2.6.9",
     "class-transformer": "0.2.3",
@@ -44,6 +45,7 @@
     "graphql-tools": "4.0.5",
     "lodash": "4.17.14",
     "merge-graphql-schemas": "1.5.8",
+    "normalize-path": "^3.0.0",
     "optional": "0.1.4",
     "ts-morph": "3.1.1",
     "uuid": "3.3.2"


### PR DESCRIPTION
Add in normalize-path package to normalize windows file paths and allow fast-glob to function.

Fix for #331 and #336

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In a windows environment when using `process.cwd()` the paths come out looking like `C:\\Users\\user\\Documents\\path\\to\\cwd` which is an invalid path for `fast-glob` and becomes a problem when trying to pass a list of graphql files for the schema first method. 

Issue Number: #331 #336 


## What is the new behavior?
With `normalize-path` added in, windows users can now use `process.cwd()` and have no problems while UNIX users are unaffected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The `normalize-path` package cannot be imported using `import` without enabling `esModuleInterop` in the tsconfig options, but it can be `required` without any issues. If this needs to be changed please let me know.