### PR TITLE
feat: add create union type and register enum type to shim

### DIFF
--- a/lib/extra/graphql-model-shim.ts
+++ b/lib/extra/graphql-model-shim.ts
@@ -9,6 +9,7 @@ import {
   ObjectTypeOptions,
   ReturnTypeFunc,
 } from '..';
+import * as src from '../type-factories';
 
 // for webpack this is resolved this way:
 // resolve: { // see: https://webpack.js.org/configuration/resolve/
@@ -75,3 +76,10 @@ export function Scalar(
 ): ClassDecorator {
   return (target, key?, descriptor?) => {};
 }
+
+export function dummyFn() {
+  return;
+}
+
+export const createUnionType: typeof src.createUnionType = dummyFn as any;
+export const registerEnumType: typeof src.registerEnumType = dummyFn;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

As a user I wish to use the @nestjs/graphql package in the front-end to take advantage of re-using some DTO classes. 
Whilst doing a migration from nest 6 to 7 and replacing instances of `type-graphql` library with the `@nestjs/graphql` library I discovered that the `createUnionType` and `registerEnumType` was not exported. 



Issue Number: N/A


## What is the new behavior?

This feature simply adds `createUnionType` and `registerEnumType` to the shim list as empty functions.

Similar to this closed issue: https://github.com/nestjs/graphql/issues/1082, it helps improve the developer experience by allowing us to bundle nestjs using tools such as webpack with a shim e.g. 

```
new NormalModuleReplacementPlugin(/@nestjs\/graphql$/, (resource: any) => {
                resource.request = resource.request.replace(
                    /@nestjs\/graphql/,
                    '@nestjs/graphql/dist/extra/graphql-model-shim'
                );
            }),
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information