### PR TITLE
fix: Use default of false for stop termination on signals

### DIFF
--- a/lib/utils/merge-defaults.util.ts
+++ b/lib/utils/merge-defaults.util.ts
@@ -4,6 +4,7 @@ import { GqlModuleOptions } from '../interfaces/gql-module-options.interface';
 const defaultOptions: GqlModuleOptions = {
   path: '/graphql',
   fieldResolverEnhancers: [],
+  stopOnTerminationSignals: false,
 };
 
 export function mergeDefaults(


### PR DESCRIPTION
Without this, Apollo also listens to termination signals and interferes
with our own attempt at graceful shutdown.

Resolves #1560

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1560 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
I've put no on breaking changes, but it's worth mentioning. There may be users who have not called `enableShutdownHooks`, but have included the `GraphQL` module and so would currently be receiving some graceful shutdown by accident. If they took this change without calling `enableShutdownHooks` they will now have no graceful shutdown at all.

## Other information