### PR TITLE
feat(decorators): add gql-headers decorator

### DIFF
--- a/lib/decorators/gql-headers.decorator.ts
+++ b/lib/decorators/gql-headers.decorator.ts
@@ -1,0 +1,29 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { IncomingMessage } from 'http';
+import { GqlExecutionContext } from '../services';
+
+/**
+ * `@GqlHeaders()` Route handler parameter decorator. Extracts the `headers`
+ * property from the `req` object and populates the decorated
+ * parameter with the value of `headers`.
+ *
+ * For example: `async update(@GqlHeaders('Cache-Control') cacheControl: string)`
+ *
+ * @param headerName name of single header property to extract.
+ *
+ * @see [Request object](https://docs.nestjs.com/controllers#request-object)
+ */
+export function GqlHeaders(headerName?: string): ParameterDecorator {
+  return createParamDecorator(
+    (headerName: string | void, context: ExecutionContext) => {
+      const ctx = GqlExecutionContext.create(context);
+      const request = ctx.getContext().req as IncomingMessage;
+
+      if (headerName) {
+        return request.headers[headerName.toLowerCase()];
+      }
+
+      return request.headers;
+    },
+  )(headerName);
+}

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -4,6 +4,7 @@ export * from './context.decorator';
 export * from './directive.decorator';
 export * from './extensions.decorator';
 export * from './field.decorator';
+export * from './gql-headers.decorator';
 export * from './hide-field.decorator';
 export * from './info.decorator';
 export * from './input-type.decorator';


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the new behavior?
One of my projects requires direct access to the request headers. I implemented this decorator in my code, and thought maybe it is worth to add to the package.
In summary, I added `GqlHeaders` parameter decorator, generally the analogue of `Headers` decorator in `@nestjs/common`.

Example usage:
```ts
import { IncomingHttpHeaders } from 'http';

@Resolver()
export class GraphqlApiResolver {
  @Query(() => String)
  content(
    @GqlHeaders('User-Agent') userAgent: string,
    @GqlHeaders() allHeaders: IncomingHttpHeaders,
  ): Promise<string> {
    return service.getSpecialContent({ userAgent });
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->