### PR TITLE
fix(): global prefix fails in some cases

### DIFF
--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -165,7 +165,7 @@ export class GraphQLModule implements OnModuleInit {
     const prefix = this.applicationConfig.getGlobalPrefix();
     const useGlobalPrefix = prefix && this.options.useGlobalPrefix;
     const path = useGlobalPrefix
-      ? prefix + this.options.path
+      ? prefix.replace(/^\/?(.*?)\/?$/, '/$1') + this.options.path
       : this.options.path;
 
     const {

--- a/tests/e2e/global-prefix.spec.ts
+++ b/tests/e2e/global-prefix.spec.ts
@@ -6,45 +6,135 @@ import { GlobalPrefixModule } from '../graphql/global-prefix.module';
 describe('GraphQL (global prefix)', () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
-    const module = await Test.createTestingModule({
-      imports: [GlobalPrefixModule],
-    }).compile();
+  describe('Global prefix with starting slash', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [GlobalPrefixModule],
+      }).compile();
 
-    app = module.createNestApplication();
-    app.setGlobalPrefix('/api/v1');
-    await app.init();
+      app = module.createNestApplication();
+      app.setGlobalPrefix('/api/v1');
+      await app.init();
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            getCats {
+              id,
+              color,
+              weight
+            }
+          }`,
+        })
+        .expect(200, {
+          data: {
+            getCats: [
+              {
+                id: 1,
+                color: 'black',
+                weight: 5,
+              },
+            ],
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
   });
 
-  it('should return query result', () => {
-    return request(app.getHttpServer())
-      .post('/api/v1/graphql')
-      .send({
-        operationName: null,
-        variables: {},
-        query: `
-        {
-          getCats {
-            id,
-            color,
-            weight
-          }
-        }`,
-      })
-      .expect(200, {
-        data: {
-          getCats: [
-            {
-              id: 1,
-              color: 'black',
-              weight: 5,
-            },
-          ],
-        },
-      });
+  describe('Global prefix without starting slash', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [GlobalPrefixModule],
+      }).compile();
+
+      app = module.createNestApplication();
+      app.setGlobalPrefix('api/v1');
+      await app.init();
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            getCats {
+              id,
+              color,
+              weight
+            }
+          }`,
+        })
+        .expect(200, {
+          data: {
+            getCats: [
+              {
+                id: 1,
+                color: 'black',
+                weight: 5,
+              },
+            ],
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
   });
 
-  afterEach(async () => {
-    await app.close();
+  describe('Global prefix with ending slash', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [GlobalPrefixModule],
+      }).compile();
+
+      app = module.createNestApplication();
+      app.setGlobalPrefix('/api/v1/');
+      await app.init();
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            getCats {
+              id,
+              color,
+              weight
+            }
+          }`,
+        })
+        .expect(200, {
+          data: {
+            getCats: [
+              {
+                id: 1,
+                color: 'black',
+                weight: 5,
+              },
+            ],
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

https://github.com/nestjs/graphql/pull/314/files#r312075349

The `useGlobalPrefix` option will fail if:

- The global prefix does not have starting slash, i.e. `app.setGlobalPrefix('api/v1')`;
- The global prefix has ending slash, i.e. `app.setGlobalPrefix('/api/v1/')`;

## What is the new behavior?

Works well.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information