### PR TITLE
bugfix(federated-directives): update federation module directive loading

### DIFF
--- a/lib/federation/graphql-federation.module.ts
+++ b/lib/federation/graphql-federation.module.ts
@@ -10,7 +10,7 @@ import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { ApolloServerBase } from 'apollo-server-core';
-import { SchemaDirectiveVisitor } from 'apollo-server-express';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
 import { GraphQLAstExplorer } from '../graphql-ast.explorer';
 import { GraphQLSchemaBuilder } from '../graphql-schema.builder';
 import { GraphQLSchemaHost } from '../graphql-schema.host';

--- a/lib/federation/graphql-federation.module.ts
+++ b/lib/federation/graphql-federation.module.ts
@@ -10,7 +10,7 @@ import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { ApolloServerBase } from 'apollo-server-core';
-import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { SchemaDirectiveVisitor } from 'apollo-server';
 import { GraphQLAstExplorer } from '../graphql-ast.explorer';
 import { GraphQLSchemaBuilder } from '../graphql-schema.builder';
 import { GraphQLSchemaHost } from '../graphql-schema.host';

--- a/lib/federation/graphql-federation.module.ts
+++ b/lib/federation/graphql-federation.module.ts
@@ -10,6 +10,7 @@ import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { ApolloServerBase } from 'apollo-server-core';
+import { SchemaDirectiveVisitor } from 'apollo-server-express';
 import { GraphQLAstExplorer } from '../graphql-ast.explorer';
 import { GraphQLSchemaBuilder } from '../graphql-schema.builder';
 import { GraphQLSchemaHost } from '../graphql-schema.host';
@@ -198,6 +199,14 @@ export class GraphQLFederationModule implements OnModuleInit {
     } = this.options;
     const app = this.httpAdapterHost.httpAdapter.getInstance();
     const path = this.getNormalizedPath(apolloOptions);
+
+    // If custom directives are provided merge them into schema per Apollo https://www.apollographql.com/docs/apollo-server/federation/implementing-services/#defining-custom-directives
+    if (apolloOptions.schemaDirectives) {
+      SchemaDirectiveVisitor.visitSchemaDirectives(
+        apolloOptions.schema,
+        apolloOptions.schemaDirectives,
+      );
+    }
 
     const apolloServer = new ApolloServer(apolloOptions as any);
     apolloServer.applyMiddleware({

--- a/tests/code-first-federation/post/post.service.ts
+++ b/tests/code-first-federation/post/post.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@nestjs/common';
 const data = [
   {
     id: 1,
-    title: 'hello world',
+    title: 'HELLO WORLD',
     authorId: 2,
   },
   {
@@ -17,7 +17,7 @@ const data = [
 @Injectable()
 export class PostService {
   public findOne(id: number) {
-    const post = data.find(p => p.id === id);
+    const post = data.find((p) => p.id === id);
     if (post) {
       return new Post(post);
     }
@@ -25,10 +25,10 @@ export class PostService {
   }
 
   public all() {
-    return data.map(p => new Post(p));
+    return data.map((p) => new Post(p));
   }
 
   public forAuthor(authorId: number) {
-    return data.filter(p => p.authorId === authorId).map(p => new Post(p));
+    return data.filter((p) => p.authorId === authorId).map((p) => new Post(p));
   }
 }

--- a/tests/e2e/graphql-federation-fastify.spec.ts
+++ b/tests/e2e/graphql-federation-fastify.spec.ts
@@ -14,10 +14,7 @@ describe('GraphQL federation with fastify', () => {
 
     app = module.createNestApplication(new FastifyAdapter());
     await app.init();
-    await app
-      .getHttpAdapter()
-      .getInstance()
-      .ready();
+    await app.getHttpAdapter().getInstance().ready();
   });
 
   it(`should return query result`, () => {
@@ -40,7 +37,7 @@ describe('GraphQL federation with fastify', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             },
           ],

--- a/tests/e2e/graphql-federation.spec.ts
+++ b/tests/e2e/graphql-federation.spec.ts
@@ -72,7 +72,7 @@ describe('GraphQL Federation', () => {
             getPosts: [
               {
                 id: '1',
-                title: 'Hello world',
+                title: 'HELLO WORLD',
                 body:
                   'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               },
@@ -104,7 +104,7 @@ describe('GraphQL Federation', () => {
             getPosts: [
               {
                 id: '1',
-                title: 'Hello world',
+                title: 'HELLO WORLD',
                 body:
                   'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
                 user: {
@@ -136,7 +136,7 @@ describe('GraphQL Federation', () => {
           data: {
             publishPost: {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               publishDate: 500,
             },

--- a/tests/e2e/graphql-gateway-async-class.spec.ts
+++ b/tests/e2e/graphql-gateway-async-class.spec.ts
@@ -57,7 +57,7 @@ describe('GraphQL Gateway async-class', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',

--- a/tests/e2e/graphql-gateway-async-existing.spec.ts
+++ b/tests/e2e/graphql-gateway-async-existing.spec.ts
@@ -57,7 +57,7 @@ describe('GraphQL gateway async-existing', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',

--- a/tests/e2e/graphql-gateway-async.spec.ts
+++ b/tests/e2e/graphql-gateway-async.spec.ts
@@ -57,7 +57,7 @@ describe('GraphQL Gateway async', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',

--- a/tests/e2e/graphql-gateway-buildservice.spec.ts
+++ b/tests/e2e/graphql-gateway-buildservice.spec.ts
@@ -69,7 +69,7 @@ describe('GraphQL Gateway buildservice', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',

--- a/tests/e2e/graphql-gateway-fastify.spec.ts
+++ b/tests/e2e/graphql-gateway-fastify.spec.ts
@@ -32,10 +32,7 @@ describe('GraphQL Gateway with fastify', () => {
 
     gatewayApp = gatewayModule.createNestApplication(new FastifyAdapter());
     await gatewayApp.init();
-    await gatewayApp
-      .getHttpAdapter()
-      .getInstance()
-      .ready();
+    await gatewayApp.getHttpAdapter().getInstance().ready();
   });
 
   it(`should run lookup across boundaries`, () => {
@@ -62,7 +59,7 @@ describe('GraphQL Gateway with fastify', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',
@@ -101,7 +98,7 @@ describe('GraphQL Gateway with fastify', () => {
             posts: [
               {
                 id: '1',
-                title: 'Hello world',
+                title: 'HELLO WORLD',
                 body:
                   'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               },

--- a/tests/e2e/graphql-gateway.spec.ts
+++ b/tests/e2e/graphql-gateway.spec.ts
@@ -57,7 +57,7 @@ describe('GraphQL Gateway', () => {
           getPosts: [
             {
               id: '1',
-              title: 'Hello world',
+              title: 'HELLO WORLD',
               body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               user: {
                 id: '5',
@@ -96,7 +96,7 @@ describe('GraphQL Gateway', () => {
             posts: [
               {
                 id: '1',
-                title: 'Hello world',
+                title: 'HELLO WORLD',
                 body:
                   'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
               },

--- a/tests/graphql-federation/posts-service/federation-posts.module.ts
+++ b/tests/graphql-federation/posts-service/federation-posts.module.ts
@@ -2,11 +2,15 @@ import { Module } from '@nestjs/common';
 import { join } from 'path';
 import { GraphQLFederationModule } from '../../../lib';
 import { PostsModule } from './posts/posts.module';
+import { UpperCaseDirective } from './posts/upper.directive';
 
 @Module({
   imports: [
     GraphQLFederationModule.forRoot({
       typePaths: [join(__dirname, '**/*.graphql')],
+      schemaDirectives: {
+        upper: UpperCaseDirective,
+      },
     }),
     PostsModule,
   ],

--- a/tests/graphql-federation/posts-service/posts/posts.service.ts
+++ b/tests/graphql-federation/posts-service/posts/posts.service.ts
@@ -6,7 +6,7 @@ export class PostsService {
   private readonly posts: Post[] = [
     {
       id: '1',
-      title: 'Hello world',
+      title: 'HELLO WORLD',
       body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       userId: '5',
       publishDate: new Date(0),
@@ -18,11 +18,11 @@ export class PostsService {
   }
 
   findById(id: string) {
-    return Promise.resolve(this.posts.find(p => p.id === id));
+    return Promise.resolve(this.posts.find((p) => p.id === id));
   }
 
   findByUserId(id: string) {
-    return Promise.resolve(this.posts.filter(p => p.userId === id));
+    return Promise.resolve(this.posts.filter((p) => p.userId === id));
   }
 
   async publish(id: string, publishDate: Date) {

--- a/tests/graphql-federation/posts-service/posts/posts.types.graphql
+++ b/tests/graphql-federation/posts-service/posts/posts.types.graphql
@@ -1,3 +1,5 @@
+directive @upper on FIELD_DEFINITION
+
 scalar Date
 
 type Post @key(fields: "id") {

--- a/tests/graphql-federation/posts-service/posts/upper.directive.ts
+++ b/tests/graphql-federation/posts-service/posts/upper.directive.ts
@@ -1,0 +1,15 @@
+import { SchemaDirectiveVisitor } from 'apollo-server-express';
+import { defaultFieldResolver, GraphQLField } from 'graphql';
+
+export class UpperCaseDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition(field: GraphQLField<any, any>) {
+    const { resolve = defaultFieldResolver } = field;
+    field.resolve = async function (...args) {
+      const result = await resolve.apply(this, args);
+      if (typeof result === 'string') {
+        return result.toUpperCase();
+      }
+      return result;
+    };
+  }
+}


### PR DESCRIPTION
Update the schema with provided custom directives before initializing the ApolloServer per unique requirements of federated services: https://www.apollographql.com/docs/apollo-server/federation/implementing-services/#defining-custom-directives

Closes #837

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Custom directives are never loaded for federated GraphQL services.

Issue Number: 837


## What is the new behavior?
As defined by Apollo, customer directives are now applied to the schema prior to initializing new ApolloServer

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information