### PR TITLE
Specify generated types for custom scalars

### DIFF
--- a/lib/graphql-definitions.factory.ts
+++ b/lib/graphql-definitions.factory.ts
@@ -35,6 +35,9 @@ export class GraphQLDefinitionsFactory {
     const definitionsGeneratorOptions: DefinitionsGeneratorOptions = {
       emitTypenameField: options.emitTypenameField,
       skipResolverArgs: options.skipResolverArgs,
+      defaultScalarType: options.defaultScalarType,
+      customScalarTypeMapping: options.customScalarTypeMapping,
+      additionalHeader: options.additionalHeader,
     };
 
     if (options.watch) {

--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -234,6 +234,9 @@ export class GraphQLFactory {
     const definitionsGeneratorOptions: DefinitionsGeneratorOptions = {
       emitTypenameField: options.definitions.emitTypenameField,
       skipResolverArgs: options.definitions.skipResolverArgs,
+      defaultScalarType: options.definitions.defaultScalarType,
+      customScalarTypeMapping: options.definitions.customScalarTypeMapping,
+      additionalHeader: options.definitions.additionalHeader,
     };
     const tsFile = await this.graphqlAstExplorer.explore(
       gql`

--- a/lib/schema-builder/type-definitions.generator.ts
+++ b/lib/schema-builder/type-definitions.generator.ts
@@ -29,7 +29,7 @@ export class TypeDefinitionsGenerator {
 
   private generateInputTypeDefs(options: BuildSchemaOptions) {
     const metadata = TypeMetadataStorage.getInputTypesMetadata();
-    const inputTypeDefs = metadata.map(metadata =>
+    const inputTypeDefs = metadata.map((metadata) =>
       this.inputTypeDefinitionFactory.create(metadata, options),
     );
     this.typeDefinitionsStorage.addInputTypes(inputTypeDefs);
@@ -37,7 +37,7 @@ export class TypeDefinitionsGenerator {
 
   private generateObjectTypeDefs(options: BuildSchemaOptions) {
     const metadata = TypeMetadataStorage.getObjectTypesMetadata();
-    const objectTypeDefs = metadata.map(metadata =>
+    const objectTypeDefs = metadata.map((metadata) =>
       this.objectTypeDefinitionFactory.create(metadata, options),
     );
     this.typeDefinitionsStorage.addObjectTypes(objectTypeDefs);
@@ -45,7 +45,7 @@ export class TypeDefinitionsGenerator {
 
   private generateInterfaceDefs(options: BuildSchemaOptions) {
     const metadata = TypeMetadataStorage.getInterfacesMetadata();
-    const interfaceDefs = metadata.map(metadata =>
+    const interfaceDefs = metadata.map((metadata) =>
       this.interfaceDefinitionFactory.create(metadata, options),
     );
     this.typeDefinitionsStorage.addInterfaces(interfaceDefs);
@@ -53,7 +53,7 @@ export class TypeDefinitionsGenerator {
 
   private generateEnumDefs() {
     const metadata = TypeMetadataStorage.getEnumsMetadata();
-    const enumDefs = metadata.map(metadata =>
+    const enumDefs = metadata.map((metadata) =>
       this.enumDefinitionFactory.create(metadata),
     );
     this.typeDefinitionsStorage.addEnums(enumDefs);
@@ -61,7 +61,7 @@ export class TypeDefinitionsGenerator {
 
   private generateUnionDefs() {
     const metadata = TypeMetadataStorage.getUnionsMetadata();
-    const unionDefs = metadata.map(metadata =>
+    const unionDefs = metadata.map((metadata) =>
       this.unionDefinitionFactory.create(metadata),
     );
     this.typeDefinitionsStorage.addUnions(unionDefs);

--- a/lib/services/base-explorer.service.ts
+++ b/lib/services/base-explorer.service.ts
@@ -21,7 +21,7 @@ export class BaseExplorerService {
   ): Module[] {
     const modules = [...modulesContainer.values()];
     return modules.filter(({ metatype }) =>
-      include.some(item => item === metatype),
+      include.some((item) => item === metatype),
     );
   }
 
@@ -30,9 +30,9 @@ export class BaseExplorerService {
     callback: (instance: InstanceWrapper, moduleRef: Module) => T | T[],
   ): T[] {
     const invokeMap = () => {
-      return modules.map(moduleRef => {
+      return modules.map((moduleRef) => {
         const providers = [...moduleRef.providers.values()];
-        return providers.map(wrapper => callback(wrapper, moduleRef));
+        return providers.map((wrapper) => callback(wrapper, moduleRef));
       });
     };
     return flattenDeep(invokeMap()).filter(identity);

--- a/lib/services/gql-arguments-host.ts
+++ b/lib/services/gql-arguments-host.ts
@@ -8,7 +8,8 @@ export interface GraphQLArgumentsHost extends ArgumentsHost {
   getContext<T = any>(): T;
 }
 
-export class GqlArgumentsHost extends ExecutionContextHost
+export class GqlArgumentsHost
+  extends ExecutionContextHost
   implements GraphQLArgumentsHost {
   static create(context: ArgumentsHost): GqlArgumentsHost {
     const type = context.getType();

--- a/lib/services/gql-execution-context.ts
+++ b/lib/services/gql-execution-context.ts
@@ -5,7 +5,8 @@ import { GraphQLArgumentsHost } from './gql-arguments-host';
 export type GqlContextType = 'graphql' | ContextType;
 export type GraphQLExecutionContext = GqlExecutionContext;
 
-export class GqlExecutionContext extends ExecutionContextHost
+export class GqlExecutionContext
+  extends ExecutionContextHost
   implements GraphQLArgumentsHost {
   static create(context: ExecutionContext): GqlExecutionContext {
     const type = context.getType();

--- a/lib/services/plugins-explorer.service.ts
+++ b/lib/services/plugins-explorer.service.ts
@@ -20,7 +20,9 @@ export class PluginsExplorerService extends BaseExplorerService {
       this.modulesContainer,
       this.gqlOptions.include || [],
     );
-    return this.flatMap<any>(modules, instance => this.filterPlugins(instance));
+    return this.flatMap<any>(modules, (instance) =>
+      this.filterPlugins(instance),
+    );
   }
 
   filterPlugins<T = any>(wrapper: InstanceWrapper<T>) {

--- a/lib/utils/async-iterator.util.ts
+++ b/lib/utils/async-iterator.util.ts
@@ -22,7 +22,7 @@ export const createAsyncIterator = async <T = any>(
     }
     return Promise.resolve(filterFn(payload.value))
       .catch(() => false)
-      .then(result => (result ? payload : getNextValue()));
+      .then((result) => (result ? payload : getNextValue()));
   };
 
   return {

--- a/tests/e2e/generated-definitions.spec.ts
+++ b/tests/e2e/generated-definitions.spec.ts
@@ -185,6 +185,79 @@ describe('Generated Definitions', () => {
     ).toBe(await readFile(outputFile, 'utf8'));
   });
 
+  it('should generate custom scalars with a default type', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('custom-scalar.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'custom-scalar-default-type.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+        defaultScalarType: 'unknown',
+      },
+    });
+
+    expect(
+      await readFile(
+        generatedDefinitions('custom-scalar-default-type.fixture.ts'),
+        'utf8',
+      ),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should generate custom scalars with a type mapping', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('custom-scalar-type-mapping.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'custom-scalar-type-mapping.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+        customScalarTypeMapping: {
+          List: 'string[]',
+          Point: '[number, number]',
+          DateTime: Date,
+        },
+      },
+    });
+
+    expect(
+      await readFile(
+        generatedDefinitions('custom-scalar-type-mapping.fixture.ts'),
+        'utf8',
+      ),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+  it('should prepend a custom header', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('custom-header.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions(
+      'custom-header.test-definitions.ts',
+    );
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+        additionalHeader: '/* Put anything here you like */',
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('custom-header.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
   it('should generate for a federated graph', async () => {
     const outputFile = generatedDefinitions('federation.test-definitions.ts');
     const factory = new GraphQLDefinitionsFactory();

--- a/tests/e2e/global-prefix-fastify.spec.ts
+++ b/tests/e2e/global-prefix-fastify.spec.ts
@@ -17,10 +17,7 @@ describe('GraphQL Fastify (global prefix)', () => {
       app.setGlobalPrefix('/api/v1');
       await app.init();
 
-      await app
-        .getHttpAdapter()
-        .getInstance()
-        .ready();
+      await app.getHttpAdapter().getInstance().ready();
     });
 
     it('should return query result', () => {

--- a/tests/e2e/graphql-fastify.spec.ts
+++ b/tests/e2e/graphql-fastify.spec.ts
@@ -14,10 +14,7 @@ describe('GraphQL with fastify', () => {
 
     app = module.createNestApplication(new FastifyAdapter());
     await app.init();
-    await app
-      .getHttpAdapter()
-      .getInstance()
-      .ready();
+    await app.getHttpAdapter().getInstance().ready();
   });
 
   it(`should return query result`, () => {

--- a/tests/e2e/graphql-request-scoped.spec.ts
+++ b/tests/e2e/graphql-request-scoped.spec.ts
@@ -22,7 +22,7 @@ describe('GraphQL request scoped', () => {
     app = module.createNestApplication();
     await app.init();
 
-    const performHttpCall = end =>
+    const performHttpCall = (end) =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
@@ -44,9 +44,9 @@ describe('GraphQL request scoped', () => {
           end();
         });
 
-    await new Promise(resolve => performHttpCall(resolve));
-    await new Promise(resolve => performHttpCall(resolve));
-    await new Promise(resolve => performHttpCall(resolve));
+    await new Promise((resolve) => performHttpCall(resolve));
+    await new Promise((resolve) => performHttpCall(resolve));
+    await new Promise((resolve) => performHttpCall(resolve));
   });
 
   it(`should create resolver for each incoming request`, () => {

--- a/tests/e2e/request-scoped.spec.ts
+++ b/tests/e2e/request-scoped.spec.ts
@@ -35,7 +35,7 @@ describe('Request scope', () => {
 
   describe('when one service is request scoped', () => {
     beforeAll(async () => {
-      const performHttpCall = end =>
+      const performHttpCall = (end) =>
         request(server)
           .post('/graphql')
           .send({
@@ -54,9 +54,9 @@ describe('Request scope', () => {
             if (err) return end(err);
             end();
           });
-      await new Promise(resolve => performHttpCall(resolve));
-      await new Promise(resolve => performHttpCall(resolve));
-      await new Promise(resolve => performHttpCall(resolve));
+      await new Promise((resolve) => performHttpCall(resolve));
+      await new Promise((resolve) => performHttpCall(resolve));
+      await new Promise((resolve) => performHttpCall(resolve));
     });
 
     it(`should create resolver for each request`, async () => {

--- a/tests/generated-definitions/custom-header.fixture.ts
+++ b/tests/generated-definitions/custom-header.fixture.ts
@@ -1,0 +1,12 @@
+
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+
+/* Put anything here you like */
+
+export type CustomDate = any;

--- a/tests/generated-definitions/custom-header.graphql
+++ b/tests/generated-definitions/custom-header.graphql
@@ -1,0 +1,1 @@
+scalar CustomDate

--- a/tests/generated-definitions/custom-scalar-default-type.fixture.ts
+++ b/tests/generated-definitions/custom-scalar-default-type.fixture.ts
@@ -1,0 +1,9 @@
+
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+export type CustomDate = unknown;

--- a/tests/generated-definitions/custom-scalar-type-mapping.fixture.ts
+++ b/tests/generated-definitions/custom-scalar-type-mapping.fixture.ts
@@ -1,0 +1,11 @@
+
+/** ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+export type List = string[];
+export type Point = [number, number];
+export type DateTime = Date;

--- a/tests/generated-definitions/custom-scalar-type-mapping.graphql
+++ b/tests/generated-definitions/custom-scalar-type-mapping.graphql
@@ -1,0 +1,3 @@
+scalar List
+scalar Point
+scalar DateTime

--- a/tests/utils/introspection-schema.utils.ts
+++ b/tests/utils/introspection-schema.utils.ts
@@ -4,7 +4,7 @@ export function getQuery(
   introspectionSchema: IntrospectionSchema,
 ): IntrospectionObjectType {
   return introspectionSchema.types.find(
-    item => item.name === introspectionSchema.queryType.name,
+    (item) => item.name === introspectionSchema.queryType.name,
   ) as IntrospectionObjectType;
 }
 
@@ -12,7 +12,7 @@ export function getMutation(
   introspectionSchema: IntrospectionSchema,
 ): IntrospectionObjectType {
   return introspectionSchema.types.find(
-    item => item.name === introspectionSchema.mutationType.name,
+    (item) => item.name === introspectionSchema.mutationType.name,
   ) as IntrospectionObjectType;
 }
 
@@ -20,7 +20,7 @@ export function getSubscription(
   introspectionSchema: IntrospectionSchema,
 ): IntrospectionObjectType {
   return introspectionSchema.types.find(
-    item => item.name === introspectionSchema.subscriptionType.name,
+    (item) => item.name === introspectionSchema.subscriptionType.name,
   ) as IntrospectionObjectType;
 }
 
@@ -29,7 +29,7 @@ export function getQueryByName(
   name: string,
 ) {
   const queryType = getQuery(introspectionSchema);
-  return queryType.fields.find(item => item.name === name);
+  return queryType.fields.find((item) => item.name === name);
 }
 
 export function getMutationByName(
@@ -37,7 +37,7 @@ export function getMutationByName(
   name: string,
 ) {
   const mutationType = getMutation(introspectionSchema);
-  return mutationType.fields.find(item => item.name === name);
+  return mutationType.fields.find((item) => item.name === name);
 }
 
 export function getSubscriptionByName(
@@ -45,5 +45,5 @@ export function getSubscriptionByName(
   name: string,
 ) {
   const subscriptionType = getSubscription(introspectionSchema);
-  return subscriptionType.fields.find(item => item.name === name);
+  return subscriptionType.fields.find((item) => item.name === name);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'd be happy to contribute documentation, but it wasn't obvious to me where to find its source.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/graphql/issues/1248


## What is the new behavior?

Adds the following 3 fields to `DefinitionsGeneratorOptions`:

```ts

  /**
   * If provided, specifies a default generated TypeScript type for custom scalars.
   * @default 'any'
   */
  defaultScalarType?: string;

  /**
   * If provided, specifies a mapping of types to use for custom scalars
   * @default undefined
   */
  customScalarTypeMapping?: Record<string, string>;

  /**
   * If provided, specifies a custom header to add to the output file (eg. for custom type imports)
   * @default undefined
   */
  header?: string;
```

Sample usage:

```graphql
scalar List
scalar Point
scalar BigNumber
```

```ts
    await graphqlFactory.generateDefinitions(typeDefs, {
      definitions: {
        path: outputFile,
        defaultScalarType: 'unknown',
        customScalarTypeMapping: {
          List: 'string[]',
          Point: '[number, number]',
          BigNumber: 'BigNumber',
        },
        header: "import { BigNumber as _BigNumber } from 'bignumber.js'",
      },
    });
```

emits:

```ts

/** ------------------------------------------------------
 * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 * -------------------------------------------------------
 */

/* tslint:disable */
/* eslint-disable */
import { BigNumber as _BigNumber } from 'bignumber.js'

export type List = string[];
export type Point = [number, number];
export type BigNumber = _BigNumber;
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The new properties are optional and do not break backwards compatibility.

## Other information
There are some additional diffs since I ran `npm run format` as suggested in the [coding rules](https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md#-coding-rules)