### PR TITLE
bugfix() merge default options when async configuration

### DIFF
--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -98,14 +98,15 @@ export class GraphQLModule implements OnModuleInit {
     if (options.useFactory) {
       return {
         provide: GRAPHQL_MODULE_OPTIONS,
-        useFactory: options.useFactory,
+        useFactory: async (...args: any[]) =>
+          mergeDefaults(await options.useFactory(args)),
         inject: options.inject || [],
       };
     }
     return {
       provide: GRAPHQL_MODULE_OPTIONS,
       useFactory: async (optionsFactory: GqlOptionsFactory) =>
-        await optionsFactory.createGqlOptions(),
+        mergeDefaults(await optionsFactory.createGqlOptions()),
       inject: [options.useExisting || options.useClass],
     };
   }

--- a/tests/e2e/global-prefix.spec.ts
+++ b/tests/e2e/global-prefix.spec.ts
@@ -1,7 +1,10 @@
 import { INestApplication } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { GlobalPrefixModule } from '../graphql/global-prefix.module';
+import { GlobalPrefixAsyncOptionsApplicationModule } from '../graphql/global-prefix-async-options.module';
+import { GlobalPrefixAsyncOptionsClassApplicationModule } from '../graphql/global-prefix-async-options-class.module';
 
 describe('GraphQL (global prefix)', () => {
   let app: INestApplication;
@@ -101,6 +104,92 @@ describe('GraphQL (global prefix)', () => {
       }).compile();
 
       app = module.createNestApplication();
+      app.setGlobalPrefix('/api/v1/');
+      await app.init();
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            getCats {
+              id,
+              color,
+              weight
+            }
+          }`,
+        })
+        .expect(200, {
+          data: {
+            getCats: [
+              {
+                id: 1,
+                color: 'black',
+                weight: 5,
+              },
+            ],
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+
+  describe('Global prefix (async configuration)', () => {
+    beforeEach(async () => {
+      app = await NestFactory.create(
+        GlobalPrefixAsyncOptionsApplicationModule,
+        { logger: false },
+      );
+      app.setGlobalPrefix('/api/v1/');
+      await app.init();
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            getCats {
+              id,
+              color,
+              weight
+            }
+          }`,
+        })
+        .expect(200, {
+          data: {
+            getCats: [
+              {
+                id: 1,
+                color: 'black',
+                weight: 5,
+              },
+            ],
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+
+  describe('Global prefix (async class)', () => {
+    beforeEach(async () => {
+      app = await NestFactory.create(
+        GlobalPrefixAsyncOptionsClassApplicationModule,
+        { logger: false },
+      );
       app.setGlobalPrefix('/api/v1/');
       await app.init();
     });

--- a/tests/graphql/global-prefix-async-options-class.module.ts
+++ b/tests/graphql/global-prefix-async-options-class.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { join } from 'path';
+import { GqlModuleOptions, GqlOptionsFactory, GraphQLModule } from '../../lib';
+import { CatsModule } from './cats/cats.module';
+
+class ConfigService implements GqlOptionsFactory {
+  createGqlOptions(): GqlModuleOptions {
+    return {
+      typePaths: [join(__dirname, '**', '*.graphql')],
+      useGlobalPrefix: true,
+    };
+  }
+}
+
+@Module({
+  imports: [
+    CatsModule,
+    GraphQLModule.forRootAsync({
+      useClass: ConfigService,
+    }),
+  ],
+})
+export class GlobalPrefixAsyncOptionsClassApplicationModule {}

--- a/tests/graphql/global-prefix-async-options.module.ts
+++ b/tests/graphql/global-prefix-async-options.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { join } from 'path';
+import { GraphQLModule } from '../../lib';
+import { CatsModule } from './cats/cats.module';
+
+@Module({
+  imports: [
+    CatsModule,
+    GraphQLModule.forRootAsync({
+      useFactory: async () => ({
+        typePaths: [join(__dirname, '**', '*.graphql')],
+        useGlobalPrefix: true,
+      }),
+    }),
+  ],
+})
+export class GlobalPrefixAsyncOptionsApplicationModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?


Issue Number: #418


## What is the new behavior?

Default options are merged when initializing the module using `GraphQLModule.forRootAsync()`

## Does this PR introduce a breaking change?
```
[x] Yes - in theory
[ ] No
```

In theory someone could have be using the current behavior where the global prefix has undefined appended to it and this would break that but I can't imagine anyone would be comfortable using a path like `/api/v1undefined`.


## Other information

I wasn't sure how to best organize the new tests. Let me know if there is anything with those or the PR in general I should change.