### PR TITLE
fix(deps): add iterall dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chokidar": "3.3.1",
     "fast-glob": "3.1.1",
     "graphql-tools": "4.0.6",
+    "iterall": "^1.2.2",
     "lodash": "4.17.15",
     "merge-graphql-schemas": "1.7.4",
     "normalize-path": "3.0.0",


### PR DESCRIPTION
iterall was imported without being in package.json

This works in some environments because the package steals iterall from its sub dependencies, but it is not a good practice and not compatible with https://yarnpkg.com/lang/en/docs/pnp/ and with upcoming similar features from `npm`

This is a bad practice in general: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md

Fixes https://github.com/nestjs/graphql/issues/537