### PR TITLE
fix(@nestjs/graphql): add missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "apollo-server-core": "^2.21.1",
+    "apollo-server-express": "^2.21.1",
+    "apollo-server-fastify": "^2.25.2",
     "apollo-server-testing": "^2.21.1",
     "graphql": "^14.1.1 || ^15.0.0",
     "reflect-metadata": "^0.1.12",
@@ -88,6 +90,12 @@
       "optional": true
     },
     "@apollo/federation": {
+      "optional": true
+    },
+    "apollo-server-express": {
+      "optional": true
+    },
+    "apollo-server-fastify": {
       "optional": true
     },
     "apollo-server-testing": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

`apollo-server-express` and `apollo-server-fastify` are missing from `peerDependencies` even though they're being required:

https://github.com/nestjs/graphql/blob/3b9b3b95952b727519430b85b4f3a4374dab574e/lib/graphql.module.ts#L181-L185
https://github.com/nestjs/graphql/blob/3b9b3b95952b727519430b85b4f3a4374dab574e/lib/graphql.module.ts#L212-L216



## What is the new behavior?

This PR adds them as optional peer dependencies in order to keep package managers happy (especially Yarn Modern).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information