### PR TITLE
feat(): Include graphql schemas from node_modules

### DIFF
--- a/lib/graphql-types.loader.ts
+++ b/lib/graphql-types.loader.ts
@@ -26,12 +26,20 @@ export class GraphQLTypesLoader {
   }
 
   private async getTypesFromPaths(paths: string | string[]): Promise<string[]> {
+    let includeNodeModules = false;
+
+    if (util.isArray(paths)) {
+      includeNodeModules = paths.some((path) => path.includes('node_modules'));
+    } else {
+      includeNodeModules = paths.includes('node_modules');
+    }
+
     paths = util.isArray(paths)
       ? paths.map((path) => normalize(path))
       : normalize(paths);
 
     const filePaths = await glob(paths, {
-      ignore: ['node_modules'],
+      ignore: includeNodeModules ? [] : ['node_modules'],
     });
     if (filePaths.length === 0) {
       throw new Error(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
GraphQL Schemas from node_modules will be ignored when discovering schemas

Issue Number: https://github.com/nestjs/graphql/issues/966


## What is the new behavior?
GraphQL schemas will conditionally include node_modules when discovering schemas as long as one of the paths defined in the `typePaths` config contains `node_modules`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information