### PR TITLE
feat: allow custom gql-on-ws protocol for subscriptions

### DIFF
--- a/lib/graphql-ws/graphql-ws-subscription.service.ts
+++ b/lib/graphql-ws/graphql-ws-subscription.service.ts
@@ -1,0 +1,135 @@
+import { makeServer, ServerOptions } from 'graphql-ws';
+import * as ws from 'ws';
+import { IncomingMessage } from 'http';
+import { execute, subscribe } from 'graphql';
+import { GraphqlWsException } from './graphql-ws.exception';
+
+export type WebSocket = typeof ws.prototype;
+
+export interface GraphqlWsSubscriptionServiceOptions {
+  schema: ServerOptions['schema'];
+  onConnect?: ServerOptions['onConnect'];
+  onDisconnect?: ServerOptions['onDisconnect'];
+  context?: ServerOptions['context'];
+  keepAlive?: number;
+}
+
+export interface Extra {
+  readonly socket: WebSocket;
+  readonly request: IncomingMessage;
+}
+
+export class GraphqlWsSubscriptionService {
+  private readonly wss: ws.Server;
+
+  constructor(
+    private readonly options: GraphqlWsSubscriptionServiceOptions,
+    server: any,
+  ) {
+    this.wss = new ws.Server({
+      server,
+      path: '/graphql',
+    });
+    this.initialize();
+  }
+
+  private initialize() {
+    const server = makeServer<Extra>({
+      schema: this.options.schema,
+      execute,
+      subscribe,
+      context: this.options.context,
+      onConnect: this.options.onConnect,
+      onDisconnect: this.options.onDisconnect,
+    });
+
+    const ws = this.wss;
+
+    ws.on('error', (err) => {
+      // catch the first thrown error and re-throw it once all clients have been notified
+      let firstErr: Error | null = err;
+
+      // report server errors by erroring out all clients with the same error
+      for (const client of ws.clients) {
+        try {
+          client.close(1011, 'Internal Error');
+        } catch (err) {
+          firstErr = firstErr ?? err;
+        }
+      }
+
+      if (firstErr) {
+        throw firstErr;
+      }
+    });
+
+    const keepAlive = this.options.keepAlive;
+
+    ws.on('connection', (socket, request) => {
+      // keep alive through ping-pong messages
+      let pongWait: NodeJS.Timeout | null = null;
+      const pingInterval =
+        keepAlive > 0 && isFinite(keepAlive)
+          ? setInterval(() => {
+              // ping pong on open sockets only
+              if (socket.readyState === socket.OPEN) {
+                // terminate the connection after pong wait has passed because the client is idle
+                pongWait = setTimeout(() => {
+                  socket.terminate();
+                }, keepAlive);
+
+                // listen for client's pong and stop socket termination
+                socket.once('pong', () => {
+                  if (pongWait) {
+                    clearTimeout(pongWait);
+                    pongWait = null;
+                  }
+                });
+
+                socket.ping();
+              }
+            }, keepAlive)
+          : null;
+
+      const closed = server.opened(
+        {
+          protocol: socket.protocol,
+          send: (data) =>
+            new Promise((resolve, reject) => {
+              socket.send(data, (err) => (err ? reject(err) : resolve()));
+            }),
+          close: (code, reason) => socket.close(code, reason),
+          onMessage: (cb) =>
+            socket.on('message', async (event) => {
+              try {
+                await cb(event.toString());
+              } catch (err) {
+                if (err instanceof GraphqlWsException) {
+                  socket.close(err.code, err.reason);
+                } else {
+                  socket.close(1011, 'Internal error');
+                }
+              }
+            }),
+        },
+        { socket, request },
+      );
+
+      socket.once('close', (code, reason) => {
+        if (pongWait) clearTimeout(pongWait);
+        if (pingInterval) clearInterval(pingInterval);
+        closed(code, reason);
+      });
+    });
+  }
+
+  async stop() {
+    for (const client of this.wss.clients) {
+      client.close(1001, 'Going away');
+    }
+    this.wss.removeAllListeners();
+    await new Promise<void>((resolve, reject) => {
+      this.wss.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}

--- a/lib/graphql-ws/graphql-ws.exception.ts
+++ b/lib/graphql-ws/graphql-ws.exception.ts
@@ -1,0 +1,14 @@
+/**
+ * Base exception that closes a WebSocket connection when using `graphql-ws`.
+ */
+export class GraphqlWsException extends Error {
+  /**
+   * Instantiate a `GraphqlWsException`.
+   *
+   * @param reason Message explaining the error.
+   * @param code Code for a `CloseEvent`.
+   */
+  constructor(readonly reason: string, readonly code: number) {
+    super(reason);
+  }
+}

--- a/lib/graphql-ws/is-graphql-ws-subscription.util.ts
+++ b/lib/graphql-ws/is-graphql-ws-subscription.util.ts
@@ -1,0 +1,14 @@
+import {
+  GraphQLWsSubscriptionsConfig,
+  SubscriptionConfig,
+} from '../interfaces/gql-module-options.interface';
+
+export function isGraphQLWSSubscriptionConfig(
+  options?: SubscriptionConfig,
+): options is GraphQLWsSubscriptionsConfig {
+  return (
+    !!options &&
+    'protocol' in (options as any) &&
+    (options as any).protocol === 'graphql-ws'
+  );
+}

--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -26,6 +26,7 @@ import {
   ScalarsExplorerService,
 } from './services';
 import { extend, removeTempField } from './utils';
+import { isGraphQLWSSubscriptionConfig } from './graphql-ws/is-graphql-ws-subscription.util';
 
 @Injectable()
 export class GraphQLFactory {
@@ -50,6 +51,12 @@ export class GraphQLFactory {
       options.plugins || [],
       this.pluginsExplorerService.explore(),
     );
+
+    // remove subscriptions configuration if graphql-ws is used
+    if (isGraphQLWSSubscriptionConfig(options.subscriptions)) {
+      const { subscriptions, installSubscriptionHandlers, ...rest } = options;
+      options = { ...rest };
+    }
 
     const transformSchema = async (schema: GraphQLSchema) =>
       options.transformSchema ? await options.transformSchema(schema) : schema;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators';
+export { GraphqlWsException } from './graphql-ws/graphql-ws.exception';
 export * from './federation';
 export * from './graphql-ast.explorer';
 export * from './graphql-definitions.factory';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,25 @@
       "version": "7.9.9",
       "license": "MIT",
       "dependencies": {
+        "@apollo/gateway": "^0.17.0",
         "@graphql-tools/merge": "6.2.7",
         "@graphql-tools/schema": "6.2.4",
         "@graphql-tools/utils": "6.2.4",
         "@nestjs/mapped-types": "0.3.0",
         "apollo-env": "0.6.5",
         "apollo-server-core": "2.16.1",
+        "apollo-server-testing": "^2.16.1",
         "chokidar": "3.5.1",
         "fast-glob": "3.2.5",
+        "graphql-ws": "^4.1.1",
         "iterall": "1.2.2",
         "lodash": "4.17.20",
         "normalize-path": "3.0.0",
+        "subscriptions-transport-ws": "^0.9.17",
+        "ts-morph": "^9.0.0",
         "tslib": "2.1.0",
-        "uuid": "8.3.2"
+        "uuid": "8.3.2",
+        "ws": "^7.4.2"
       },
       "devDependencies": {
         "@apollo/federation": "0.18.1",
@@ -40,6 +46,9 @@
         "@types/normalize-path": "3.0.0",
         "@typescript-eslint/eslint-plugin": "4.15.1",
         "@typescript-eslint/parser": "4.15.1",
+        "apollo-cache-inmemory": "^1.6.6",
+        "apollo-client": "^2.6.10",
+        "apollo-link-ws": "^1.0.20",
         "apollo-server-express": "2.16.1",
         "apollo-server-fastify": "2.16.1",
         "apollo-server-testing": "2.16.1",
@@ -49,6 +58,7 @@
         "eslint-config-prettier": "8.0.0",
         "eslint-plugin-import": "2.22.1",
         "graphql": "15.4.0",
+        "graphql-ws": "^4.1.1",
         "husky": "5.1.0",
         "jest": "26.6.3",
         "lint-staged": "10.5.4",
@@ -56,6 +66,7 @@
         "reflect-metadata": "0.1.13",
         "release-it": "14.4.1",
         "rimraf": "3.0.2",
+        "subscriptions-transport-ws": "^0.9.17",
         "supertest": "6.1.3",
         "ts-jest": "26.5.1",
         "ts-morph": "9.1.0",
@@ -65,6 +76,8 @@
       "optionalDependencies": {
         "@apollo/gateway": "^0.17.0",
         "apollo-server-testing": "^2.16.1",
+        "graphql-ws": "^4.1.1",
+        "subscriptions-transport-ws": "^0.9.17",
         "ts-morph": "^9.0.0"
       },
       "peerDependencies": {
@@ -87,9 +100,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "peerDependencies": {
-        "graphql": "^14.5.0 || ^15.0.0"
       }
     },
     "node_modules/@apollo/federation/node_modules/apollo-env": {
@@ -128,9 +138,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0"
       }
     },
     "node_modules/@apollo/federation/node_modules/form-data": {
@@ -170,9 +177,6 @@
       },
       "engines": {
         "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.5.0 || ^15.0.0"
       }
     },
     "node_modules/@apollo/gateway/node_modules/@apollo/federation": {
@@ -188,9 +192,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "peerDependencies": {
-        "graphql": "^14.5.0 || ^15.0.0"
       }
     },
     "node_modules/@apollo/gateway/node_modules/@jest/types": {
@@ -237,9 +238,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@apollo/gateway/node_modules/chalk": {
@@ -253,9 +251,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@apollo/gateway/node_modules/color-convert": {
@@ -310,7 +305,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.3.tgz",
       "integrity": "sha512-gqeT810Ect9WIqsrgfUvr+ljSB5m1PyBae9HGdrRyQ3HjHjTcjVvxpsMYXlUk4rUHnrfUqyoGvLSy2yLlRGEOw==",
-      "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -406,17 +400,12 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -604,9 +593,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-bigint": {
@@ -616,9 +602,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
@@ -628,9 +611,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
@@ -640,9 +620,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-meta/node_modules/@babel/helper-plugin-utils": {
@@ -658,9 +635,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
@@ -670,9 +644,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators/node_modules/@babel/helper-plugin-utils": {
@@ -688,9 +659,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
@@ -700,9 +668,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-numeric-separator/node_modules/@babel/helper-plugin-utils": {
@@ -718,9 +683,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
@@ -730,9 +692,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
@@ -742,9 +701,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
@@ -754,9 +710,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-top-level-await/node_modules/@babel/helper-plugin-utils": {
@@ -797,7 +750,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -887,9 +839,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@commitlint/cli/node_modules/chalk": {
@@ -903,9 +852,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/cli/node_modules/color-convert": {
@@ -1013,9 +959,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@commitlint/format/node_modules/chalk": {
@@ -1029,9 +972,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/format/node_modules/color-convert": {
@@ -1135,9 +1075,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@commitlint/load/node_modules/chalk": {
@@ -1151,9 +1088,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@commitlint/load/node_modules/color-convert": {
@@ -1287,9 +1221,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/top-level/node_modules/locate-path": {
@@ -1302,9 +1233,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/top-level/node_modules/p-limit": {
@@ -1317,9 +1245,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/top-level/node_modules/p-locate": {
@@ -1332,9 +1257,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@commitlint/types": {
@@ -1390,9 +1312,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
@@ -1440,9 +1359,6 @@
         "@graphql-tools/schema": "^7.0.0",
         "@graphql-tools/utils": "^7.0.0",
         "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/schema": {
@@ -1452,9 +1368,6 @@
       "dependencies": {
         "@graphql-tools/utils": "^7.1.2",
         "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/schema/node_modules/tslib": {
@@ -1470,9 +1383,6 @@
         "@ardatan/aggregate-error": "0.0.6",
         "camel-case": "4.1.2",
         "tslib": "~2.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/camel-case": {
@@ -1517,9 +1427,6 @@
       "dependencies": {
         "@graphql-tools/utils": "^6.2.4",
         "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/tslib": {
@@ -1535,9 +1442,6 @@
         "@ardatan/aggregate-error": "0.0.6",
         "camel-case": "4.1.1",
         "tslib": "~2.0.1"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@graphql-tools/utils/node_modules/tslib": {
@@ -1628,9 +1532,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/chalk": {
@@ -1644,9 +1545,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/console/node_modules/color-convert": {
@@ -1779,9 +1677,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/chalk": {
@@ -1795,9 +1690,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/core/node_modules/color-convert": {
@@ -1906,9 +1798,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/environment/node_modules/chalk": {
@@ -1922,9 +1811,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/environment/node_modules/color-convert": {
@@ -2012,9 +1898,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/fake-timers/node_modules/chalk": {
@@ -2028,9 +1911,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/fake-timers/node_modules/color-convert": {
@@ -2138,9 +2018,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/globals/node_modules/chalk": {
@@ -2154,9 +2031,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/globals/node_modules/color-convert": {
@@ -2217,6 +2091,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2265,9 +2140,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/chalk": {
@@ -2281,9 +2153,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/reporters/node_modules/color-convert": {
@@ -2412,9 +2281,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/test-result/node_modules/chalk": {
@@ -2428,9 +2294,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/test-result/node_modules/color-convert": {
@@ -2549,9 +2412,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/chalk": {
@@ -2565,9 +2425,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/transform/node_modules/color-convert": {
@@ -2661,9 +2518,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/chalk": {
@@ -2677,9 +2531,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@jest/types/node_modules/color-convert": {
@@ -2719,33 +2570,12 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.6.13.tgz",
       "integrity": "sha512-xijw6so4yA8Ywi8mnrA7Kz97ZC36u20Eyb5/XvmokdLcgTcTyHVdE39r44JYnjHPf8SKZoJ965zdu/fKl4s4GQ==",
+      "dev": true,
       "dependencies": {
         "axios": "0.21.1",
         "iterare": "1.2.1",
         "tslib": "2.1.0",
         "uuid": "8.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "cache-manager": "*",
-        "class-transformer": "*",
-        "class-validator": "*",
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "cache-manager": {
-          "optional": true
-        },
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nestjs/core": {
@@ -2753,7 +2583,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.6.13.tgz",
       "integrity": "sha512-8oY8yZSgri2DngqmvBMtwYw1GIAaXbUXS7Y0mp/iSZ6jP7CQqYCybdcMPneunrt5PG8rtJsq6n+4JNRvxXrVmA==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.0.7",
@@ -2762,29 +2591,6 @@
         "path-to-regexp": "3.2.0",
         "tslib": "2.1.0",
         "uuid": "8.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0",
-        "@nestjs/microservices": "^7.0.0",
-        "@nestjs/platform-express": "^7.0.0",
-        "@nestjs/websockets": "^7.0.0",
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nestjs/microservices": {
-          "optional": true
-        },
-        "@nestjs/platform-express": {
-          "optional": true
-        },
-        "@nestjs/websockets": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nestjs/core/node_modules/path-to-regexp": {
@@ -2796,13 +2602,7 @@
     "node_modules/@nestjs/mapped-types": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.3.0.tgz",
-      "integrity": "sha512-AdWVTOg3AhAEcVhPGgUJiLbLXb7L5Pe7vc20YQ0oOXP/KD/nJj0I3BcytVdBhzmgepol67BdivNUvo27Hx3Ndw==",
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.8",
-        "class-transformer": "^0.2.0 || ^0.3.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
-        "reflect-metadata": "^0.1.12"
-      }
+      "integrity": "sha512-AdWVTOg3AhAEcVhPGgUJiLbLXb7L5Pe7vc20YQ0oOXP/KD/nJj0I3BcytVdBhzmgepol67BdivNUvo27Hx3Ndw=="
     },
     "node_modules/@nestjs/platform-express": {
       "version": "7.6.13",
@@ -2815,14 +2615,6 @@
         "express": "4.17.1",
         "multer": "1.4.2",
         "tslib": "2.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0",
-        "@nestjs/core": "^7.0.0"
       }
     },
     "node_modules/@nestjs/platform-fastify": {
@@ -2838,14 +2630,6 @@
         "middie": "5.2.0",
         "path-to-regexp": "3.2.0",
         "tslib": "2.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0",
-        "@nestjs/core": "^7.0.0"
       }
     },
     "node_modules/@nestjs/platform-fastify/node_modules/path-to-regexp": {
@@ -2862,24 +2646,6 @@
       "dependencies": {
         "optional": "0.1.4",
         "tslib": "2.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nest"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^7.0.0",
-        "@nestjs/core": "^7.0.0",
-        "@nestjs/microservices": "^7.0.0",
-        "@nestjs/platform-express": "^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@nestjs/microservices": {
-          "optional": true
-        },
-        "@nestjs/platform-express": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2966,9 +2732,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@nuxtjs/opencollective/node_modules/chalk": {
@@ -2982,9 +2745,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@nuxtjs/opencollective/node_modules/color-convert": {
@@ -3087,19 +2847,13 @@
       "dev": true,
       "dependencies": {
         "@octokit/types": "^6.10.0"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=2"
       }
     },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
+      "dev": true
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "4.12.0",
@@ -3109,9 +2863,6 @@
       "dependencies": {
         "@octokit/types": "^6.10.0",
         "deprecation": "^2.3.1"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/request": {
@@ -3232,9 +2983,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3683,7 +3431,8 @@
     "node_modules/@types/validator": {
       "version": "13.1.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
+      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "7.2.6",
@@ -3708,6 +3457,12 @@
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "devOptional": true
     },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz",
@@ -3725,19 +3480,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
@@ -3788,13 +3530,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -3810,18 +3545,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -3835,10 +3558,6 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -3848,10 +3567,6 @@
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
@@ -3870,15 +3585,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
@@ -3925,10 +3631,6 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
@@ -3939,6 +3641,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/@wry/context/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@wry/equality": {
       "version": "0.1.9",
@@ -4004,10 +3722,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
+      "dev": true
     },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
@@ -4034,7 +3749,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -4064,7 +3778,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -4099,10 +3812,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ajv/node_modules/fast-deep-equal": {
@@ -4189,9 +3898,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
@@ -4201,9 +3907,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -4239,6 +3942,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apollo-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
+      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+      "dev": true,
+      "dependencies": {
+        "apollo-utilities": "^1.3.4",
+        "tslib": "^1.10.0"
+      }
+    },
     "node_modules/apollo-cache-control": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz",
@@ -4249,10 +3962,90 @@
       },
       "engines": {
         "node": ">=6.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
+    },
+    "node_modules/apollo-cache-inmemory": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
+      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
+      "dev": true,
+      "dependencies": {
+        "apollo-cache": "^1.3.5",
+        "apollo-utilities": "^1.3.4",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/apollo-cache-inmemory/node_modules/apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "dev": true,
+      "dependencies": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/apollo-cache-inmemory/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/apollo-cache/node_modules/apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "dev": true,
+      "dependencies": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/apollo-cache/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/apollo-client": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
+      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+      "dev": true,
+      "dependencies": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.5",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.4",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.0"
+      }
+    },
+    "node_modules/apollo-client/node_modules/apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "dev": true,
+      "dependencies": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/apollo-client/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/apollo-datasource": {
       "version": "0.7.2",
@@ -4283,9 +4076,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-engine-reporting-protobuf": {
@@ -4329,9 +4119,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0"
       }
     },
     "node_modules/apollo-engine-reporting/node_modules/form-data": {
@@ -4394,9 +4181,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^14.2.1"
       }
     },
     "node_modules/apollo-link": {
@@ -4408,10 +4192,23 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.21"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
+    },
+    "node_modules/apollo-link-ws": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.20.tgz",
+      "integrity": "sha512-mjSFPlQxmoLArpHBeUb2Xj+2HDYeTaJqFGOqQ+I8NVJxgL9lJe84PDWcPah/yMLv3rB7QgBDSuZ0xoRFBPlySw==",
+      "dev": true,
+      "dependencies": {
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/apollo-link-ws/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/apollo-link/node_modules/tslib": {
       "version": "1.13.0",
@@ -4459,9 +4256,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-core/node_modules/graphql-tools": {
@@ -4474,9 +4268,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-core/node_modules/uuid": {
@@ -4485,6 +4276,14 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/apollo-server-core/node_modules/ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/apollo-server-env": {
@@ -4505,9 +4304,6 @@
       "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-express": {
@@ -4535,9 +4331,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-express/node_modules/graphql-tools": {
@@ -4551,9 +4344,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-express/node_modules/uuid": {
@@ -4581,9 +4371,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-fastify/node_modules/fastify-cors": {
@@ -4607,9 +4394,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-fastify/node_modules/uuid": {
@@ -4630,9 +4414,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-testing": {
@@ -4645,9 +4426,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-server-types": {
@@ -4661,9 +4439,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-tracing": {
@@ -4676,9 +4451,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-utilities": {
@@ -4690,9 +4462,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.10.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
       }
     },
     "node_modules/apollo-utilities/node_modules/tslib": {
@@ -4787,9 +4556,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/es-abstract": {
@@ -4812,9 +4578,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/es-to-primitive": {
@@ -4829,9 +4592,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/has-symbols": {
@@ -4841,9 +4601,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/is-callable": {
@@ -4853,9 +4610,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/is-regex": {
@@ -4868,9 +4622,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-includes/node_modules/object-keys": {
@@ -4911,9 +4662,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/es-abstract": {
@@ -4936,9 +4684,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/es-to-primitive": {
@@ -4953,9 +4698,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/has-symbols": {
@@ -4965,9 +4707,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/is-callable": {
@@ -4977,9 +4716,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/is-regex": {
@@ -4992,9 +4728,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flat/node_modules/object-keys": {
@@ -5130,6 +4863,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
@@ -5151,9 +4885,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/@jest/types": {
@@ -5191,9 +4922,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/chalk": {
@@ -5207,9 +4935,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/babel-jest/node_modules/color-convert": {
@@ -5300,9 +5025,6 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -5316,9 +5038,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/backo2": {
@@ -5404,21 +5123,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "dev": true
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -5530,9 +5235,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/ansi-styles": {
@@ -5545,9 +5247,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/boxen/node_modules/camelcase": {
@@ -5557,9 +5256,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/chalk": {
@@ -5573,9 +5269,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/boxen/node_modules/color-convert": {
@@ -5618,9 +5311,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/wrap-ansi": {
@@ -5635,9 +5325,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/brace-expansion": {
@@ -5693,20 +5380,6 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5807,9 +5480,6 @@
       },
       "engines": {
         "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacache/node_modules/mkdirp": {
@@ -5881,9 +5551,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/callsites": {
@@ -5930,9 +5597,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/capture-exit": {
@@ -5989,6 +5653,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6006,7 +5671,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
       "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6039,7 +5703,8 @@
     "node_modules/class-transformer": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.2.tgz",
-      "integrity": "sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw=="
+      "integrity": "sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw==",
+      "dev": true
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -6072,6 +5737,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
       "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "dev": true,
       "dependencies": {
         "@types/validator": "^13.1.3",
         "libphonenumber-js": "^1.9.7",
@@ -6094,9 +5760,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -6118,9 +5781,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
@@ -6134,9 +5794,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -6419,12 +6076,7 @@
     "node_modules/core-js": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -6560,18 +6212,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
       "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
       "engines": {
         "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/debug/node_modules/ms": {
@@ -6636,9 +6282,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
@@ -6648,9 +6291,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -6977,9 +6617,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -7104,7 +6741,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -7112,9 +6750,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -7166,9 +6801,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -7178,9 +6810,6 @@
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -7209,9 +6838,6 @@
       "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -7337,9 +6963,6 @@
       },
       "engines": {
         "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -7477,9 +7100,6 @@
       "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -7505,9 +7125,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -7529,9 +7146,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/chalk": {
@@ -7545,9 +7159,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/color-convert": {
@@ -7595,9 +7206,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -7996,9 +7604,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/chalk": {
@@ -8012,9 +7617,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/expect/node_modules/color-convert": {
@@ -8529,9 +8131,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -8669,19 +8268,9 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
       "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
+      "dev": true,
       "engines": {
         "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/for-in": {
@@ -8720,10 +8309,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
+      "dev": true
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -8806,9 +8392,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
       "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -8868,9 +8452,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -9005,9 +8586,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/got": {
@@ -9030,9 +8608,6 @@
       },
       "engines": {
         "node": ">=10.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -9045,6 +8620,7 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
       "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -9060,9 +8636,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/graphql-subscriptions": {
@@ -9072,18 +8645,12 @@
       "dev": true,
       "dependencies": {
         "iterall": "^1.2.1"
-      },
-      "peerDependencies": {
-        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0"
       }
     },
     "node_modules/graphql-tag": {
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
-      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA==",
-      "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
+      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
     },
     "node_modules/graphql-upload": {
       "version": "8.1.0",
@@ -9097,9 +8664,6 @@
       },
       "engines": {
         "node": ">=8.5"
-      },
-      "peerDependencies": {
-        "graphql": "0.13.1 - 14"
       }
     },
     "node_modules/graphql-upload/node_modules/busboy": {
@@ -9149,6 +8713,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
+    "node_modules/graphql-ws": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.6.tgz",
+      "integrity": "sha512-ktlbTXrTEukTsDe1q62OVjf/Jzj2wZ11pX5My2Dmfwxx5oS9EqPoOv8Y0WAZUOKmBx9Pbi8+94BFjg7lhaHSMQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -9169,7 +8742,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.3",
@@ -9352,7 +8924,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -9399,9 +8970,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -9421,7 +8989,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -9456,17 +9023,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.0.tgz",
       "integrity": "sha512-Os0EY2haOO+59YZSwMiUDsHY43RFwBVIRStHcnnT8/kvA+sFfaA/YS4uLFRiymXYgQl6E6TQTt3y4v/Z2ctEtw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/typicode"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/husky"
-        }
-      ],
-      "hasInstallScript": true,
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -9490,21 +9046,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "dev": true
     },
     "node_modules/ignore": {
       "version": "5.1.4",
@@ -9629,7 +9171,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
       "dev": true,
       "engines": {
         "node": "*"
@@ -9669,9 +9210,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/inquirer/node_modules/chalk": {
@@ -9685,9 +9223,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/inquirer/node_modules/color-convert": {
@@ -9843,9 +9378,6 @@
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-data-descriptor": {
@@ -9914,9 +9446,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -9976,9 +9505,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally/node_modules/global-dirs": {
@@ -9991,9 +9517,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally/node_modules/ini": {
@@ -10036,9 +9559,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -10151,9 +9671,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-symbol": {
@@ -10356,6 +9873,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10426,9 +9944,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/chalk": {
@@ -10442,9 +9957,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/color-convert": {
@@ -10491,9 +10003,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -10506,9 +10015,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-changed-files/node_modules/has-flag": {
@@ -10625,14 +10131,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      },
-      "peerDependencies": {
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-node": {
-          "optional": true
-        }
       }
     },
     "node_modules/jest-config/node_modules/@jest/types": {
@@ -10670,9 +10168,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/chalk": {
@@ -10686,9 +10181,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/color-convert": {
@@ -10793,9 +10285,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/chalk": {
@@ -10809,9 +10298,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-diff/node_modules/color-convert": {
@@ -10910,9 +10396,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/chalk": {
@@ -10926,9 +10409,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-each/node_modules/color-convert": {
@@ -11061,9 +10541,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/chalk": {
@@ -11077,9 +10554,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/color-convert": {
@@ -11190,9 +10664,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-environment-node/node_modules/chalk": {
@@ -11206,9 +10677,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-environment-node/node_modules/color-convert": {
@@ -11287,6 +10755,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11338,9 +10807,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-haste-map/node_modules/chalk": {
@@ -11354,9 +10820,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-haste-map/node_modules/color-convert": {
@@ -11479,9 +10942,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/chalk": {
@@ -11495,9 +10955,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-jasmine2/node_modules/color-convert": {
@@ -11625,9 +11082,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-leak-detector/node_modules/chalk": {
@@ -11641,9 +11095,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-leak-detector/node_modules/color-convert": {
@@ -11750,9 +11201,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
@@ -11766,9 +11214,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-matcher-utils/node_modules/color-convert": {
@@ -11904,9 +11349,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/chalk": {
@@ -11920,9 +11362,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-message-util/node_modules/color-convert": {
@@ -12033,9 +11472,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-mock/node_modules/chalk": {
@@ -12049,9 +11485,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-mock/node_modules/color-convert": {
@@ -12094,14 +11527,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
       }
     },
     "node_modules/jest-regex-util": {
@@ -12181,9 +11606,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve-dependencies/node_modules/chalk": {
@@ -12197,9 +11619,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve-dependencies/node_modules/color-convert": {
@@ -12270,9 +11689,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/chalk": {
@@ -12286,9 +11702,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-resolve/node_modules/color-convert": {
@@ -12343,9 +11756,6 @@
       "dependencies": {
         "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jest-resolve/node_modules/supports-color": {
@@ -12426,9 +11836,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/chalk": {
@@ -12442,9 +11849,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runner/node_modules/color-convert": {
@@ -12579,9 +11983,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/chalk": {
@@ -12595,9 +11996,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-runtime/node_modules/color-convert": {
@@ -12759,9 +12157,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
@@ -12775,9 +12170,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-snapshot/node_modules/color-convert": {
@@ -12903,9 +12295,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/chalk": {
@@ -12919,9 +12308,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-util/node_modules/color-convert": {
@@ -13015,9 +12401,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/camelcase": {
@@ -13027,9 +12410,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-validate/node_modules/chalk": {
@@ -13043,9 +12423,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-validate/node_modules/color-convert": {
@@ -13155,9 +12532,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/chalk": {
@@ -13171,9 +12545,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-watcher/node_modules/color-convert": {
@@ -13302,9 +12673,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/chalk": {
@@ -13318,9 +12686,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest/node_modules/color-convert": {
@@ -13488,14 +12853,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
       }
     },
     "node_modules/jsdom/node_modules/ws": {
@@ -13505,18 +12862,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/jsesc": {
@@ -13594,10 +12939,8 @@
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonparse": {
@@ -13704,7 +13047,8 @@
     "node_modules/libphonenumber-js": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.7.tgz",
-      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw=="
+      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw==",
+      "dev": true
     },
     "node_modules/light-my-request": {
       "version": "4.4.1",
@@ -13763,9 +13107,6 @@
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
       }
     },
     "node_modules/lint-staged/node_modules/ansi-styles": {
@@ -13778,9 +13119,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/chalk": {
@@ -13794,9 +13132,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/color-convert": {
@@ -13843,9 +13178,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/lint-staged/node_modules/get-stream": {
@@ -13858,9 +13190,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lint-staged/node_modules/has-flag": {
@@ -13967,9 +13296,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
       }
     },
     "node_modules/listr2/node_modules/ansi-styles": {
@@ -13982,9 +13308,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/chalk": {
@@ -13998,9 +13321,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/listr2/node_modules/color-convert": {
@@ -14148,9 +13468,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
@@ -14164,9 +13481,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/log-symbols/node_modules/color-convert": {
@@ -14215,9 +13529,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/ansi-styles": {
@@ -14230,9 +13541,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/log-update/node_modules/astral-regex": {
@@ -14268,9 +13576,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/loglevel": {
@@ -14279,10 +13584,6 @@
       "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
       "engines": {
         "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
       }
     },
     "node_modules/long": {
@@ -14327,9 +13628,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -14453,9 +13751,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/hosted-git-info": {
@@ -14505,9 +13800,6 @@
       "dependencies": {
         "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/meow/node_modules/semver": {
@@ -14529,9 +13821,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/yallist": {
@@ -14745,6 +14034,7 @@
       "integrity": "sha512-ssHt0dkljEDaKmTgQ04DQgx2ag6G2gMPxA5hpcsoeTbfDgRf2fC2gNSRc6kISjD7ckCpHwwQvXxuTBK8402fXg==",
       "optional": true,
       "dependencies": {
+        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-pipeline": "^1.2.2",
         "minipass-sized": "^1.0.3",
@@ -14752,9 +14042,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
       }
     },
     "node_modules/minipass-flush": {
@@ -14900,9 +14187,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mute-stream": {
@@ -15174,10 +14458,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "dev": true
     },
     "node_modules/object-keys": {
       "version": "1.1.0",
@@ -15259,9 +14540,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/es-abstract": {
@@ -15284,9 +14562,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/es-to-primitive": {
@@ -15301,9 +14576,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/has-symbols": {
@@ -15313,9 +14585,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/is-callable": {
@@ -15325,9 +14594,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/is-regex": {
@@ -15340,9 +14606,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values/node_modules/object-keys": {
@@ -15385,9 +14648,15 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "dev": true,
+      "dependencies": {
+        "@wry/context": "^0.4.0"
       }
     },
     "node_modules/optional": {
@@ -15430,9 +14699,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/ansi-styles": {
@@ -15445,9 +14711,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/chalk": {
@@ -15461,9 +14724,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/color-convert": {
@@ -15510,9 +14770,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/os-tmpdir": {
@@ -15585,9 +14842,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -15663,9 +14917,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json/node_modules/decompress-response": {
@@ -15793,9 +15044,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse-path": {
@@ -15817,9 +15065,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/parse-url": {
@@ -15941,9 +15186,6 @@
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "engines": {
         "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pify": {
@@ -16075,9 +15317,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/pretty-format/node_modules/color-convert": {
@@ -16242,30 +15481,13 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
       "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "dev": true
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.1",
@@ -16363,9 +15585,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
@@ -16431,7 +15650,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -16453,9 +15673,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/registry-auth-token": {
@@ -16534,9 +15751,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/release-it/node_modules/chalk": {
@@ -16550,9 +15764,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/release-it/node_modules/ci-info": {
@@ -16597,11 +15808,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/release-it/node_modules/execa": {
@@ -16622,9 +15828,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/release-it/node_modules/find-up": {
@@ -16638,9 +15841,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/form-data": {
@@ -16664,9 +15864,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/has-flag": {
@@ -16718,9 +15915,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/lru-cache": {
@@ -16763,9 +15957,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/p-locate": {
@@ -16778,9 +15969,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/path-key": {
@@ -16898,7 +16086,6 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -16936,16 +16123,12 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
       "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
       "dependencies": {
         "request-promise-core": "1.1.4",
@@ -16954,9 +16137,6 @@
       },
       "engines": {
         "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
       }
     },
     "node_modules/request-promise-native/node_modules/tough-cookie": {
@@ -16976,21 +16156,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "dev": true
     },
     "node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -17090,7 +16256,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
     },
     "node_modules/responselike": {
@@ -17157,9 +16322,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rsvp": {
@@ -17183,26 +16345,13 @@
     "node_modules/run-parallel": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
     },
     "node_modules/rxjs": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -17213,7 +16362,8 @@
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.1",
@@ -17673,9 +16823,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/astral-regex": {
@@ -17890,7 +17037,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
@@ -18204,9 +17350,6 @@
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/es-abstract": {
@@ -18229,9 +17372,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/es-to-primitive": {
@@ -18246,9 +17386,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/has-symbols": {
@@ -18258,9 +17395,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/is-callable": {
@@ -18270,9 +17404,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/is-regex": {
@@ -18285,9 +17416,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimend/node_modules/object-keys": {
@@ -18307,9 +17435,6 @@
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/es-abstract": {
@@ -18332,9 +17457,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/es-to-primitive": {
@@ -18349,9 +17471,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/has-symbols": {
@@ -18361,9 +17480,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/is-callable": {
@@ -18373,9 +17489,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/is-regex": {
@@ -18388,9 +17501,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart/node_modules/object-keys": {
@@ -18483,9 +17593,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/subscriptions-transport-ws": {
@@ -18498,9 +17605,6 @@
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
         "ws": "^5.2.0"
-      },
-      "peerDependencies": {
-        "graphql": ">=0.10.0"
       }
     },
     "node_modules/subscriptions-transport-ws/node_modules/ws": {
@@ -18578,9 +17682,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/superagent/node_modules/readable-stream": {
@@ -18716,10 +17817,6 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/table/node_modules/ansi-styles": {
@@ -18732,9 +17829,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/table/node_modules/color-convert": {
@@ -18767,9 +17861,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/tar": {
@@ -18818,9 +17909,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -18852,9 +17940,6 @@
       },
       "engines": {
         "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-extensions": {
@@ -19116,10 +18201,6 @@
       },
       "engines": {
         "node": ">= 10"
-      },
-      "peerDependencies": {
-        "jest": ">=26 <27",
-        "typescript": ">=3.8 <5.0"
       }
     },
     "node_modules/ts-jest/node_modules/lru-cache": {
@@ -19208,9 +18289,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -19261,9 +18339,6 @@
       },
       "engines": {
         "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/tsutils/node_modules/tslib": {
@@ -19510,9 +18585,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/ansi-styles": {
@@ -19525,9 +18597,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/chalk": {
@@ -19541,9 +18610,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/color-convert": {
@@ -19625,7 +18691,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "deprecated": "Please see https://github.com/lydell/urix#deprecated",
       "dev": true
     },
     "node_modules/url-join": {
@@ -19730,6 +18795,7 @@
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
       "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -19874,9 +18940,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/windows-release/node_modules/cross-spawn": {
@@ -19911,9 +18974,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/windows-release/node_modules/get-stream": {
@@ -19926,9 +18986,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/windows-release/node_modules/is-stream": {
@@ -20031,9 +19088,6 @@
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
@@ -20067,11 +19121,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+      "engines": {
+        "node": ">=8.3.0"
       }
     },
     "node_modules/xdg-basedir": {
@@ -20195,9 +19249,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zen-observable": {
@@ -22347,6 +21398,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.6.13.tgz",
       "integrity": "sha512-xijw6so4yA8Ywi8mnrA7Kz97ZC36u20Eyb5/XvmokdLcgTcTyHVdE39r44JYnjHPf8SKZoJ965zdu/fKl4s4GQ==",
+      "dev": true,
       "requires": {
         "axios": "0.21.1",
         "iterare": "1.2.1",
@@ -22380,8 +21432,7 @@
     "@nestjs/mapped-types": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.3.0.tgz",
-      "integrity": "sha512-AdWVTOg3AhAEcVhPGgUJiLbLXb7L5Pe7vc20YQ0oOXP/KD/nJj0I3BcytVdBhzmgepol67BdivNUvo27Hx3Ndw==",
-      "requires": {}
+      "integrity": "sha512-AdWVTOg3AhAEcVhPGgUJiLbLXb7L5Pe7vc20YQ0oOXP/KD/nJj0I3BcytVdBhzmgepol67BdivNUvo27Hx3Ndw=="
     },
     "@nestjs/platform-express": {
       "version": "7.6.13",
@@ -22597,8 +21648,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
       "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "4.12.0",
@@ -23160,7 +22210,8 @@
     "@types/validator": {
       "version": "13.1.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA=="
+      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
+      "dev": true
     },
     "@types/ws": {
       "version": "7.2.6",
@@ -23184,6 +22235,12 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "devOptional": true
+    },
+    "@types/zen-observable": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.2.tgz",
+      "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.15.1",
@@ -23328,6 +22385,24 @@
         }
       }
     },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "@wry/equality": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
@@ -23385,8 +22460,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -23574,6 +22648,36 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apollo-cache": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.5.tgz",
+      "integrity": "sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==",
+      "dev": true,
+      "requires": {
+        "apollo-utilities": "^1.3.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+          "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+          "dev": true,
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "apollo-cache-control": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz",
@@ -23581,6 +22685,75 @@
       "requires": {
         "apollo-server-env": "^2.4.5",
         "apollo-server-plugin-base": "^0.9.1"
+      }
+    },
+    "apollo-cache-inmemory": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz",
+      "integrity": "sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==",
+      "dev": true,
+      "requires": {
+        "apollo-cache": "^1.3.5",
+        "apollo-utilities": "^1.3.4",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+          "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+          "dev": true,
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "apollo-client": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.10.tgz",
+      "integrity": "sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==",
+      "dev": true,
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.5",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.4",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.0"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+          "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+          "dev": true,
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.10.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "apollo-datasource": {
@@ -23717,6 +22890,24 @@
         }
       }
     },
+    "apollo-link-ws": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.20.tgz",
+      "integrity": "sha512-mjSFPlQxmoLArpHBeUb2Xj+2HDYeTaJqFGOqQ+I8NVJxgL9lJe84PDWcPah/yMLv3rB7QgBDSuZ0xoRFBPlySw==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "apollo-server-caching": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.2.tgz",
@@ -23770,6 +22961,14 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
         }
       }
     },
@@ -23785,8 +22984,7 @@
     "apollo-server-errors": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
-      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
-      "requires": {}
+      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ=="
     },
     "apollo-server-express": {
       "version": "2.16.1",
@@ -24244,6 +23442,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -24950,7 +24149,8 @@
     "class-transformer": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.2.tgz",
-      "integrity": "sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw=="
+      "integrity": "sha512-9QY6QXBH/+Gt1C3HBmJCrgY6+EFpIa6aLjfDnlXFx0zQl/HjrCE7qoaI0srNrxpMIfsobCpgUdDG5JYtJOpVsw==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -24979,6 +24179,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
       "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "dev": true,
       "requires": {
         "@types/validator": "^13.1.3",
         "libphonenumber-js": "^1.9.7",
@@ -26029,8 +25230,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.0.0.tgz",
       "integrity": "sha512-5EaAVPsIHu+grmm5WKjxUia4yHgRrbkd8I0ffqUSwixCPMVBrbS97UnzlEY/Q7OWo584vgixefM0kJnUfo/VjA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -27050,7 +26250,8 @@
     "follow-redirects": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -27325,7 +26526,8 @@
     "graphql": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
+      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "dev": true
     },
     "graphql-extensions": {
       "version": "0.12.4",
@@ -27349,8 +26551,7 @@
     "graphql-tag": {
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
-      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA==",
-      "requires": {}
+      "integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA=="
     },
     "graphql-upload": {
       "version": "8.1.0",
@@ -27402,6 +26603,12 @@
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         }
       }
+    },
+    "graphql-ws": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.6.tgz",
+      "integrity": "sha512-ktlbTXrTEukTsDe1q62OVjf/Jzj2wZ11pX5My2Dmfwxx5oS9EqPoOv8Y0WAZUOKmBx9Pbi8+94BFjg7lhaHSMQ==",
+      "optional": true
     },
     "growly": {
       "version": "1.3.0",
@@ -28305,7 +27512,8 @@
     "iterare": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
-      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q=="
+      "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "dev": true
     },
     "jest": {
       "version": "26.6.3",
@@ -29768,8 +28976,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -30741,8 +29948,7 @@
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
           "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -30892,7 +30098,8 @@
     "libphonenumber-js": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.7.tgz",
-      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw=="
+      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw==",
+      "dev": true
     },
     "light-my-request": {
       "version": "4.4.1",
@@ -32187,6 +31394,15 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "optimism": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
+      "dev": true,
+      "requires": {
+        "@wry/context": "^0.4.0"
+      }
+    },
     "optional": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
@@ -32988,7 +32204,8 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -33534,6 +32751,7 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -33541,7 +32759,8 @@
         "tslib": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+          "dev": true
         }
       }
     },
@@ -35542,7 +34761,8 @@
     "validator": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
@@ -35803,12 +35023,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "@types/normalize-path": "3.0.0",
     "@typescript-eslint/eslint-plugin": "4.15.1",
     "@typescript-eslint/parser": "4.15.1",
+    "apollo-cache-inmemory": "^1.6.6",
+    "apollo-client": "^2.6.10",
+    "apollo-link-ws": "^1.0.20",
     "apollo-server-express": "2.16.1",
     "apollo-server-fastify": "2.16.1",
     "apollo-server-testing": "2.16.1",
@@ -44,6 +47,7 @@
     "eslint-config-prettier": "8.0.0",
     "eslint-plugin-import": "2.22.1",
     "graphql": "15.4.0",
+    "graphql-ws": "^4.1.1",
     "husky": "5.1.0",
     "jest": "26.6.3",
     "lint-staged": "10.5.4",
@@ -51,6 +55,7 @@
     "reflect-metadata": "0.1.13",
     "release-it": "14.4.1",
     "rimraf": "3.0.2",
+    "subscriptions-transport-ws": "^0.9.17",
     "supertest": "6.1.3",
     "ts-jest": "26.5.1",
     "ts-morph": "9.1.0",
@@ -70,7 +75,8 @@
     "lodash": "4.17.20",
     "normalize-path": "3.0.0",
     "tslib": "2.1.0",
-    "uuid": "8.3.2"
+    "uuid": "8.3.2",
+    "ws": "^7.4.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
@@ -81,6 +87,8 @@
   "optionalDependencies": {
     "@apollo/gateway": "^0.17.0",
     "apollo-server-testing": "^2.16.1",
+    "graphql-ws": "^4.1.1",
+    "subscriptions-transport-ws": "^0.9.17",
     "ts-morph": "^9.0.0"
   },
   "lint-staged": {

--- a/tests/subscriptions/app/app.module.ts
+++ b/tests/subscriptions/app/app.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import {
+  GqlModuleOptions,
+  SubscriptionConfig,
+} from '../../../lib/interfaces/gql-module-options.interface';
+import { DynamicModule } from '@nestjs/common/interfaces';
+import { NotificationModule } from './notification.module';
+import { GraphQLModule } from '../../../lib';
+
+export type AppModuleConfig = {
+  context?: GqlModuleOptions['context'];
+  subscriptions?: SubscriptionConfig;
+};
+
+@Module({})
+export class AppModule {
+  static forRoot(options?: AppModuleConfig): DynamicModule {
+    return {
+      module: AppModule,
+      imports: [
+        NotificationModule,
+        GraphQLModule.forRoot({
+          debug: false,
+          context: options?.context,
+          autoSchemaFile: true,
+          installSubscriptionHandlers: true,
+          subscriptions: options?.subscriptions,
+        }),
+      ],
+    };
+  }
+}

--- a/tests/subscriptions/app/auth.guard.ts
+++ b/tests/subscriptions/app/auth.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '../../../lib';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const ctx = GqlExecutionContext.create(context).getContext();
+    return !!ctx.user.startsWith('test');
+  }
+}

--- a/tests/subscriptions/app/notification.module.ts
+++ b/tests/subscriptions/app/notification.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { NotificationResolver } from './notification.resolver';
+
+@Module({
+  providers: [NotificationResolver],
+})
+export class NotificationModule {}

--- a/tests/subscriptions/app/notification.resolver.ts
+++ b/tests/subscriptions/app/notification.resolver.ts
@@ -1,0 +1,38 @@
+import { PubSub } from 'apollo-server-express';
+import { Args, Query, Resolver, Subscription } from '../../../lib';
+import { Notification } from './notification';
+import { Logger, UseGuards } from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+
+export const pubSub = new PubSub();
+
+@Resolver(() => Notification)
+export class NotificationResolver {
+  private readonly logger = new Logger(NotificationResolver.name);
+
+  @Query(() => Notification)
+  getNotification() {
+    return {
+      message: 'Hello!',
+    };
+  }
+
+  @UseGuards(AuthGuard)
+  @Subscription(() => Notification, {
+    filter(payload, variables, context) {
+      return (
+        context.user === payload.newNotification.recipient &&
+        payload.newNotification.id === variables.id
+      );
+    },
+  })
+  newNotification(
+    @Args('id', {
+      nullable: false,
+    })
+    id: string,
+  ) {
+    this.logger.log('User subscribed to newNotification');
+    return pubSub.asyncIterator('newNotification');
+  }
+}

--- a/tests/subscriptions/app/notification.ts
+++ b/tests/subscriptions/app/notification.ts
@@ -1,0 +1,19 @@
+import { Field, ObjectType } from '../../../lib';
+
+@ObjectType()
+export class Notification {
+  @Field({
+    nullable: false,
+  })
+  id: string;
+
+  @Field({
+    nullable: false,
+  })
+  recipient: string;
+
+  @Field({
+    nullable: false,
+  })
+  message: string;
+}

--- a/tests/subscriptions/graphql-ws.spec.ts
+++ b/tests/subscriptions/graphql-ws.spec.ts
@@ -1,0 +1,238 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Client, Context, createClient } from 'graphql-ws';
+import { AppModule } from './app/app.module';
+import { pubSub } from './app/notification.resolver';
+import * as ws from 'ws';
+import ApolloClient, { ApolloError } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { GraphQLWsLink } from './utils/graphql-ws.link';
+import { gql } from 'apollo-server-express';
+import { MissingAuthorizationException } from './utils/missing-authorization.exception';
+import { MalformedTokenException } from './utils/malformed-token.exception';
+
+const subscriptionQuery = gql`
+  subscription TestSubscription($id: String!) {
+    newNotification(id: $id) {
+      id
+      message
+    }
+  }
+`;
+
+describe('graphql-ws protocol', () => {
+  let app: INestApplication;
+  let wsClient: Client;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        AppModule.forRoot({
+          context: (context) => {
+            const { authorization } = context?.connectionParams ?? {};
+            if (authorization) {
+              return { user: authorization.split('Bearer ')[1] };
+            } else {
+              return {};
+            }
+          },
+          subscriptions: {
+            protocol: 'graphql-ws',
+            onConnect: (context: Context) => {
+              if (!context.connectionParams.authorization) {
+                throw new MissingAuthorizationException();
+              }
+              const authorization = context.connectionParams
+                .authorization as string;
+              if (!authorization.startsWith('Bearer ')) {
+                throw new MalformedTokenException();
+              }
+              return true;
+            },
+          },
+        }),
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    await app.listen(3000);
+  });
+
+  it('should receive an error if missing token', (done) => {
+    wsClient = createClient({
+      url: 'ws://localhost:3000/graphql',
+      webSocketImpl: ws,
+      connectionParams: {},
+      retryAttempts: 0,
+    });
+
+    wsClient.on('closed', (ev: CloseEvent) => {
+      expect(ev.code).toEqual(4100);
+      expect(ev.reason).toEqual('Missing authorization');
+      done();
+    });
+
+    const apolloClient = new ApolloClient({
+      link: new GraphQLWsLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error() {},
+      });
+  });
+
+  it('should receive an error if token is malformed', (done) => {
+    wsClient = createClient({
+      url: 'ws://localhost:3000/graphql',
+      webSocketImpl: ws,
+      connectionParams: {
+        authorization: 'wrong token',
+      },
+      retryAttempts: 0,
+    });
+
+    wsClient.on('closed', (ev: CloseEvent) => {
+      expect(ev.code).toEqual(4101);
+      expect(ev.reason).toEqual('Malformed token');
+      done();
+    });
+
+    const apolloClient = new ApolloClient({
+      link: new GraphQLWsLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error() {},
+      });
+  });
+
+  it('should receive error on subscription if guard fails', (done) => {
+    wsClient = createClient({
+      url: 'ws://localhost:3000/graphql',
+      webSocketImpl: ws,
+      connectionParams: {
+        authorization: 'Bearer notest',
+      },
+      retryAttempts: 0,
+    });
+
+    const apolloClient = new ApolloClient({
+      link: new GraphQLWsLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error(error: unknown) {
+          expect(error).toBeInstanceOf(ApolloError);
+          expect((error as ApolloError).graphQLErrors[0].message).toEqual(
+            'Forbidden resource',
+          );
+          expect((error as ApolloError).graphQLErrors[0].path[0]).toEqual(
+            'newNotification',
+          );
+          done();
+        },
+      });
+  });
+
+  it('should connect to subscriptions', (done) => {
+    wsClient = createClient({
+      url: 'ws://localhost:3000/graphql',
+      webSocketImpl: ws,
+      connectionParams: {
+        authorization: 'Bearer test',
+      },
+      retryAttempts: 0,
+    });
+
+    wsClient.on('connected', () => {
+      // timeout needed to allow the subscription to be established
+      setTimeout(() => {
+        pubSub.publish('newNotification', {
+          newNotification: {
+            id: '2',
+            recipient: 'test',
+            message: 'wrong message!',
+          },
+        });
+        pubSub.publish('newNotification', {
+          newNotification: {
+            id: '1',
+            recipient: 'someone-else',
+            message: 'wrong message!',
+          },
+        });
+        pubSub.publish('newNotification', {
+          newNotification: {
+            id: '1',
+            recipient: 'test',
+            message: 'Hello graphql-ws',
+          },
+        });
+      }, 100);
+    });
+
+    const apolloClient = new ApolloClient({
+      link: new GraphQLWsLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next(value: any) {
+          expect(value.data.newNotification.id).toEqual('1');
+          expect(value.data.newNotification.message).toEqual(
+            'Hello graphql-ws',
+          );
+          done();
+        },
+        complete() {},
+        error(error: unknown) {
+          done(error);
+        },
+      });
+  });
+
+  afterEach(async () => {
+    try {
+      await wsClient.dispose();
+    } catch {}
+    await app.close();
+  });
+});

--- a/tests/subscriptions/subscription-transport-ws.spec.ts
+++ b/tests/subscriptions/subscription-transport-ws.spec.ts
@@ -1,0 +1,226 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from './app/app.module';
+import { pubSub } from './app/notification.resolver';
+import { SubscriptionClient } from 'subscriptions-transport-ws';
+import ApolloClient, { ApolloError } from 'apollo-client';
+import { WebSocketLink } from 'apollo-link-ws';
+import { gql } from 'apollo-server-express';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import * as ws from 'ws';
+
+const subscriptionQuery = gql`
+  subscription TestSubscription($id: String!) {
+    newNotification(id: $id) {
+      id
+      message
+    }
+  }
+`;
+
+describe('subscriptions-transport-ws protocol', () => {
+  let app: INestApplication;
+  let wsClient: SubscriptionClient;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        AppModule.forRoot({
+          context: ({ connection }) => {
+            return connection?.context ?? {};
+          },
+          subscriptions: {
+            onConnect: (connectionParams) => {
+              if (!connectionParams.authorization) {
+                throw new Error('Missing authorization header');
+              }
+              const { authorization } = connectionParams;
+              if (!authorization.startsWith('Bearer ')) {
+                throw new Error('Malformed authorization token');
+              }
+              return { user: authorization.split('Bearer ')[1] };
+            },
+          },
+        }),
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    await app.listen(3001);
+  });
+
+  it('should receive an error if missing token', (done) => {
+    wsClient = new SubscriptionClient(
+      'ws://localhost:3001/graphql',
+      {
+        connectionCallback: (errors) => {
+          const error = (errors as unknown) as Error;
+          expect(error.message).toEqual('Missing authorization header');
+          done();
+        },
+        connectionParams: {},
+      },
+      ws,
+    );
+
+    const apolloClient = new ApolloClient({
+      link: new WebSocketLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error() {},
+      });
+  });
+
+  it('should receive an error if token is malformed', (done) => {
+    wsClient = new SubscriptionClient(
+      'ws://localhost:3001/graphql',
+      {
+        connectionCallback: (errors) => {
+          const error = (errors as unknown) as Error;
+          expect(error.message).toEqual('Malformed authorization token');
+          done();
+        },
+        connectionParams: {
+          authorization: 'wrong token',
+        },
+      },
+      ws,
+    );
+
+    const apolloClient = new ApolloClient({
+      link: new WebSocketLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error() {},
+      });
+  });
+
+  it('should fail to connect if no authorization is provided', (done) => {
+    wsClient = new SubscriptionClient(
+      'ws://localhost:3001/graphql',
+      {
+        connectionParams: {
+          authorization: 'Bearer notest',
+        },
+      },
+      ws,
+    );
+
+    const apolloClient = new ApolloClient({
+      link: new WebSocketLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next() {},
+        complete() {},
+        error(error: unknown) {
+          expect(error).toBeInstanceOf(ApolloError);
+          expect((error as ApolloError).graphQLErrors[0].message).toEqual(
+            'Forbidden resource',
+          );
+          expect((error as ApolloError).graphQLErrors[0].path[0]).toEqual(
+            'newNotification',
+          );
+          done();
+        },
+      });
+  });
+
+  it('should receive subscriptions', (done) => {
+    wsClient = new SubscriptionClient(
+      'ws://localhost:3001/graphql',
+      {
+        connectionParams: {
+          authorization: 'Bearer test',
+        },
+      },
+      ws,
+    );
+
+    wsClient.on('connected', () => {
+      pubSub.publish('newNotification', {
+        newNotification: {
+          id: '2',
+          recipient: 'test',
+          message: 'wrong message!',
+        },
+      });
+      pubSub.publish('newNotification', {
+        newNotification: {
+          id: '1',
+          recipient: 'someone-else',
+          message: 'wrong message!',
+        },
+      });
+      pubSub.publish('newNotification', {
+        newNotification: {
+          id: '1',
+          recipient: 'test',
+          message: 'Hello subscription-transport-ws',
+        },
+      });
+    });
+
+    const apolloClient = new ApolloClient({
+      link: new WebSocketLink(wsClient),
+      cache: new InMemoryCache(),
+    });
+
+    apolloClient
+      .subscribe({
+        query: subscriptionQuery,
+        variables: {
+          id: '1',
+        },
+      })
+      .subscribe({
+        next(value: any) {
+          expect(value.data.newNotification.id).toEqual('1');
+          expect(value.data.newNotification.message).toEqual(
+            'Hello subscription-transport-ws',
+          );
+          done();
+        },
+        complete() {},
+        error(error: unknown) {
+          done(error);
+        },
+      });
+  });
+
+  afterEach(async () => {
+    await wsClient.close();
+    await app.close();
+  });
+});

--- a/tests/subscriptions/utils/graphql-ws.link.ts
+++ b/tests/subscriptions/utils/graphql-ws.link.ts
@@ -1,0 +1,26 @@
+import { ApolloLink, Operation, FetchResult } from 'apollo-link';
+import { Observable } from 'apollo-client/util/Observable';
+import { print } from 'graphql';
+import { Client } from 'graphql-ws';
+
+export class GraphQLWsLink extends ApolloLink {
+  private client: Client;
+
+  constructor(client: Client) {
+    super();
+    this.client = client;
+  }
+
+  public request(operation: Operation): Observable<FetchResult> {
+    return new Observable((sink) => {
+      return this.client.subscribe<FetchResult>(
+        { ...operation, query: print(operation.query) },
+        {
+          next: sink.next.bind(sink),
+          complete: sink.complete.bind(sink),
+          error: sink.error.bind(sink),
+        },
+      );
+    });
+  }
+}

--- a/tests/subscriptions/utils/malformed-token.exception.ts
+++ b/tests/subscriptions/utils/malformed-token.exception.ts
@@ -1,0 +1,7 @@
+import { GraphqlWsException } from '../../../lib/graphql-ws/graphql-ws.exception';
+
+export class MalformedTokenException extends GraphqlWsException {
+  constructor() {
+    super('Malformed token', 4101);
+  }
+}

--- a/tests/subscriptions/utils/missing-authorization.exception.ts
+++ b/tests/subscriptions/utils/missing-authorization.exception.ts
@@ -1,0 +1,7 @@
+import { GraphqlWsException } from '../../../lib/graphql-ws/graphql-ws.exception';
+
+export class MissingAuthorizationException extends GraphqlWsException {
+  constructor() {
+    super('Missing authorization', 4100);
+  }
+}


### PR DESCRIPTION
This could close #1341 for the moment, and provide a way to use `graphql-ws` instead of `subscriptions-transport-ws` without breaking existing NestJS services that already use subscriptions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1341 

As described in the issue, the GraphQL module currently relies on `subscriptions-transport-ws`, which has several issues and is being deprecated in favor of `graphql-ws`. Apollo will change the gql-on-ws protocol in the future, but I don't believe `subscriptions-transport-ws` to be production ready, and cannot wait for Apollo to switch protocols nor renounce to NestJS.

## What is the new behavior?

It's now possible to specify a `protocol` when passing `subscriptions` options to the GraphQL module.
The new protocol is `graphql-ws`, and has a few differences in the signature of the callback that the user can provide.
The signatures match the ones documented in `graphql-ws`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The `GraphqlWsSubscriptionService` is taken from the [example implementation](https://github.com/enisdenjo/graphql-ws/blob/master/src/use/ws.ts) provided by `graphql-ws`. The purpose of this class is to connect the WebSocket server, the `graphql-ws` server, and Apollo. The main difference with the example implementation is in how errors are handled.

The `GraphqlWsException` class can be used to close the WebSocket connection with a specific code and reason, as suggested in the `graphql-ws` documentation to implement custom authentication protocols (see [here](https://github.com/enisdenjo/graphql-ws#ws-auth-handling)). The `onConnect` callback can use this exception to signal errors to the client, and the client may behave differently based on the error, e.g., it may refresh the authentication token if it is expired. The tests cover this part.

The `graphql-ws` server is highly customizable via callbacks, that are called by the protocol in different phases of the subscription. Most of these are quite advanced and "low level", and allow manipulation of the `ExecutionArgs` or of the protocol message, so I only included the `onConnect`, `onDisconnect`, and `onClose` ones in the GraphQL module `subscriptions` configuration.

A catch: while the new library is called `graphql-ws`, its [WebSocket sub-protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#communication) is called `graphql-transport-ws`, and the [WebSocket sub-protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/protocol.ts#L1) of `subscriptions-transport-ws` is called `graphql-ws`! :disappointed:  Maybe the `protocol` option passed to the `subscriptions` configuration should be named after the actual WebSocket sub-protocol, and not after the library, to avoid confusion.