### PR TITLE
fix(): support multiple GraphQLModule in an app

### DIFF
--- a/lib/schema-builder/graphql-schema.factory.ts
+++ b/lib/schema-builder/graphql-schema.factory.ts
@@ -54,6 +54,7 @@ export class GraphQLSchemaFactory {
     }
 
     TypeMetadataStorage.clear();
+    this.typeDefinitionsGenerator.clearTypeDefinitionStorage();
     LazyMetadataStorage.load(resolvers);
     TypeMetadataStorage.compile(options.orphanedTypes);
 

--- a/lib/schema-builder/storages/type-definitions.storage.ts
+++ b/lib/schema-builder/storages/type-definitions.storage.ts
@@ -41,6 +41,11 @@ export class TypeDefinitionsStorage {
   private inputTypeDefinitionsLinks?: Map<GqlInputTypeKey, GqlInputType>;
   private outputTypeDefinitionsLinks?: Map<GqlOutputTypeKey, GqlOutputType>;
 
+  clear() {
+    this.inputTypeDefinitionsLinks = null;
+    this.outputTypeDefinitionsLinks = null;
+  }
+
   addEnums(enumDefs: EnumDefinition[]) {
     enumDefs.forEach(item => this.enumTypeDefinitions.set(item.enumRef, item));
   }

--- a/lib/schema-builder/type-definitions.generator.ts
+++ b/lib/schema-builder/type-definitions.generator.ts
@@ -27,6 +27,10 @@ export class TypeDefinitionsGenerator {
     this.generateInputTypeDefs(options);
   }
 
+  clearTypeDefinitionStorage() {
+    this.typeDefinitionsStorage.clear();
+  }
+
   private generateInputTypeDefs(options: BuildSchemaOptions) {
     const metadata = TypeMetadataStorage.getInputTypesMetadata();
     const inputTypeDefs = metadata.map((metadata) =>

--- a/tests/code-first/app.module.ts
+++ b/tests/code-first/app.module.ts
@@ -12,6 +12,12 @@ import { RecipesModule } from './recipes/recipes.module';
       installSubscriptionHandlers: true,
       autoSchemaFile: true,
     }),
+    GraphQLModule.forRoot({
+      debug: false,
+      installSubscriptionHandlers: true,
+      autoSchemaFile: true,
+      path: 'not-default',
+    }),
   ],
 })
 export class ApplicationModule {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added
- [ ] Docs have been added / updated *Docs were already formulated as if this bug didn't exist*

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
```

## What is the current behavior?
Currently, when wanting to use multiple GraphQLModules (different schemas for separate endpoints) in combination with the code-first approach, there will be an error such as `Error: Schema must contain uniquely named types but contains multiple types named "User".`.

Issue Number: #721


## What is the new behavior?
Now it works.
During `GraphQLModule` initialization, basically all storages are cleared and the codebase is re-scanned from scratch including re-evaluation of annotations. Only the `TypeDefinitionsStorage` is an exception, which keeps references to outdated objects using the maps `InputTypeDefinitionsLinks` and `outputTypeDefinitionsLinks`.

With the new behavior, these storages are cleared as well in the `GraphQLSchemaFactory` during `GraphQLModule` initialization.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
I opted to keep code changes minimal while fixing the bug. This means I mixed static method calls with intance method calls in the `GraphQLSchemaFactory` and extended an existing test to mimic the problem. If you want me to add an additional test or structure the code differently, just let me know.
Same goes for a Changelog or docs, so far I haven't touched any.

Closes #721