### PR TITLE
fix: inherit directive and extensions in type helpers, compile unique directives

### DIFF
--- a/lib/type-helpers/intersection-type.helper.ts
+++ b/lib/type-helpers/intersection-type.helper.ts
@@ -7,6 +7,7 @@ import {
 import { Field } from '../decorators';
 import { ClassDecoratorFactory } from '../interfaces/class-decorator-factory.interface';
 import { getFieldsAndDecoratorForType } from '../schema-builder/utils/get-fields-and-decorator.util';
+import { applyFieldDecorators } from './type-helpers.utils';
 
 export function IntersectionType<A, B>(
   classARef: Type<A>,
@@ -41,6 +42,7 @@ export function IntersectionType<A, B>(
       IntersectionObjectType.prototype,
       item.name,
     );
+    applyFieldDecorators(IntersectionObjectType, item);
   });
 
   Object.defineProperty(IntersectionObjectType, 'name', {

--- a/lib/type-helpers/omit-type.helper.ts
+++ b/lib/type-helpers/omit-type.helper.ts
@@ -8,6 +8,7 @@ import {
 import { Field } from '../decorators';
 import { ClassDecoratorFactory } from '../interfaces/class-decorator-factory.interface';
 import { getFieldsAndDecoratorForType } from '../schema-builder/utils/get-fields-and-decorator.util';
+import { applyFieldDecorators } from './type-helpers.utils';
 
 export function OmitType<T, K extends keyof T>(
   classRef: Type<T>,
@@ -47,6 +48,7 @@ export function OmitType<T, K extends keyof T>(
         OmitObjectType.prototype,
         item.name,
       );
+      applyFieldDecorators(OmitObjectType, item);
     });
   return OmitObjectType as Type<Omit<T, typeof keys[number]>>;
 }

--- a/lib/type-helpers/partial-type.helper.ts
+++ b/lib/type-helpers/partial-type.helper.ts
@@ -10,6 +10,7 @@ import { Field } from '../decorators';
 import { ClassDecoratorFactory } from '../interfaces/class-decorator-factory.interface';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { getFieldsAndDecoratorForType } from '../schema-builder/utils/get-fields-and-decorator.util';
+import { applyFieldDecorators } from './type-helpers.utils';
 
 export function PartialType<T>(
   classRef: Type<T>,
@@ -44,6 +45,7 @@ export function PartialType<T>(
       item.name,
     );
     applyIsOptionalDecorator(PartialObjectType, item.name);
+    applyFieldDecorators(PartialObjectType, item);
   });
 
   if (PartialObjectType[METADATA_FACTORY_NAME]) {

--- a/lib/type-helpers/pick-type.helper.ts
+++ b/lib/type-helpers/pick-type.helper.ts
@@ -8,6 +8,7 @@ import {
 import { Field } from '../decorators';
 import { ClassDecoratorFactory } from '../interfaces/class-decorator-factory.interface';
 import { getFieldsAndDecoratorForType } from '../schema-builder/utils/get-fields-and-decorator.util';
+import { applyFieldDecorators } from './type-helpers.utils';
 
 export function PickType<T, K extends keyof T>(
   classRef: Type<T>,
@@ -48,6 +49,7 @@ export function PickType<T, K extends keyof T>(
         PickObjectType.prototype,
         item.name,
       );
+      applyFieldDecorators(PickObjectType, item);
     });
   return PickObjectType as Type<Pick<T, typeof keys[number]>>;
 }

--- a/lib/type-helpers/type-helpers.utils.ts
+++ b/lib/type-helpers/type-helpers.utils.ts
@@ -1,0 +1,16 @@
+import { Directive, Extensions } from '../decorators';
+import { PropertyMetadata } from '../schema-builder/metadata';
+
+export function applyFieldDecorators(
+  targetClass: Function,
+  item: PropertyMetadata,
+) {
+  if (item.extensions) {
+    Extensions(item.extensions)(targetClass.prototype, item.name);
+  }
+  if (item.directives?.length) {
+    item.directives.map((directive) => {
+      Directive(directive.sdl)(targetClass.prototype, item.name);
+    });
+  }
+}

--- a/tests/type-helpers/intersection-type.helper.spec.ts
+++ b/tests/type-helpers/intersection-type.helper.spec.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '../../lib/decorators';
+import { Directive, Extensions, Field, ObjectType } from '../../lib/decorators';
 import { METADATA_FACTORY_NAME } from '../../lib/plugin/plugin-constants';
 import { getFieldsAndDecoratorForType } from '../../lib/schema-builder/utils/get-fields-and-decorator.util';
 import { IntersectionType } from '../../lib/type-helpers';
@@ -7,6 +7,8 @@ describe('IntersectionType', () => {
   @ObjectType()
   class ClassA {
     @Field({ nullable: true })
+    @Directive('@upper')
+    @Extensions({ extension: true })
     login: string;
 
     @Field()
@@ -16,6 +18,8 @@ describe('IntersectionType', () => {
   @ObjectType()
   class ClassB {
     @Field()
+    @Directive('@upper')
+    @Extensions({ extension: true })
     lastName: string;
 
     firstName?: string;
@@ -30,13 +34,30 @@ describe('IntersectionType', () => {
   class UpdateUserDto extends IntersectionType(ClassA, ClassB) {}
 
   it('should inherit all fields from two types', () => {
-    const { fields } = getFieldsAndDecoratorForType(
-      Object.getPrototypeOf(UpdateUserDto),
-    );
+    const prototype = Object.getPrototypeOf(UpdateUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
     expect(fields.length).toEqual(4);
     expect(fields[0].name).toEqual('login');
     expect(fields[1].name).toEqual('password');
     expect(fields[2].name).toEqual('lastName');
     expect(fields[3].name).toEqual('firstName');
+    expect(fields[0].directives.length).toEqual(1);
+    expect(fields[0].directives).toContainEqual({
+      fieldName: 'login',
+      sdl: '@upper',
+      target: prototype,
+    });
+    expect(fields[0].extensions).toEqual({
+      extension: true,
+    });
+    expect(fields[2].directives.length).toEqual(1);
+    expect(fields[2].directives).toContainEqual({
+      fieldName: 'lastName',
+      sdl: '@upper',
+      target: prototype,
+    });
+    expect(fields[2].extensions).toEqual({
+      extension: true,
+    });
   });
 });

--- a/tests/type-helpers/omit-type.helper.spec.ts
+++ b/tests/type-helpers/omit-type.helper.spec.ts
@@ -1,6 +1,6 @@
 import { Transform } from 'class-transformer';
 import { MinLength } from 'class-validator';
-import { Field, ObjectType } from '../../lib/decorators';
+import { Directive, Extensions, Field, ObjectType } from '../../lib/decorators';
 import { getFieldsAndDecoratorForType } from '../../lib/schema-builder/utils/get-fields-and-decorator.util';
 import { OmitType } from '../../lib/type-helpers';
 
@@ -14,6 +14,8 @@ describe('OmitType', () => {
     @Transform((str) => str + '_transformed')
     @MinLength(10)
     @Field()
+    @Directive('@upper')
+    @Extensions({ extension: true })
     password: string;
 
     @Field({ name: 'id' })
@@ -23,10 +25,18 @@ describe('OmitType', () => {
   class UpdateUserDto extends OmitType(CreateUserDto, ['login', '_id']) {}
 
   it('should inherit all fields except for "login" and "_id"', () => {
-    const { fields } = getFieldsAndDecoratorForType(
-      Object.getPrototypeOf(UpdateUserDto),
-    );
+    const prototype = Object.getPrototypeOf(UpdateUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
     expect(fields.length).toEqual(1);
     expect(fields[0].name).toEqual('password');
+    expect(fields[0].directives.length).toEqual(1);
+    expect(fields[0].directives).toContainEqual({
+      fieldName: 'password',
+      sdl: '@upper',
+      target: prototype,
+    });
+    expect(fields[0].extensions).toEqual({
+      extension: true,
+    });
   });
 });

--- a/tests/type-helpers/partial-type.helper.spec.ts
+++ b/tests/type-helpers/partial-type.helper.spec.ts
@@ -1,6 +1,6 @@
 import { Expose, Transform } from 'class-transformer';
 import { IsString } from 'class-validator';
-import { Field, ObjectType } from '../../lib/decorators';
+import { Directive, Extensions, Field, ObjectType } from '../../lib/decorators';
 import { getFieldsAndDecoratorForType } from '../../lib/schema-builder/utils/get-fields-and-decorator.util';
 import { PartialType } from '../../lib/type-helpers';
 
@@ -8,6 +8,8 @@ describe('PartialType', () => {
   @ObjectType({ isAbstract: true })
   abstract class BaseType {
     @Field()
+    @Directive('@upper')
+    @Extensions({ extension: true })
     id: string;
 
     @Field()
@@ -32,9 +34,8 @@ describe('PartialType', () => {
   class UpdateUserDto extends PartialType(CreateUserDto) {}
 
   it('should inherit all fields and set "nullable" to true', () => {
-    const { fields } = getFieldsAndDecoratorForType(
-      Object.getPrototypeOf(UpdateUserDto),
-    );
+    const prototype = Object.getPrototypeOf(UpdateUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
 
     expect(fields.length).toEqual(5);
     expect(fields).toEqual(
@@ -61,5 +62,14 @@ describe('PartialType', () => {
         }),
       ]),
     );
+    expect(fields[0].directives.length).toEqual(1);
+    expect(fields[0].directives).toContainEqual({
+      fieldName: 'id',
+      sdl: '@upper',
+      target: prototype,
+    });
+    expect(fields[0].extensions).toEqual({
+      extension: true,
+    });
   });
 });


### PR DESCRIPTION
This closes #1351.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. `Directive` and `Extensions` decorators does not inherit when using mapped types.
2. Directives metadata applying multiple times

Issue Number: #1351


## What is the new behavior?
1. `Directive` and `Extensions` decorators is inherited when using mapped types.
2. Skip adding existing directive metadata

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information