### PR TITLE
refactor(): stop apollo server on module destroy

### DIFF
--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -156,7 +156,7 @@ export class GraphQLModule implements OnModuleInit, OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    this.apolloServer.stop();
+    await this.apolloServer?.stop();
   }
 
   private registerGqlServer(apolloOptions: GqlModuleOptions) {

--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -2,6 +2,7 @@ import { Inject, Module } from '@nestjs/common';
 import {
   DynamicModule,
   OnModuleInit,
+  OnModuleDestroy,
   Provider,
 } from '@nestjs/common/interfaces';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
@@ -48,7 +49,7 @@ import {
   ],
   exports: [GraphQLTypesLoader, GraphQLAstExplorer, GraphQLSchemaHost],
 })
-export class GraphQLModule implements OnModuleInit {
+export class GraphQLModule implements OnModuleInit, OnModuleDestroy {
   protected apolloServer: ApolloServerBase;
   constructor(
     private readonly httpAdapterHost: HttpAdapterHost,
@@ -152,6 +153,10 @@ export class GraphQLModule implements OnModuleInit {
         httpAdapter.getHttpServer(),
       );
     }
+  }
+
+  async onModuleDestroy() {
+    this.apolloServer.stop();
   }
 
   private registerGqlServer(apolloOptions: GqlModuleOptions) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

There is no graceful apollo server shutdown on module destroy. It leads to issues like "tests leaking" in jest.

## What is the new behavior?

Graphql module stops apollo server using the destroy hook.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```