### PR TITLE
Allow GraphQLDefinitionsFactory to accept typePaths and typeDef for schema generation via cli.

### DIFF
--- a/lib/graphql-definitions.factory.ts
+++ b/lib/graphql-definitions.factory.ts
@@ -154,7 +154,7 @@ export class GraphQLDefinitionsFactory {
     typeDefs?: string | string[]
   ) {
     const typePathDefs = await this.gqlTypesLoader.mergeTypesByPaths(typePaths  || []);
-    const mergedTypeDefs = extend(typePathDefs, typeDefs || '');
+    const mergedTypeDefs = extend(typePathDefs, typeDefs);
     if (!mergedTypeDefs) {
       throw new Error(`"typeDefs" property cannot be null.`);
     }

--- a/lib/graphql-definitions.factory.ts
+++ b/lib/graphql-definitions.factory.ts
@@ -9,7 +9,7 @@ import {
   GraphQLAstExplorer,
 } from './graphql-ast.explorer';
 import { GraphQLTypesLoader } from './graphql-types.loader';
-import { removeTempField } from './utils';
+import { extend, removeTempField } from './utils';
 
 export class GraphQLDefinitionsFactory {
   private readonly gqlAstExplorer = new GraphQLAstExplorer();
@@ -23,6 +23,7 @@ export class GraphQLDefinitionsFactory {
       watch?: boolean;
       debug?: boolean;
       federation?: boolean;
+      typeDefs?: string | string[];
     } & DefinitionsGeneratorOptions,
   ) {
     const isDebugEnabled = !(options && options.debug === false);
@@ -59,6 +60,7 @@ export class GraphQLDefinitionsFactory {
           isFederation,
           isDebugEnabled,
           definitionsGeneratorOptions,
+          options.typeDefs
         );
       });
     }
@@ -69,6 +71,7 @@ export class GraphQLDefinitionsFactory {
       isFederation,
       isDebugEnabled,
       definitionsGeneratorOptions,
+      options.typeDefs
     );
   }
 
@@ -79,6 +82,7 @@ export class GraphQLDefinitionsFactory {
     isFederation: boolean,
     isDebugEnabled: boolean,
     definitionsGeneratorOptions: DefinitionsGeneratorOptions = {},
+    typeDefs?: string | string[]
   ) {
     if (isFederation) {
       return this.exploreAndEmitFederation(
@@ -87,6 +91,7 @@ export class GraphQLDefinitionsFactory {
         outputAs,
         isDebugEnabled,
         definitionsGeneratorOptions,
+        typeDefs
       );
     }
     return this.exploreAndEmitRegular(
@@ -95,6 +100,7 @@ export class GraphQLDefinitionsFactory {
       outputAs,
       isDebugEnabled,
       definitionsGeneratorOptions,
+      typeDefs
     );
   }
 
@@ -104,8 +110,10 @@ export class GraphQLDefinitionsFactory {
     outputAs: 'class' | 'interface',
     isDebugEnabled: boolean,
     definitionsGeneratorOptions: DefinitionsGeneratorOptions,
+    typeDefs?: string | string[]
   ) {
-    const typeDefs = await this.gqlTypesLoader.mergeTypesByPaths(typePaths);
+    const typePathDefs = await this.gqlTypesLoader.mergeTypesByPaths(typePaths);
+    const mergedTypeDefs = extend(typePathDefs, typeDefs);
 
     const {
       buildFederatedSchema,
@@ -117,7 +125,7 @@ export class GraphQLDefinitionsFactory {
     const schema = buildFederatedSchema([
       {
         typeDefs: gql`
-          ${typeDefs}
+          ${mergedTypeDefs}
         `,
         resolvers: {},
       },
@@ -143,15 +151,15 @@ export class GraphQLDefinitionsFactory {
     outputAs: 'class' | 'interface',
     isDebugEnabled: boolean,
     definitionsGeneratorOptions: DefinitionsGeneratorOptions,
+    typeDefs?: string | string[]
   ) {
-    const typeDefs = await this.gqlTypesLoader.mergeTypesByPaths(
-      typePaths || [],
-    );
-    if (!typeDefs) {
+    const typePathDefs = await this.gqlTypesLoader.mergeTypesByPaths(typePaths  || []);
+    const mergedTypeDefs = extend(typePathDefs, typeDefs || '');
+    if (!mergedTypeDefs) {
       throw new Error(`"typeDefs" property cannot be null.`);
     }
     let schema = makeExecutableSchema({
-      typeDefs,
+      typeDefs: mergedTypeDefs,
       resolverValidationOptions: { requireResolversToMatchSchema: 'ignore' },
     });
     schema = removeTempField(schema);

--- a/tests/e2e/generated-definitions.spec.ts
+++ b/tests/e2e/generated-definitions.spec.ts
@@ -273,6 +273,25 @@ describe('Generated Definitions', () => {
     ).toBe(await readFile(outputFile, 'utf8'));
   });
 
+  it('should generate for a federated graph with typeDef', async () => {
+    const outputFile = generatedDefinitions('federation-typedef.test-definitions.ts');
+    const factory = new GraphQLDefinitionsFactory();
+    await factory.generate({
+      typePaths: [generatedDefinitions('federation-typedef.graphql')],
+      typeDefs: `enum Animal {
+        DOG
+        CAT
+      }`,
+      path: outputFile,
+      outputAs: 'class',
+      federation: true,
+    });
+
+    expect(
+      await readFile(generatedDefinitions('federation-typedef.fixture.ts'), 'utf8'),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
+
   it('should generate with __typename field for each object type', async () => {
     const typeDefs = await readFile(
       generatedDefinitions('typename.graphql'),

--- a/tests/generated-definitions/federation-typedef.fixture.ts
+++ b/tests/generated-definitions/federation-typedef.fixture.ts
@@ -1,0 +1,33 @@
+
+/*
+ * ------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+export enum Animal {
+    DOG = "DOG",
+    CAT = "CAT"
+}
+
+export enum Category {
+    POST = "POST"
+}
+
+export class Post {
+    id: string;
+    title: string;
+    author: User;
+    category: Category;
+}
+
+export abstract class IQuery {
+    abstract getPosts(): Post[] | Promise<Post[]>;
+}
+
+export class User {
+    id: string;
+    posts?: Post[];
+}

--- a/tests/generated-definitions/federation-typedef.graphql
+++ b/tests/generated-definitions/federation-typedef.graphql
@@ -1,0 +1,19 @@
+type Post {
+  id: ID!
+  title: String!
+  author: User!
+  category: Category!
+}
+
+extend type User @key(fields: "id") {
+  id: ID! @external
+  posts: [Post]
+}
+
+extend type Query {
+  getPosts: [Post]
+}
+
+extend enum Category {
+  POST
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/nestjs/graphql/issues/1581

Issue Number: 1581


## What is the new behavior?

Type Def defined in the generation are correctly merged with defined schema in the typePath

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information

This is my first ever PR on a public library, so please take a careful look that I not break something carelessly 