### PR TITLE
feat(): use request context id symbol, attach to ctx

### DIFF
--- a/lib/services/resolvers-explorer.service.ts
+++ b/lib/services/resolvers-explorer.service.ts
@@ -13,6 +13,7 @@ import { InternalCoreModule } from '@nestjs/core/injector/internal-core-module';
 import { Module } from '@nestjs/core/injector/module';
 import { ModulesContainer } from '@nestjs/core/injector/modules-container';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
+import { REQUEST_CONTEXT_ID } from '@nestjs/core/router/request/request-constants';
 import { head, identity } from 'lodash';
 import { GqlModuleOptions, SubscriptionOptions } from '..';
 import { GqlParamtype } from '../enums/gql-paramtype.enum';
@@ -29,8 +30,6 @@ import { createAsyncIterator } from '../utils/async-iterator.util';
 import { extractMetadata } from '../utils/extract-metadata.util';
 import { BaseExplorerService } from './base-explorer.service';
 import { GqlContextType } from './gql-execution-context';
-
-const gqlContextIdSymbol = Symbol('GQL_CONTEXT_ID');
 
 @Injectable()
 export class ResolversExplorerService extends BaseExplorerService {
@@ -151,11 +150,17 @@ export class ResolversExplorerService extends BaseExplorerService {
           args,
         );
         let contextId: ContextId;
-        if (gqlContext && gqlContext[gqlContextIdSymbol]) {
-          contextId = gqlContext[gqlContextIdSymbol];
+        if (gqlContext && gqlContext[REQUEST_CONTEXT_ID]) {
+          contextId = gqlContext[REQUEST_CONTEXT_ID];
+        } else if (
+          gqlContext &&
+          gqlContext.req &&
+          gqlContext.req[REQUEST_CONTEXT_ID]
+        ) {
+          contextId = gqlContext.req[REQUEST_CONTEXT_ID];
         } else {
           contextId = createContextId();
-          Object.defineProperty(gqlContext, gqlContextIdSymbol, {
+          Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {
             value: contextId,
             enumerable: false,
             configurable: false,

--- a/lib/utils/merge-defaults.util.ts
+++ b/lib/utils/merge-defaults.util.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { GqlModuleOptions } from '../interfaces/gql-module-options.interface';
 
 const defaultOptions: GqlModuleOptions = {
@@ -9,8 +10,34 @@ export function mergeDefaults(
   options: GqlModuleOptions,
   defaults: GqlModuleOptions = defaultOptions,
 ): GqlModuleOptions {
-  return {
+  const moduleOptions = {
     ...defaults,
     ...options,
   };
+  if (!moduleOptions.context) {
+    moduleOptions.context = ({ req }) => ({ req });
+  } else if (isFunction(moduleOptions.context)) {
+    moduleOptions.context = (...args: unknown[]) => {
+      const ctx = (options.context as Function)(...args);
+      const { req } = args[0] as Record<string, unknown>;
+      if (typeof ctx === 'object') {
+        return {
+          req,
+          ...ctx,
+        };
+      }
+      return ctx;
+    };
+  } else {
+    moduleOptions.context = ({ req }: Record<string, unknown>) => {
+      if (typeof options.context === 'object') {
+        return {
+          req,
+          ...options.context,
+        };
+      }
+      return options.context;
+    };
+  }
+  return moduleOptions;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #695 #730


## What is the new behavior?

1. Middleware + resolvers use the same context id.
2. `ContextIdFactory.getByRequest(this.ctx)` to get the current context id (where `ctx` = `@Inject(CONTEXT)`)

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information