### PR TITLE
fix(@nestjs/graphql) explicitly disabling subscriptions in gateway

### DIFF
--- a/lib/federation/graphql-gateway.module.ts
+++ b/lib/federation/graphql-gateway.module.ts
@@ -126,7 +126,7 @@ export class GraphQLGatewayModule implements OnModuleInit, OnModuleDestroy {
     await this.registerGqlServer({
       ...serverOpts,
       gateway,
-      subscriptions: undefined,
+      subscriptions: false,
     });
 
     if (serverOpts.installSubscriptionHandlers) {

--- a/lib/interfaces/gql-module-options.interface.ts
+++ b/lib/interfaces/gql-module-options.interface.ts
@@ -62,7 +62,7 @@ export interface GqlModuleOptions
     schema: GraphQLSchema,
   ) => GraphQLExecutor | Promise<GraphQLExecutor>;
   installSubscriptionHandlers?: boolean;
-  subscriptions?: SubscriptionConfig;
+  subscriptions?: boolean | SubscriptionConfig;
   resolverValidationOptions?: IResolverValidationOptions;
   directiveResolvers?: any;
   schemaDirectives?: Record<string, any>;


### PR DESCRIPTION
Fixes the Promise rejection from Apollo Server which requires explicitly setting subscriptions to false in Apollo Server's constructor.

Solves #1749 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The subscriptions option is not set in Apollo Server constructor when using Federation Gateway
Issue Number: #1749 

## What is the new behavior?
The subscriptions option is set as false in Apollo Server constructor when using Federation Gateway

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information