### PR TITLE
fix(federation): Handle ObjectTypeExtension

### DIFF
--- a/lib/graphql-ast.explorer.ts
+++ b/lib/graphql-ast.explorer.ts
@@ -2,17 +2,24 @@ import { Injectable } from '@nestjs/common';
 import {
   DocumentNode,
   EnumTypeDefinitionNode,
+  EnumTypeExtensionNode,
   FieldDefinitionNode,
   InputObjectTypeDefinitionNode,
+  InputObjectTypeExtensionNode,
   InputValueDefinitionNode,
   InterfaceTypeDefinitionNode,
+  InterfaceTypeExtensionNode,
   NamedTypeNode,
   ObjectTypeDefinitionNode,
+  ObjectTypeExtensionNode,
   OperationTypeDefinitionNode,
   ScalarTypeDefinitionNode,
+  ScalarTypeExtensionNode,
   TypeNode,
   TypeSystemDefinitionNode,
+  TypeSystemExtensionNode,
   UnionTypeDefinitionNode,
+  UnionTypeExtensionNode,
 } from 'graphql';
 import { get, map, sortBy, upperFirst } from 'lodash';
 import {
@@ -84,7 +91,7 @@ export class GraphQLAstExplorer {
   }
 
   lookupDefinition(
-    item: Readonly<TypeSystemDefinitionNode>,
+    item: Readonly<TypeSystemDefinitionNode | TypeSystemExtensionNode>,
     tsFile: SourceFile,
     mode: 'class' | 'interface',
     options: DefinitionsGeneratorOptions,
@@ -97,15 +104,21 @@ export class GraphQLAstExplorer {
           mode,
         );
       case 'ObjectTypeDefinition':
+      case 'ObjectTypeExtension':
       case 'InputObjectTypeDefinition':
+      case 'InputObjectTypeExtension':
         return this.addObjectTypeDefinition(item, tsFile, mode, options);
       case 'InterfaceTypeDefinition':
+      case 'InterfaceTypeExtension':
         return this.addObjectTypeDefinition(item, tsFile, 'interface', options);
       case 'ScalarTypeDefinition':
+      case 'ScalarTypeExtension':
         return this.addScalarDefinition(item, tsFile);
       case 'EnumTypeDefinition':
+      case 'EnumTypeExtension':
         return this.addEnumDefinition(item, tsFile);
       case 'UnionTypeDefinition':
+      case 'UnionTypeExtension':
         return this.addUnionDefinition(item, tsFile);
     }
   }
@@ -146,8 +159,11 @@ export class GraphQLAstExplorer {
   addObjectTypeDefinition(
     item:
       | ObjectTypeDefinitionNode
+      | ObjectTypeExtensionNode
       | InputObjectTypeDefinitionNode
-      | InterfaceTypeDefinitionNode,
+      | InputObjectTypeExtensionNode
+      | InterfaceTypeDefinitionNode
+      | InterfaceTypeExtensionNode,
     tsFile: SourceFile,
     mode: 'class' | 'interface',
     options: DefinitionsGeneratorOptions,
@@ -327,7 +343,10 @@ export class GraphQLAstExplorer {
     });
   }
 
-  addScalarDefinition(item: ScalarTypeDefinitionNode, tsFile: SourceFile) {
+  addScalarDefinition(
+    item: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
+    tsFile: SourceFile,
+  ) {
     const name = get(item, 'name.value');
     if (!name || name === 'Date') {
       return;
@@ -369,7 +388,10 @@ export class GraphQLAstExplorer {
     });
   }
 
-  addEnumDefinition(item: EnumTypeDefinitionNode, tsFile: SourceFile) {
+  addEnumDefinition(
+    item: EnumTypeDefinitionNode | EnumTypeExtensionNode,
+    tsFile: SourceFile,
+  ) {
     const name = get(item, 'name.value');
     if (!name) {
       return;
@@ -385,7 +407,10 @@ export class GraphQLAstExplorer {
     });
   }
 
-  addUnionDefinition(item: UnionTypeDefinitionNode, tsFile: SourceFile) {
+  addUnionDefinition(
+    item: UnionTypeDefinitionNode | UnionTypeExtensionNode,
+    tsFile: SourceFile,
+  ) {
     const name = get(item, 'name.value');
     if (!name) {
       return;

--- a/tests/generated-definitions/federation.fixture.ts
+++ b/tests/generated-definitions/federation.fixture.ts
@@ -6,7 +6,22 @@
 
 /* tslint:disable */
 /* eslint-disable */
+export enum Category {
+    POST = "POST"
+}
+
 export class Post {
     id: string;
     title: string;
+    author: User;
+    category: Category;
+}
+
+export abstract class IQuery {
+    abstract getPosts(): Post[] | Promise<Post[]>;
+}
+
+export class User {
+    id: string;
+    posts?: Post[];
 }

--- a/tests/generated-definitions/federation.graphql
+++ b/tests/generated-definitions/federation.graphql
@@ -1,6 +1,8 @@
 type Post {
   id: ID!
   title: String!
+  author: User!
+  category: Category!
 }
 
 extend type User @key(fields: "id") {
@@ -10,4 +12,8 @@ extend type User @key(fields: "id") {
 
 extend type Query {
   getPosts: [Post]
+}
+
+extend enum Category {
+  POST
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

From [the federation example](), the following _invalid_ typings are generated:

```graphql
type Post @key(fields: "id") {
  id: ID!
  title: String!
  body: String!
  user: User
}

extend type User @key(fields: "id") {
  id: ID! @external
  posts: [Post]
}

extend type Query {
  getPosts: [Post]
}
```

```ts
export class Post {
  id: string;
  title: string;
  body: string;
  user?: User
}
```

Where a `User` class/interface is not generated 

Issue Number: N/A

## What is the new behavior?

This PR handles `ObjectTypeExtension` the same was as `ObjectTypeDefinition` when generating Typescript definitions.

```ts
export class Post {
  id: string;
  title: string;
  body: string;
  user?: User
}

export abstract class IQuery {
    abstract getPosts(): Post[] | Promise<Post[]>;
}

export class User {
    id: string;
    posts?: Post[];
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information