### PR TITLE
Fix CustomScalar interface for strictNullChecks

### DIFF
--- a/lib/interfaces/custom-scalar.interface.ts
+++ b/lib/interfaces/custom-scalar.interface.ts
@@ -1,6 +1,6 @@
 export interface CustomScalar<T, K> {
-  description: string;
-  parseValue(value: T): K;
-  serialize(value: K): T;
-  parseLiteral(ast): K;
+  description: string | null | undefined;
+  parseValue(value: T): K | null | undefined;
+  serialize(value: K): T | null | undefined;
+  parseLiteral(ast): K | null | undefined;
 }

--- a/lib/interfaces/custom-scalar.interface.ts
+++ b/lib/interfaces/custom-scalar.interface.ts
@@ -1,8 +1,12 @@
-import { ValueNode } from 'graphql';
+import {
+  GraphQLScalarLiteralParser,
+  GraphQLScalarSerializer,
+  GraphQLScalarValueParser,
+} from 'graphql';
 
 export interface CustomScalar<T, K> {
   description: string | null | undefined;
-  parseValue(value: T): K | null | undefined;
-  serialize(value: K): T | null | undefined;
-  parseLiteral(ast: ValueNode): K | null | undefined;
+  parseValue: GraphQLScalarValueParser<K>;
+  serialize: GraphQLScalarSerializer<T>;
+  parseLiteral: GraphQLScalarLiteralParser<K>;
 }

--- a/lib/interfaces/custom-scalar.interface.ts
+++ b/lib/interfaces/custom-scalar.interface.ts
@@ -1,6 +1,8 @@
+import { ValueNode } from 'graphql';
+
 export interface CustomScalar<T, K> {
   description: string | null | undefined;
   parseValue(value: T): K | null | undefined;
   serialize(value: K): T | null | undefined;
-  parseLiteral(ast): K | null | undefined;
+  parseLiteral(ast: ValueNode): K | null | undefined;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #222 


In strict mode of TypeScript, the current definition of `CustomScalar` doesn't allow us to return `null` or `undefined`.

## What is the new behavior?

This code will not throw any errors in strict mode.

```typescript
parseLiteral(ast: any): Date {
  if (ast.kind === Kind.INT) {
    return new Date(ast.value);
  }
  return null;
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

References:

- https://github.com/graphql/graphql-js/blob/278bde0a5cd71008452b555065f19dcd1160270a/src/type/definition.d.ts#L293-L296
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html
