### PR TITLE
fix(@nestjs/graphql): fixed fatal error regarding graphql-ws

### DIFF
--- a/lib/graphql-ws/graphql-subscription.service.ts
+++ b/lib/graphql-ws/graphql-subscription.service.ts
@@ -87,7 +87,7 @@ export class GraphQLSubscriptionService {
         ? protocol
         : protocol?.split(',').map((p) => p.trim());
 
-      protocols = protocols.filter((protocol) =>
+      protocols = protocols?.filter((protocol) =>
         supportedProtocols.includes(protocol),
       );
 


### PR DESCRIPTION
fixed fatal error when sec-websocket-protocol isn't exists in request headers using graphql-ws

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1731


## What is the new behavior?
Server still working when sec-websocket-protocol isn't exist in request header

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information