### PR TITLE
GraphQL Federation - typedefs merged with typePaths

### DIFF
--- a/lib/federation/graphql-federation.module.ts
+++ b/lib/federation/graphql-federation.module.ts
@@ -29,7 +29,12 @@ import {
   ResolversExplorerService,
   ScalarsExplorerService,
 } from '../services';
-import { generateString, mergeDefaults, normalizeRoutePath } from '../utils';
+import {
+  generateString,
+  mergeDefaults,
+  normalizeRoutePath,
+  extend,
+} from '../utils';
 import { GraphQLFederationFactory } from './graphql-federation.factory';
 
 @Module({
@@ -135,11 +140,13 @@ export class GraphQLFederationModule implements OnModuleInit {
     );
 
     const { typePaths } = this.options;
-    const typeDefs = await this.graphqlTypesLoader.mergeTypesByPaths(typePaths);
+    const typeDefs =
+      (await this.graphqlTypesLoader.mergeTypesByPaths(typePaths)) || [];
 
+    const mergedTypeDefs = extend(typeDefs, this.options.typeDefs);
     const apolloOptions = await this.graphqlFederationFactory.mergeOptions({
       ...this.options,
-      typeDefs,
+      typeDefs: mergedTypeDefs,
     });
 
     if (this.options.definitions && this.options.definitions.path) {


### PR DESCRIPTION
## PR Checklist
Extends GraphQL Federation module to use the typeDefs in addition to typePaths. The feature is already available in NestJS GraphQL base module.

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
```ts

const myTypeDefs = gql`
 
extend type Query {
    ...
}

`

GraphQLFederationModule.forRoot({
    typePaths: ['./**/*.graphql'],
    typeDefs: [myTypeDefs] // Override by typePaths
})
```

## What is the new behavior?

```ts

const myTypeDefs = gql`
 
extend type Query {
    ...
}

`

GraphQLFederationModule.forRoot({
    typePaths: ['./**/*.graphql'],
    typeDefs: [myTypeDefs] // Merged with typePaths
})
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

## Other information