### PR TITLE
Better support on windows

### DIFF
--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -23,6 +23,7 @@ import {
   ParameterDeclarationStructure,
   SourceFile,
   StructureKind,
+  NewLineKind,
 } from 'ts-morph';
 import { DEFINITIONS_FILE_HEADER } from './graphql.constants';
 
@@ -39,7 +40,14 @@ export class GraphQLAstExplorer {
       return;
     }
     const tsMorphLib = await import('ts-morph');
-    const tsAstHelper = new tsMorphLib.Project();
+    const tsAstHelper = new tsMorphLib.Project({
+      manipulationSettings: {
+        newLineKind:
+          process.platform === 'win32'
+            ? NewLineKind.CarriageReturnLineFeed
+            : NewLineKind.LineFeed,
+      },
+    });
     const tsFile = tsAstHelper.createSourceFile(outputPath, '', {
       overwrite: true,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -395,6 +395,15 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -4475,6 +4484,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -7387,10 +7405,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kamil Mysliwiec",
   "license": "MIT",
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json",
     "format": "prettier **/**/*.ts --ignore-path ./.prettierignore --write",
     "prepublish:npm": "npm run build",
@@ -47,6 +47,7 @@
     "lodash": "4.17.15",
     "merge-graphql-schemas": "1.7.6",
     "normalize-path": "3.0.0",
+    "rimraf": "^3.0.0",
     "ts-morph": "5.0.0",
     "uuid": "3.3.3"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- `npm run build` will fail on Windows because `rm` command is not an executable 
- When we take the schema first approach and use the `GraphQLDefinitionsFactory` to generate the typescript file, it will always use LF line endings, which will cause warnings when using `git add` on Windows

## What is the new behavior?

- `npm run build` can run on Windows
- The generated typescript file will have appropriate line endings(CRLF on windows and LF on *nix) 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information