### PR TITLE
fix : unhandled promise rejection in registerFastify method

### DIFF
--- a/lib/federation/graphql-federation.module.ts
+++ b/lib/federation/graphql-federation.module.ts
@@ -254,6 +254,7 @@ export class GraphQLFederationModule implements OnModuleInit, OnModuleDestroy {
     }
 
     const apolloServer = new ApolloServer(apolloOptions as any);
+    await apolloServer.start();
     const {
       disableHealthCheck,
       onHealthCheck,

--- a/lib/federation/graphql-gateway.module.ts
+++ b/lib/federation/graphql-gateway.module.ts
@@ -196,6 +196,7 @@ export class GraphQLGatewayModule implements OnModuleInit, OnModuleDestroy {
     const path = this.getNormalizedPath(apolloOptions);
 
     const apolloServer = new ApolloServer(apolloOptions);
+    await apolloServer.start();
     const {
       disableHealthCheck,
       onHealthCheck,

--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -219,6 +219,7 @@ export class GraphQLModule implements OnModuleInit, OnModuleDestroy {
     const path = this.getNormalizedPath(apolloOptions);
 
     const apolloServer = new ApolloServer(apolloOptions as any);
+    await apolloServer.start();
     const {
       disableHealthCheck,
       onHealthCheck,


### PR DESCRIPTION
Apollo server throws unhandled promise rejection when using fastify adapter, now it awaits for the server to start and then proceeds with the createHandler method

fix issue #1536

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Apollo server throws unhandled promise rejection when using fastify adapter

Issue Number: #1536 


## What is the new behavior?
registerFastify method awaits for the apollo server to start and then proceeds with the createHandler method

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information