### PR TITLE
fix(ast): correctly mark fields as nullable when not required

### DIFF
--- a/tests/generated-definitions/array-property.fixture.ts
+++ b/tests/generated-definitions/array-property.fixture.ts
@@ -8,7 +8,9 @@
 /* eslint-disable */
 export interface Foo {
     a: string[];
-    b?: string[];
-    c: string[];
-    d?: string[];
+    b?: Nullable<string[]>;
+    c: Nullable<string>[];
+    d?: Nullable<Nullable<string>[]>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/custom-header.fixture.ts
+++ b/tests/generated-definitions/custom-header.fixture.ts
@@ -10,3 +10,4 @@
 /* Put anything here you like */
 
 export type CustomDate = any;
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/custom-scalar-default-type.fixture.ts
+++ b/tests/generated-definitions/custom-scalar-default-type.fixture.ts
@@ -7,3 +7,4 @@
 /* tslint:disable */
 /* eslint-disable */
 export type CustomDate = unknown;
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/custom-scalar-type-mapping.fixture.ts
+++ b/tests/generated-definitions/custom-scalar-type-mapping.fixture.ts
@@ -9,3 +9,4 @@
 export type List = string[];
 export type Point = [number, number];
 export type DateTime = Date;
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/custom-scalar.fixture.ts
+++ b/tests/generated-definitions/custom-scalar.fixture.ts
@@ -7,3 +7,4 @@
 /* tslint:disable */
 /* eslint-disable */
 export type CustomDate = any;
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/enum.fixture.ts
+++ b/tests/generated-definitions/enum.fixture.ts
@@ -11,3 +11,5 @@ export enum Foobar {
     Bar = "Bar",
     Baz = "Baz"
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/federation.fixture.ts
+++ b/tests/generated-definitions/federation.fixture.ts
@@ -18,10 +18,12 @@ export class Post {
 }
 
 export abstract class IQuery {
-    abstract getPosts(): Post[] | Promise<Post[]>;
+    abstract getPosts(): Nullable<Nullable<Post>[]> | Promise<Nullable<Nullable<Post>[]>>;
 }
 
 export class User {
     id: string;
-    posts?: Post[];
+    posts?: Nullable<Nullable<Post>[]>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/interface-property.fixture.ts
+++ b/tests/generated-definitions/interface-property.fixture.ts
@@ -12,5 +12,7 @@ export interface Bar {
 
 export interface Foo {
     a: Bar;
-    b?: Bar;
+    b?: Nullable<Bar>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/mutation.fixture.ts
+++ b/tests/generated-definitions/mutation.fixture.ts
@@ -11,10 +11,12 @@ export interface Cat {
 }
 
 export interface IMutation {
-    createCat(name?: string): Cat | Promise<Cat>;
-    returnsQuery(): IQuery | Promise<IQuery>;
+    createCat(name?: Nullable<string>): Nullable<Cat> | Promise<Nullable<Cat>>;
+    returnsQuery(): Nullable<IQuery> | Promise<Nullable<IQuery>>;
 }
 
 export interface IQuery {
-    query(): number | Promise<number>;
+    query(): Nullable<number> | Promise<Nullable<number>>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/query-skip-args.fixture.ts
+++ b/tests/generated-definitions/query-skip-args.fixture.ts
@@ -11,5 +11,7 @@ export interface Cat {
 }
 
 export interface IQuery {
-    cat?: Cat;
+    cat?: Nullable<Cat>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/query.fixture.ts
+++ b/tests/generated-definitions/query.fixture.ts
@@ -11,5 +11,7 @@ export interface Cat {
 }
 
 export interface IQuery {
-    cat(id: string): Cat | Promise<Cat>;
+    cat(id: string): Nullable<Cat> | Promise<Nullable<Cat>>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/simple-type.fixture.ts
+++ b/tests/generated-definitions/simple-type.fixture.ts
@@ -9,7 +9,9 @@
 export interface Cat {
     id: number;
     name: string;
-    age?: number;
-    color?: string;
-    weight?: number;
+    age?: Nullable<number>;
+    color?: Nullable<string>;
+    weight?: Nullable<number>;
 }
+
+type Nullable<T> = T | null;

--- a/tests/generated-definitions/typename.fixture.ts
+++ b/tests/generated-definitions/typename.fixture.ts
@@ -10,7 +10,9 @@ export interface Cat {
     __typename?: 'Cat';
     id: number;
     name: string;
-    age?: number;
-    color?: string;
-    weight?: number;
+    age?: Nullable<number>;
+    color?: Nullable<string>;
+    weight?: Nullable<number>;
 }
+
+type Nullable<T> = T | null;


### PR DESCRIPTION
Creates a new type alias `Nullable<T>` which will make a given field nullable
if that field is not required by the schema.

This more accurately models the allowed types for GraphQL since GraphQL will
accept `null` as a valid value when a field is marked as such. Prior to this change,
`null` was not allowed as a value in TypeScript since the generated type definition did not allow it.

Closes #1128

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #1128


## What is the new behavior?

Nullable fields in the GraphQL schema will correctly be marked as nullable in the generated type definitions.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

I don't believe this introduces any breaking changes unless people were doing explicit type checks or something like that. If anything, this should allow people to _remove_ some type assertions, depending on how the generated definitions were being used. In our sizeable codebase, I expect us to have to delete many type assertions (since we had to assert a given type was valid even when `null` was not assignable to `undefined | T`


## Other information