### PR TITLE
feat(@nestjs/graphql): add enumsAsTypes to definitions generator options

### DIFF
--- a/lib/graphql-definitions.factory.ts
+++ b/lib/graphql-definitions.factory.ts
@@ -39,6 +39,7 @@ export class GraphQLDefinitionsFactory {
       customScalarTypeMapping: options.customScalarTypeMapping,
       additionalHeader: options.additionalHeader,
       defaultTypeMapping: options.defaultTypeMapping,
+      enumsAsTypes: options.enumsAsTypes,
     };
 
     if (options.watch) {

--- a/lib/graphql.factory.ts
+++ b/lib/graphql.factory.ts
@@ -238,6 +238,7 @@ export class GraphQLFactory {
       customScalarTypeMapping: options.definitions.customScalarTypeMapping,
       additionalHeader: options.definitions.additionalHeader,
       defaultTypeMapping: options.definitions.defaultTypeMapping,
+      enumsAsTypes: options.definitions.enumsAsTypes,
     };
     const tsFile = await this.graphqlAstExplorer.explore(
       gql`

--- a/tests/e2e/generated-definitions.spec.ts
+++ b/tests/e2e/generated-definitions.spec.ts
@@ -165,6 +165,26 @@ describe('Generated Definitions', () => {
     ).toBe(await readFile(outputFile, 'utf8'));
   });
 
+  it('should generate enums as types', async () => {
+    const typeDefs = await readFile(
+      generatedDefinitions('enum-as-type.graphql'),
+      'utf8',
+    );
+
+    const outputFile = generatedDefinitions('enum-as-type.test-definitions.ts');
+    await graphqlFactory.generateDefinitions(typeDefs, {
+      definitions: {
+        path: outputFile,
+        enumsAsTypes: true,
+      },
+    });
+
+    expect(
+      await readFile(generatedDefinitions('enum-as-type.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
+
   it('should generate custom scalars', async () => {
     const typeDefs = await readFile(
       generatedDefinitions('custom-scalar.graphql'),

--- a/tests/generated-definitions/enum-as-type.fixture.ts
+++ b/tests/generated-definitions/enum-as-type.fixture.ts
@@ -1,0 +1,10 @@
+
+/*
+ * ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+export type Foobar = "Foo" | "Bar" | "Baz";

--- a/tests/generated-definitions/enum-as-type.graphql
+++ b/tests/generated-definitions/enum-as-type.graphql
@@ -1,0 +1,5 @@
+enum Foobar {
+  Foo
+  Bar
+  Baz
+}


### PR DESCRIPTION
Add enumsAsTypes option to generate string literal union types instead of enums.

Closes #1557

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1557 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->