### PR TITLE
fix(federation): assignment GraphqlSchemaHost#schema in factory

### DIFF
--- a/lib/federation/graphql-federation.factory.ts
+++ b/lib/federation/graphql-federation.factory.ts
@@ -31,6 +31,7 @@ import {
 } from '../services';
 import { extend } from '../utils';
 import { transformSchema } from '../utils/transform-schema.util';
+import { GraphQLSchemaHost } from '../graphql-schema.host';
 
 @Injectable()
 export class GraphQLFederationFactory {
@@ -39,6 +40,7 @@ export class GraphQLFederationFactory {
     private readonly scalarsExplorerService: ScalarsExplorerService,
     private readonly pluginsExplorerService: PluginsExplorerService,
     private readonly gqlSchemaBuilder: GraphQLSchemaBuilder,
+    private readonly gqlSchemaHost: GraphQLSchemaHost,
   ) {}
 
   async mergeOptions(
@@ -60,6 +62,8 @@ export class GraphQLFederationFactory {
     } else {
       schema = this.buildSchemaFromTypeDefs(options);
     }
+
+    this.gqlSchemaHost.schema = schema;
 
     return {
       ...options,

--- a/tests/e2e/graphql-federation-schema-host.spec.ts
+++ b/tests/e2e/graphql-federation-schema-host.spec.ts
@@ -1,0 +1,28 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../graphql-federation/posts-service/federation-posts.module';
+import { GraphQLSchemaHost } from '../../lib';
+import { GraphQLSchema } from 'graphql';
+
+describe('GraphQL federation GraphQLSchemaHost using', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it(`GraphQLSchemaHost should contain schema`, () => {
+      const schemaHost = app.get(GraphQLSchemaHost)
+
+      expect(schemaHost.schema).toBeInstanceOf(GraphQLSchema)
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
GraphqlSchemaHost#schema wasn't assigned after GraphqlFederationModule initialization

resolves nestjs/graphql#1478

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1478 


## What is the new behavior?

GraphqlSchemaHost#schema assigned and can be used correctly after GraphqlFederationModule initialization

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information