### PR TITLE
feat(@nestjs/graphql): base exception filter for apollo exceptions

### DIFF
--- a/lib/graphql-base-exception-filter.ts
+++ b/lib/graphql-base-exception-filter.ts
@@ -1,0 +1,39 @@
+import { Catch, ArgumentsHost, HttpException } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import {
+  ApolloError,
+  AuthenticationError,
+  ForbiddenError,
+} from 'apollo-server-errors';
+import { GqlContextType } from './services';
+
+const apolloPredefinedExceptions: Record<number, typeof ApolloError> = {
+  401: AuthenticationError,
+  403: ForbiddenError,
+};
+
+@Catch(HttpException)
+export class GraphQLBaseExceptionFilter extends BaseExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    if (host.getType<GqlContextType>() !== 'graphql') {
+      return null;
+    }
+
+    let error: ApolloError;
+    if (exception.getStatus() in apolloPredefinedExceptions) {
+      error = new apolloPredefinedExceptions[exception.getStatus()](
+        exception.message,
+      );
+    } else {
+      error = new ApolloError(
+        exception.message,
+        exception.getStatus().toString(),
+      );
+    }
+
+    error.stack = exception.stack;
+    error.extensions['response'] = exception.getResponse();
+
+    throw error;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ export * from './decorators';
 export * from './federation';
 export * from './graphql-ast.explorer';
 export * from './graphql-definitions.factory';
+export * from './graphql-base-exception-filter';
 export * from './graphql-schema.host';
 export * from './graphql-types.loader';
 export * from './graphql.factory';

--- a/tests/e2e/guards-filters.spec.ts
+++ b/tests/e2e/guards-filters.spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
+import { GraphQLBaseExceptionFilter } from '../../lib';
 import { ApplicationModule } from '../code-first/app.module';
 
 describe('GraphQL - Guards', () => {
@@ -12,6 +13,7 @@ describe('GraphQL - Guards', () => {
     }).compile();
 
     app = module.createNestApplication();
+    app.useGlobalFilters(new GraphQLBaseExceptionFilter());
     await app.init();
   });
 
@@ -26,7 +28,7 @@ describe('GraphQL - Guards', () => {
       .expect(200, {
         errors: [
           {
-            message: 'Unauthorized error',
+            message: 'Unauthorized',
             locations: [
               {
                 line: 2,
@@ -35,7 +37,11 @@ describe('GraphQL - Guards', () => {
             ],
             path: ['recipe'],
             extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
+              code: 'UNAUTHENTICATED',
+              response: {
+                statusCode: 401,
+                message: 'Unauthorized',
+              },
             },
           },
         ],

--- a/tests/e2e/pipes.spec.ts
+++ b/tests/e2e/pipes.spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
+import { GraphQLBaseExceptionFilter } from '../../lib';
 import { ApplicationModule } from '../code-first/app.module';
 
 describe('GraphQL - Pipes', () => {
@@ -12,6 +13,7 @@ describe('GraphQL - Pipes', () => {
     }).compile();
 
     app = module.createNestApplication();
+    app.useGlobalFilters(new GraphQLBaseExceptionFilter());
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
@@ -30,17 +32,13 @@ describe('GraphQL - Pipes', () => {
         errors: [
           {
             extensions: {
-              code: 'INTERNAL_SERVER_ERROR',
-              exception: {
-                message: 'Bad Request Exception',
-                response: {
-                  error: 'Bad Request',
-                  message: [
-                    'description must be longer than or equal to 30 characters',
-                  ],
-                  statusCode: 400,
-                },
-                status: 400,
+              code: '400',
+              response: {
+                error: 'Bad Request',
+                message: [
+                  'description must be longer than or equal to 30 characters',
+                ],
+                statusCode: 400,
               },
             },
             locations: [


### PR DESCRIPTION
Closes #1053

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Exceptions are built by Apollo server engine, and because it doesn't recognizes Nest.js's exceptions, it always returns a generic HTTP 500 error, even for other errors, specifically UNAUTHORIZED. 

Issue Number: #1053 


## What is the new behavior?
Exceptions are converted explicitly to an `ApolloError`, possibly to a specific exception (if exists), and then thrown for the Apollo server to catch and format. 

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This change might cause breakages if clients used to assume HTTP 500 is always returned. However, this will now be in-line with the rest of Apollo server errors and exceptions so it should work well with compliant clients.

## Other information