### PR TITLE
feat(): add custom graphql-ws exception handling

### DIFF
--- a/lib/graphql-ws/graphql-subscription.service.ts
+++ b/lib/graphql-ws/graphql-subscription.service.ts
@@ -1,6 +1,9 @@
 import { execute, GraphQLSchema, subscribe } from 'graphql';
-import { GRAPHQL_TRANSPORT_WS_PROTOCOL, ServerOptions } from 'graphql-ws';
-import { useServer } from 'graphql-ws/lib/use/ws';
+import {
+  GRAPHQL_TRANSPORT_WS_PROTOCOL,
+  makeServer,
+  ServerOptions,
+} from 'graphql-ws';
 import { GRAPHQL_WS, SubscriptionServer } from 'subscriptions-transport-ws';
 import * as ws from 'ws';
 import {
@@ -8,11 +11,20 @@ import {
   GraphQLWsSubscriptionsConfig,
   SubscriptionConfig,
 } from '../interfaces/gql-module-options.interface';
+import { IncomingMessage } from 'http';
+import { GraphqlWsException } from './graphql-ws.exception';
 
 export interface GraphQLSubscriptionServiceOptions extends SubscriptionConfig {
   schema: GraphQLSchema;
   path?: string;
   context?: ServerOptions['context'];
+}
+
+type WebSocket = typeof ws.prototype;
+
+interface Extra {
+  readonly socket: WebSocket;
+  readonly request: IncomingMessage;
 }
 
 export class GraphQLSubscriptionService {
@@ -48,16 +60,13 @@ export class GraphQLSubscriptionService {
       const graphqlWsOptions =
         this.options['graphql-ws'] === true ? {} : this.options['graphql-ws'];
       supportedProtocols.push(GRAPHQL_TRANSPORT_WS_PROTOCOL);
-      useServer(
-        {
-          schema: this.options.schema,
-          execute,
-          subscribe,
-          context: this.options.context,
-          ...graphqlWsOptions,
-        },
-        this.wss,
-      );
+      this.useGraphQLWsServer(this.wss, {
+        schema: this.options.schema,
+        execute,
+        subscribe,
+        context: this.options.context,
+        ...graphqlWsOptions,
+      });
     }
 
     if ('subscriptions-transport-ws' in this.options) {
@@ -103,10 +112,98 @@ export class GraphQLSubscriptionService {
     });
   }
 
+  private useGraphQLWsServer(
+    ws: ws.Server,
+    options: ServerOptions & GraphQLWsSubscriptionsConfig,
+  ) {
+    const server = makeServer<Extra>(options);
+
+    ws.on('error', (err) => {
+      // catch the first thrown error and re-throw it once all clients have been notified
+      let firstErr: Error | null = err;
+
+      // report server errors by erroring out all clients with the same error
+      for (const client of ws.clients) {
+        try {
+          client.close(1011, 'Internal Error');
+        } catch (err) {
+          firstErr = firstErr ?? err;
+        }
+      }
+
+      if (firstErr) {
+        throw firstErr;
+      }
+    });
+
+    const keepAlive = options.keepAlive;
+
+    ws.on('connection', (socket, request) => {
+      // keep alive through ping-pong messages
+      let pongWait: NodeJS.Timeout | null = null;
+      const pingInterval =
+        keepAlive > 0 && isFinite(keepAlive)
+          ? setInterval(() => {
+              // ping pong on open sockets only
+              if (socket.readyState === socket.OPEN) {
+                // terminate the connection after pong wait has passed because the client is idle
+                pongWait = setTimeout(() => {
+                  socket.terminate();
+                }, keepAlive);
+
+                // listen for client's pong and stop socket termination
+                socket.once('pong', () => {
+                  if (pongWait) {
+                    clearTimeout(pongWait);
+                    pongWait = null;
+                  }
+                });
+
+                socket.ping();
+              }
+            }, keepAlive)
+          : null;
+
+      const closed = server.opened(
+        {
+          protocol: socket.protocol,
+          send: (data) =>
+            new Promise((resolve, reject) => {
+              socket.send(data, (err) => (err ? reject(err) : resolve()));
+            }),
+          close: (code, reason) => socket.close(code, reason),
+          onMessage: (cb) =>
+            socket.on('message', async (event) => {
+              try {
+                await cb(event.toString());
+              } catch (err) {
+                if (err instanceof GraphqlWsException) {
+                  socket.close(err.code, err.reason);
+                } else {
+                  socket.close(1011, 'Internal error');
+                }
+              }
+            }),
+        },
+        { socket, request },
+      );
+
+      socket.once('close', (code, reason) => {
+        if (pongWait) clearTimeout(pongWait);
+        if (pingInterval) clearInterval(pingInterval);
+        closed(code, reason.toString());
+      });
+    });
+  }
+
   async stop() {
     for (const client of this.wss.clients) {
       client.close(1001, 'Going away');
     }
+    this.wss.removeAllListeners();
+    await new Promise<void>((resolve, reject) => {
+      this.wss.close((err) => (err ? reject(err) : resolve()));
+    });
     for (const client of this.subTransWs.clients) {
       client.close(1001, 'Going away');
     }

--- a/lib/graphql-ws/graphql-ws.exception.ts
+++ b/lib/graphql-ws/graphql-ws.exception.ts
@@ -1,0 +1,14 @@
+/**
+ * Base exception that closes a WebSocket connection when using `graphql-ws`.
+ */
+export class GraphqlWsException extends Error {
+  /**
+   * Instantiate a `GraphqlWsException`.
+   *
+   * @param reason Message explaining the error.
+   * @param code Code for a `CloseEvent`.
+   */
+  constructor(readonly reason: string, readonly code: number) {
+    super(reason);
+  }
+}

--- a/lib/interfaces/gql-module-options.interface.ts
+++ b/lib/interfaces/gql-module-options.interface.ts
@@ -33,6 +33,7 @@ export type GraphQLWsSubscriptionsConfig = Partial<
     | 'onNext'
   >
 > & {
+  keepAlive?: number;
   path?: string;
 };
 

--- a/tests/subscriptions/graphql-ws.spec.ts
+++ b/tests/subscriptions/graphql-ws.spec.ts
@@ -9,6 +9,7 @@ import { AppModule } from './app/app.module';
 import { pubSub } from './app/notification.resolver';
 import { GraphQLWsLink } from './utils/graphql-ws.link';
 import { MalformedTokenException } from './utils/malformed-token.exception';
+import { MissingAuthorizationException } from './utils/missing-authorization.exception';
 
 const subscriptionQuery = gql`
   subscription TestSubscription($id: String!) {
@@ -39,10 +40,7 @@ describe('graphql-ws protocol', () => {
             'graphql-ws': {
               onConnect: (context: Context<any>) => {
                 if (!context.connectionParams.authorization) {
-                  return context.extra.socket.close(
-                    4000,
-                    'Missing authorization',
-                  );
+                  throw new MissingAuthorizationException();
                 }
                 const authorization = context.connectionParams
                   .authorization as string;
@@ -71,7 +69,7 @@ describe('graphql-ws protocol', () => {
     });
 
     wsClient.on('closed', (ev: any) => {
-      expect(ev.code).toEqual(4000);
+      expect(ev.code).toEqual(4100);
       expect(ev.reason).toEqual('Missing authorization');
       done();
     });
@@ -106,7 +104,7 @@ describe('graphql-ws protocol', () => {
     });
 
     wsClient.on('closed', (ev: any) => {
-      expect(ev.code).toEqual(4500);
+      expect(ev.code).toEqual(4101);
       expect(ev.reason).toEqual('Malformed token');
       done();
     });

--- a/tests/subscriptions/subscription-transport-ws.spec.ts
+++ b/tests/subscriptions/subscription-transport-ws.spec.ts
@@ -8,6 +8,8 @@ import { SubscriptionClient } from 'subscriptions-transport-ws';
 import * as ws from 'ws';
 import { AppModule } from './app/app.module';
 import { pubSub } from './app/notification.resolver';
+import { MalformedTokenException } from './utils/malformed-token.exception';
+import { MissingAuthorizationException } from './utils/missing-authorization.exception';
 
 const subscriptionQuery = gql`
   subscription TestSubscription($id: String!) {
@@ -33,11 +35,11 @@ describe('subscriptions-transport-ws protocol', () => {
             'subscriptions-transport-ws': {
               onConnect: (connectionParams) => {
                 if (!connectionParams.authorization) {
-                  throw new Error('Missing authorization header');
+                  throw new MissingAuthorizationException();
                 }
                 const { authorization } = connectionParams;
                 if (!authorization.startsWith('Bearer ')) {
-                  throw new Error('Malformed authorization token');
+                  throw new MalformedTokenException();
                 }
                 return { user: authorization.split('Bearer ')[1] };
               },
@@ -58,7 +60,7 @@ describe('subscriptions-transport-ws protocol', () => {
       {
         connectionCallback: (errors) => {
           const error = errors as unknown as Error;
-          expect(error.message).toEqual('Missing authorization header');
+          expect(error.message).toEqual('Missing authorization');
           done();
         },
         connectionParams: {},
@@ -91,7 +93,7 @@ describe('subscriptions-transport-ws protocol', () => {
       {
         connectionCallback: (errors) => {
           const error = errors as unknown as Error;
-          expect(error.message).toEqual('Malformed authorization token');
+          expect(error.message).toEqual('Malformed token');
           done();
         },
         connectionParams: {

--- a/tests/subscriptions/utils/malformed-token.exception.ts
+++ b/tests/subscriptions/utils/malformed-token.exception.ts
@@ -1,5 +1,7 @@
-export class MalformedTokenException extends Error {
+import { GraphqlWsException } from '../../../lib/graphql-ws/graphql-ws.exception';
+
+export class MalformedTokenException extends GraphqlWsException {
   constructor() {
-    super('Malformed token');
+    super('Malformed token', 4101);
   }
 }

--- a/tests/subscriptions/utils/missing-authorization.exception.ts
+++ b/tests/subscriptions/utils/missing-authorization.exception.ts
@@ -1,5 +1,7 @@
-export class MissingAuthorizationException extends Error {
+import { GraphqlWsException } from '../../../lib/graphql-ws/graphql-ws.exception';
+
+export class MissingAuthorizationException extends GraphqlWsException {
   constructor() {
-    super('Missing authorization');
+    super('Missing authorization', 4100);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, error handling for `graphql-ws` on the master branch is done by closing the WebSocket connection manually.
`graphql-ws` relies on the code contained in the CloseEvent for error handling.

Issue Number: N/A


## What is the new behavior?

This PR adds support for custom error handling via a dedicated `GraphqlWsException`, that contains the reason and code that will be used to close the WebSocket connection.
This PR also removes the usage of `useServer` from `graphql-ws`, since it's just an example implementation ([see here](https://github.com/enisdenjo/graphql-ws/blob/master/src/use/ws.ts#L34)) and should be adapted to the needs of the integration.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
