### PR TITLE
fix(deps): move apollo-server-core to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@graphql-tools/utils": "6.2.4",
     "@nestjs/mapped-types": "0.1.1",
     "apollo-env": "0.6.5",
-    "apollo-server-core": "2.16.1",
     "chokidar": "3.4.3",
     "fast-glob": "3.2.4",
     "iterall": "1.2.2",
@@ -76,7 +75,8 @@
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
     "graphql": "^14.1.1 || ^15.0.0",
-    "reflect-metadata": "^0.1.12"
+    "reflect-metadata": "^0.1.12",
+    "apollo-server-core": "2.19.0",
   },
   "optionalDependencies": {
     "@apollo/gateway": "^0.17.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since 7.8.0 (#1104) there is the option to get the Apollo Server from the app. This is used in e2e tests to be able to create an apollo test client like so


```
  beforeAll(async () => {
    const moduleRef = await Test.createTestingModule({
      imports: [...],
    }).compile();

    app = moduleRef.createNestApplication();
    await app.init();

    const apolloServer = getApolloServer(app);
    apolloClient = createTestClient(apolloServer);
  });
```

Unfortunately, this breaks typescript compilation because apollo-server-express, @nestjs/graphql > @apollo/gateway and @nestjs/graphql >apollo-server-testing depend on apollo-server-core@2.19.0

This results in a mismatch between versions:

```
tests/users.e2e-spec.ts(45,37): error TS2345: Argument of type 'import("/Users/roderik/Development/bpaas-launchpad/node_modules/@nestjs/graphql/node_modules/apollo-server-core/dist/ApolloServer").ApolloServerBase' is not assignable to parameter of type 'import("/Users/roderik/Development/bpaas-launchpad/node_modules/apollo-server-core/dist/ApolloServer").ApolloServerBase'.
  Type 'ApolloServerBase' is missing the following properties from type 'ApolloServerBase': apolloConfig, serverlessFramework
```

Issue Number: N/A

## What is the new behavior?

By moving the apollo-server-core to the peer dependencies, we can bypass this.

## Workaround

When using yarn, add the following to your package.json

```
  "resolutions": {
    "apollo-server-core": "2.19.0"
  },
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The issue would also (temporarily) be solved when #1118 is merged, but any future update of graphql packages will resurface this issue.