### PR TITLE
Import d.ts from @apollo/federation and @apollo/gateway instead of ts

### DIFF
--- a/lib/interfaces/gql-gateway-module-options.interface.ts
+++ b/lib/interfaces/gql-gateway-module-options.interface.ts
@@ -1,5 +1,5 @@
 import { GatewayConfig, ServiceEndpointDefinition } from '@apollo/gateway';
-import { GraphQLDataSource } from '@apollo/gateway/src/datasources/types';
+import { GraphQLDataSource } from '@apollo/gateway/dist/datasources/types';
 import { Type } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { GqlModuleOptions } from './gql-module-options.interface';

--- a/lib/utils/transform-schema.util.ts
+++ b/lib/utils/transform-schema.util.ts
@@ -2,7 +2,7 @@
 // The changed lines are 31-40 and 85-87 and the original file can be found here:
 // https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/schema/transformSchema.ts
 
-import { GraphQLReferenceResolver } from '@apollo/federation/src/types';
+import { GraphQLReferenceResolver } from '@apollo/federation/dist/types';
 import {
   GraphQLFieldConfigArgumentMap,
   GraphQLFieldConfigMap,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the ts files from `@apollo/federation` and `@apollo/gateway` are being imported directly, hence any stricter configuration to tsconfig.json on the consumer level is being enforced on these ts files from `@apollo/federation` and `@apollo/gateway`.

For example, I have `importsNotUsedAsValues` as `error` in my local tsconfig.json, and even with `skipLibCheck` as `true`, tsc still throw this error:

```
node_modules/@apollo/gateway/src/datasources/types.ts:1:1 - error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.

1 import { GraphQLResponse, GraphQLRequestContext } from 'apollo-server-types';
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[8:31:55 PM] Found 1 error. Watching for file changes.
```


## What is the new behavior?


With the changes, tsc will resolve d.ts files in dist instead of ts files in src. Hence any stricter configuration made in tsconfig.json is not being applied on these ts files anymore.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information