### PR TITLE
Consider __typename property of plain javascript objects for type

### DIFF
--- a/lib/schema-builder/factories/interface-definition.factory.ts
+++ b/lib/schema-builder/factories/interface-definition.factory.ts
@@ -87,6 +87,9 @@ export class InterfaceDefinitionFactory {
             (Type) => instance instanceof Type,
           );
           if (!target) {
+            if (Reflect.has(instance, '__typename')) {
+              return instance.__typename;
+            }
             throw new ReturnTypeCannotBeResolvedError(metadata.name);
           }
           return this.typeDefinitionsStorage.getObjectTypeByTarget(target).type;

--- a/lib/schema-builder/factories/union-definition.factory.ts
+++ b/lib/schema-builder/factories/union-definition.factory.ts
@@ -42,6 +42,9 @@ export class UnionDefinitionFactory {
             .find(Type => instance instanceof Type);
 
           if (!target) {
+            if (Reflect.has(instance, '__typename')) {
+              return instance.__typename;
+            }
             throw new ReturnTypeCannotBeResolvedError(metadata.name);
           }
           const objectDef = this.typeDefinitionsStorage.getObjectTypeByTarget(


### PR DESCRIPTION
Most GraphQL implementations support using the `__typename` property to determine the type of an object.

So in addition to looking for a match on instance type, this introduces a fallback to the `__typename` property, when it is set.

If you think this is a valuable addition I will cleanup the PR and make sure to follow the contributing guidelines.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information