### PR TITLE
fix(): subscription.subscribe() not copied

### DIFF
--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -131,11 +131,8 @@ export class GraphQLFactory {
           if (schemaFields[resolverName]) {
             schemaFields[resolverName].resolve =
               executableSchemaFields[resolverName].resolve;
-
-            if (schemaFields[resolverName].subscribe) {
-              schemaFields[resolverName].subscribe =
-                executableSchemaFields[resolverName].subscribe;
-            }
+            schemaFields[resolverName].subscribe =
+              executableSchemaFields[resolverName].subscribe;
           } else {
             schemaFields[resolverName] = executableSchemaFields[resolverName];
           }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Methods decorated with `@Subscription` are not copied into the resolvers. As a result, `AsyncIterator` is not returned causing `Subscription field must return Async Iterable. Received: undefined`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 663


## What is the new behavior?
References to methods are copied accordingly. Subscribers subscribe to `AsyncIterators` and receive updates.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Copying `subscribe()` does not affect any resolvers. 