### PR TITLE
fix: make sure to handle undefined case in ResolveTypeFactory

### DIFF
--- a/lib/schema-builder/factories/resolve-type.factory.ts
+++ b/lib/schema-builder/factories/resolve-type.factory.ts
@@ -21,7 +21,7 @@ export class ResolveTypeFactory {
       const typeDef = this.typeDefinitionsStorage.getObjectTypeByTarget(
         resolvedType,
       );
-      return typeDef.type;
+      return typeDef?.type;
     };
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I was messing with Union types when this error appeared. It turned out the actual error message did not return because of a missing undefined check: 

```
TypeError: Cannot read property 'type' of undefined"
  at ResolveTypeFactory.<anonymous> 
  (.../node_modules/@nestjs/graphql/dist/schema-builder/factories/resolve-type.factory.js:18:28)
```


## What is the new behavior?

With this patch the error no longer gets swallowed:

```
Abstract type \"ProjectType\" must resolve to an Object type at runtime for field \"Project.type\" with value {}, received \"undefined\". Either the \"ProjectType\" type should provide a \"resolveType\" function or each possible type should provide an \"isTypeOf\" function."
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information