### PR TITLE
fix: equality check in getDefaultValue

### DIFF
--- a/lib/schema-builder/helpers/get-default-value.helper.ts
+++ b/lib/schema-builder/helpers/get-default-value.helper.ts
@@ -1,5 +1,5 @@
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import { TypeOptions } from '../../interfaces/type-options.interface';
 import { DefaultValuesConflictError } from '../errors/default-values-conflict.error';
 

--- a/lib/schema-builder/helpers/get-default-value.helper.ts
+++ b/lib/schema-builder/helpers/get-default-value.helper.ts
@@ -1,4 +1,5 @@
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
+import isEqual from 'lodash/isEqual';
 import { TypeOptions } from '../../interfaces/type-options.interface';
 import { DefaultValuesConflictError } from '../errors/default-values-conflict.error';
 
@@ -13,7 +14,7 @@ export function getDefaultValue<T = any>(
     return initializerValue;
   }
   if (
-    options.defaultValue !== initializerValue &&
+    !isEqual(options.defaultValue, initializerValue) &&
     !isUndefined(initializerValue)
   ) {
     throw new DefaultValuesConflictError(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, a `===` is used, which only works for primitive default values. However, this was failing when using an array of values for a default. I think it is simply easier to use the deep equality check with `lodash`, since you are already have that as a dependency.

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information