### PR TITLE
Add back apollo-server-* peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "apollo-server-core": "^3.0.0",
+    "apollo-server-express": "^2.21.1",
+    "apollo-server-fastify": "^2.25.2",
+    "apollo-server-testing": "^2.21.1",
     "graphql": "^15.5.1",
     "reflect-metadata": "^0.1.13",
     "ts-morph": "^11.0.3"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
272b186 removed the `apollo-server-express`, `apollo-server-fastify` and `apollo-server-testing` from `peerDependencies`, which are required for package managers that do hoisting.

Fixes #1708


## What is the new behavior?
Package managers see `apollo-server-*` as a peer dependency and do not hoist `@nestjs/graphql` if the peer dependecies do not get hoisted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have noticed, that the dependencies have been updated in `devDependencies`.

```
"apollo-server-express": "3.1.2",
"apollo-server-fastify": "3.1.2",
```

I thought apollo-server-* v3 is not supported at the moment. Should I also update the peer dependencies to `3.1.2`?