### PR TITLE
bugfix: move @apollo/{gateway, federation},ts-morph into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "@apollo/federation": "0.16.0",
-    "@apollo/gateway": "0.16.0",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-angular": "8.3.4",
     "@nestjs/common": "7.1.0",
@@ -53,11 +51,12 @@
     "rimraf": "3.0.2",
     "supertest": "4.0.2",
     "ts-jest": "26.0.0",
-    "ts-morph": "7.0.0",
     "ts-node": "8.10.1",
     "typescript": "3.9.3"
   },
   "dependencies": {
+    "@apollo/federation": "0.16.0",
+    "@apollo/gateway": "0.16.0",
     "@nestjs/mapped-types": "0.0.5",
     "chokidar": "3.4.0",
     "fast-glob": "3.2.2",
@@ -65,18 +64,18 @@
     "lodash": "4.17.15",
     "merge-graphql-schemas": "1.7.8",
     "normalize-path": "3.0.0",
+    "ts-morph": "7.0.0",
     "tslib": "2.0.0",
     "uuid": "8.1.0"
+  },
+  "engines": {
+    "node": ">=12.13.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
     "graphql": "^14.1.1 || ^15.0.0",
-    "reflect-metadata": "^0.1.12"
-  },
-  "optionalDependencies": {
-    "@apollo/federation": "^0.16.0",
-    "@apollo/gateway": "^0.16.0",
+    "reflect-metadata": "^0.1.12",
     "ts-morph": "^7.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
I am using node v10.15 to install the latest version of `@nestjs/graphql@7.3.11`， and I got below errors:

![image](https://user-images.githubusercontent.com/1506900/83127854-3ab7eb00-a10d-11ea-969b-824b8b17131e.png)

causing this error is `@apollo/gateway` is dependent on `node >= 12.13.0`, and it's in optionalDeps, so it not installed.

## What is the new behavior?
`@nestjs/graphql` really depended on `@apollo/{gateway, faderation}`, so it should in dependencies, not in optionalDependencies.

and `@apollo/gateway` has restraint node version, so I add :
```
"engines": {
    "node": ">=12.13.0"
  },
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information