### PR TITLE
fix(@nestjs/graphql): support intersection-type for arrays

### DIFF
--- a/lib/utils/reflection.utilts.ts
+++ b/lib/utils/reflection.utilts.ts
@@ -100,14 +100,14 @@ function createWrappedExplicitTypeFn(
   explicitTypeFn: ReturnTypeFunc,
   options: TypeOptions,
 ) {
-  return () => {
-    const explicitTypeRef = explicitTypeFn();
-    if (Array.isArray(explicitTypeRef)) {
-      const { depth, typeRef } = getTypeReferenceAndArrayDepth(explicitTypeRef);
-      options.isArray = true;
-      options.arrayDepth = depth;
-      return typeRef;
-    }
-    return explicitTypeRef;
-  };
+  let explicitTypeRef = explicitTypeFn();
+
+  if (Array.isArray(explicitTypeRef)) {
+    const { depth, typeRef } = getTypeReferenceAndArrayDepth(explicitTypeRef);
+    options.isArray = true;
+    options.arrayDepth = depth;
+    explicitTypeRef = typeRef;
+  }
+
+  return () => explicitTypeRef;
 }

--- a/tests/type-helpers/intersection-type.helper.spec.ts
+++ b/tests/type-helpers/intersection-type.helper.spec.ts
@@ -20,6 +20,9 @@ describe('IntersectionType', () => {
 
     firstName?: string;
 
+    @Field(() => [String])
+    hobbies?: string[];
+
     static [METADATA_FACTORY_NAME]() {
       return {
         firstName: { nullable: true, type: () => String },
@@ -33,10 +36,13 @@ describe('IntersectionType', () => {
     const { fields } = getFieldsAndDecoratorForType(
       Object.getPrototypeOf(UpdateUserDto),
     );
-    expect(fields.length).toEqual(4);
+
+    expect(fields.length).toEqual(5);
     expect(fields[0].name).toEqual('login');
     expect(fields[1].name).toEqual('password');
     expect(fields[2].name).toEqual('lastName');
-    expect(fields[3].name).toEqual('firstName');
+    expect(fields[3].name).toEqual('hobbies');
+    expect(fields[3].options).toEqual({ isArray: true, arrayDepth: 1 });
+    expect(fields[4].name).toEqual('firstName');
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

The problem was in `createWrappedExplicitTypeFn` function, when it executes in `reflectTypeFromMetadata` the options did not updated, because options modifying in returned callback from `createWrappedExplicitTypeFn`. But this options need to know before callback executes.

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/nestjs/graphql/issues/1376

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information