### PR TITLE
WIP: Feature/update ts transform plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier',
-    'prettier/@typescript-eslint',
   ],
   root: true,
   env: {

--- a/lib/plugin/merge-options.ts
+++ b/lib/plugin/merge-options.ts
@@ -3,11 +3,13 @@ import { isString } from '@nestjs/common/utils/shared.utils';
 export interface PluginOptions {
   typeFileNameSuffix?: string | string[];
   introspectComments?: boolean;
+  advancedTypeIntrospection?: boolean;
 }
 
 const defaultOptions: PluginOptions = {
   typeFileNameSuffix: ['.input.ts', '.args.ts', '.entity.ts', '.model.ts'],
   introspectComments: false,
+  advancedTypeIntrospection: true,
 };
 
 export const mergePluginOptions = (

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -1,339 +1,218 @@
-import { compact, flatten } from 'lodash';
 import * as ts from 'typescript';
-import { HideField } from '../../decorators';
+import { SyntaxKind, isTypeReferenceNode, isArrayTypeNode, Identifier, Expression } from 'typescript';
+import { HideField, ObjectType } from '../../decorators';
 import { PluginOptions } from '../merge-options';
 import { METADATA_FACTORY_NAME } from '../plugin-constants';
-import { findNullableTypeFromUnion, getDescriptionOfNode, isNull, isUndefined } from '../utils/ast-utils';
 import {
-  getDecoratorOrUndefinedByNames,
-  getTypeReferenceAsString,
-  hasPropertyKey,
-  replaceImportPath,
-} from '../utils/plugin-utils';
+  createBoolean,
+  hasDecorators,
+  hasModifiers,
+  getJsDocDeprecation,
+  getJSDocDescription,
+} from '../utils/ast-utils';
+import { getMemberTypeFromTypeChecker } from '../utils/plugin-utils';
 
-const metadataHostMap = new Map();
-const importsToAddPerFile = new Map<string, Set<string>>();
+
+export type MetadataTypeDef = {
+  arrayType: boolean,
+  typeName: string,
+}
+
+type MetadataDef = {
+  propertyName: string,
+  nullable: boolean,
+  type: MetadataTypeDef,
+  description?: string;
+  deprecated?: string | boolean;
+  // needImport?
+  // specialType like ID and Float | Int ?
+}
+
+
+function getMemberTypeFromAst(node: ts.TypeNode): MetadataTypeDef {
+  if (!node) {
+    // todo: or throw new Error('Property should have an explicitly defined type!');
+    return {
+      typeName: 'Object',
+      arrayType: false,
+    }
+  }
+
+  if (isTypeReferenceNode(node)) {
+    return {
+      typeName: (node.typeName as Identifier).escapedText.toString(),
+      arrayType: false,
+    };
+  }
+
+  if (isArrayTypeNode(node)) {
+    const metaType = getMemberTypeFromAst(node.elementType);
+
+    return {
+      ...metaType,
+      arrayType: true,
+    };
+  }
+
+  const mapping = {
+    [SyntaxKind.StringKeyword]: 'String',
+    [SyntaxKind.BooleanKeyword]: 'Boolean',
+    [SyntaxKind.NumberKeyword]: 'Number',
+
+    // todo: improve here to support string unions
+    // [SyntaxKind.UnionType]: 'Object',
+    // [SyntaxKind.AnyKeyword]: 'Object',
+    // [SyntaxKind.UnknownKeyword]: 'Object',
+    // [SyntaxKind.ObjectKeyword]: 'Object',
+  };
+
+  // if we were fail to discover type - fallback to Object
+  return {
+    typeName: mapping[node.kind] || 'Object',
+    arrayType: false,
+  };
+
+
+  // todo: isPromiseOrObservable and add test case
+  // todo union like 'foo' | 'bar'
+  // todo Float | Integer
+  // todo: Date | undefined
+}
+
+/**
+ * create:
+ *  { type: () => Number }
+ */
+function createTypePropertyAssignment(f: ts.NodeFactory, metadataType: MetadataTypeDef): ts.PropertyAssignment {
+  const typeIdentifier = f.createIdentifier(metadataType.typeName);
+
+  const fnBody = metadataType.arrayType
+    ? f.createArrayLiteralExpression([typeIdentifier])
+    : typeIdentifier;
+
+  const typeArrowFn = f.createArrowFunction(undefined, undefined, undefined, undefined, undefined, fnBody);
+
+  return f.createPropertyAssignment('type', typeArrowFn);
+}
+
+function createScalarPropertyAssigment(f: ts.NodeFactory, name: string, value: undefined | string | boolean): ts.PropertyAssignment {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  let initializer: Expression;
+  if (typeof value === 'string') {
+    initializer = f.createStringLiteral(value);
+  } else if (typeof value === 'boolean') {
+    initializer = createBoolean(f, value)
+  }
+
+  return f.createPropertyAssignment(name, initializer);
+}
 
 export class ModelClassVisitor {
   visit(
     sourceFile: ts.SourceFile,
     ctx: ts.TransformationContext,
-    program: ts.Program,
+    program: ts.Program | undefined,
     pluginOptions: PluginOptions,
   ) {
-    const typeChecker = program.getTypeChecker();
+    const f = ctx.factory;
 
+    const typeChecker = program?.getTypeChecker();
+    if (pluginOptions.advancedTypeIntrospection && !typeChecker) {
+      throw new Error(
+        'Type checker is not available while {advancedTypeIntrospection: true}. ' +
+        'Probably you running you typescript compilation in transpileOnly mode ' +
+        'or with isolatedModules in ts-jest'
+      )
+    }
+
+    // ctx.
     const visitNode = (node: ts.Node): ts.Node => {
-      if (ts.isClassDeclaration(node)) {
-        this.clearMetadataOnRestart(node);
-
-        node = ts.visitEachChild(node, visitNode, ctx);
-        return this.addMetadataFactory(node as ts.ClassDeclaration);
-      } else if (ts.isPropertyDeclaration(node)) {
-        const decorators = node.decorators;
-        const hideField = getDecoratorOrUndefinedByNames(
-          [HideField.name],
-          decorators,
-        );
-        if (hideField) {
-          return node;
-        }
-        const isPropertyStatic = (node.modifiers || []).some(
-          (modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword,
-        );
-        if (isPropertyStatic) {
-          return node;
-        }
-        try {
-          this.inspectPropertyDeclaration(
-            node,
-            typeChecker,
-            sourceFile.fileName,
-            sourceFile,
-            pluginOptions,
-          );
-        } catch (err) {
-          return node;
-        }
-        return node;
-      } else if (ts.isSourceFile(node)) {
-        const visitedNode = ts.visitEachChild(node, visitNode, ctx);
-        const importsToAdd = importsToAddPerFile.get(node.fileName);
-        if (!importsToAdd) {
-          return visitedNode;
-        }
-        return this.updateImports(visitedNode, Array.from(importsToAdd));
+      // todo: here should be all types of decorators, or ask maintainers why it wasn't in original code
+      if (ts.isClassDeclaration(node) && hasDecorators(node.decorators, [ObjectType.name])) {
+        const propertiesMetadata = this.collectMetadataFromClassMembers(node.members, pluginOptions, typeChecker);
+        return this.addMetadataFactory(node, propertiesMetadata, f);
       }
+
       return ts.visitEachChild(node, visitNode, ctx);
     };
+
     return ts.visitNode(sourceFile, visitNode);
   }
 
-  clearMetadataOnRestart(node: ts.ClassDeclaration) {
-    const classMetadata = this.getClassMetadata(node);
-    if (classMetadata) {
-      metadataHostMap.delete(node.name.getText());
-    }
-  }
+  private addMetadataFactory(node: ts.ClassDeclaration, propertiesMetadata: MetadataDef[], f: ts.NodeFactory) {
+    const factoryProperties = propertiesMetadata.map((metadata) => {
+      return f.createPropertyAssignment(
+        metadata.propertyName,
+        f.createObjectLiteralExpression([
+          createTypePropertyAssignment(f, metadata.type),
+          createScalarPropertyAssigment(f, 'nullable', metadata.nullable),
+          createScalarPropertyAssigment(f, 'description', metadata.description),
+          createScalarPropertyAssigment(f, 'deprecationReason', metadata.deprecated === true ? 'deprecated' : metadata.deprecated),
+        ]));
+    });
 
-  addMetadataFactory(node: ts.ClassDeclaration) {
-    const classMutableNode = ts.getMutableClone(node);
-    const classMetadata = this.getClassMetadata(node as ts.ClassDeclaration);
-    const returnValue = classMetadata
-      ? ts.createObjectLiteral(
-          Object.keys(classMetadata).map((key) =>
-            ts.createPropertyAssignment(
-              ts.createIdentifier(key),
-              classMetadata[key],
-            ),
-          ),
-        )
-      : ts.createObjectLiteral([], false);
+    const returnValue = f.createObjectLiteralExpression(factoryProperties, true);
 
-    const method = ts.createMethod(
+    const method = f.createMethodDeclaration(
       undefined,
-      [ts.createModifier(ts.SyntaxKind.StaticKeyword)],
+      [f.createModifier(ts.SyntaxKind.StaticKeyword)],
       undefined,
-      ts.createIdentifier(METADATA_FACTORY_NAME),
+      f.createIdentifier(METADATA_FACTORY_NAME),
       undefined,
       undefined,
       [],
       undefined,
-      ts.createBlock([ts.createReturn(returnValue)], true),
+      f.createBlock([f.createReturnStatement(returnValue)], true),
     );
-    (classMutableNode as any).members = ts.createNodeArray([
-      ...(classMutableNode as ts.ClassDeclaration).members,
+
+    return f.updateClassDeclaration(node, node.decorators, node.modifiers, node.name, node.typeParameters, node.heritageClauses, [
+      ...node.members,
       method,
     ]);
-    return classMutableNode;
   }
 
-  inspectPropertyDeclaration(
-    compilerNode: ts.PropertyDeclaration,
-    typeChecker: ts.TypeChecker,
-    hostFilename: string,
-    sourceFile: ts.SourceFile,
+  private collectMetadataFromClassMembers(
+    members: ts.NodeArray<ts.ClassElement>,
     pluginOptions: PluginOptions,
-  ) {
-    const objectLiteralExpr = this.createDecoratorObjectLiteralExpr(
-      compilerNode,
-      typeChecker,
-      ts.createNodeArray(),
-      hostFilename,
-      sourceFile,
-      pluginOptions,
-    );
-    this.addClassMetadata(compilerNode, objectLiteralExpr, sourceFile);
-  }
+    typeChecker: ts.TypeChecker | undefined,
+  ): MetadataDef[] {
+    const propertiesMetadata: MetadataDef[] = [];
 
-  createDecoratorObjectLiteralExpr(
-    node: ts.PropertyDeclaration | ts.PropertySignature,
-    typeChecker: ts.TypeChecker,
-    existingProperties: ts.NodeArray<ts.PropertyAssignment> = ts.createNodeArray(),
-    hostFilename = '',
-    sourceFile?: ts.SourceFile,
-    pluginOptions?: PluginOptions,
-  ): ts.ObjectLiteralExpression {
-    const type = typeChecker.getTypeAtLocation(node);
-    const isNullable = !!node.questionToken || isNull(type) || isUndefined(type);
+    members.forEach((member) => {
+      if (
+        ts.isPropertyDeclaration(member)
+        && !hasModifiers(member.modifiers, [SyntaxKind.StaticKeyword, SyntaxKind.PrivateKeyword])
+        && !hasDecorators(member.decorators, [HideField.name])
+      ) {
+        // todo merge with existing annotations, what is the "existing declaration" ? Where they can be set?
 
-    const properties = [
-      ...existingProperties,
-      !hasPropertyKey('nullable', existingProperties) && isNullable &&
-        ts.createPropertyAssignment('nullable', ts.createLiteral(isNullable)),
-      this.createTypePropertyAssignment(
-        node.type,
-        typeChecker,
-        existingProperties,
-        hostFilename,
-        sourceFile,
-        pluginOptions,
-      ),
-      this.createDescriptionPropertyAssigment(
-        node,
-        existingProperties,
-        pluginOptions,
-        sourceFile,
-      ),
-    ];
-    const objectLiteral = ts.createObjectLiteral(compact(flatten(properties)));
-    return objectLiteral;
-  }
+        const metadataTypeDef = typeChecker
+          ? getMemberTypeFromTypeChecker(member, typeChecker)
+          : getMemberTypeFromAst(member.type);
 
-  createTypePropertyAssignment(
-    node: ts.TypeNode,
-    typeChecker: ts.TypeChecker,
-    existingProperties: ts.NodeArray<ts.PropertyAssignment>,
-    hostFilename: string,
-    sourceFile?: ts.SourceFile,
-    pluginOptions?: PluginOptions
-  ): ts.PropertyAssignment {
-    const key = 'type';
-    if (hasPropertyKey(key, existingProperties)) {
-      return undefined;
-    }
+        let description: string;
+        let deprecated: string | boolean;
 
-    if (node) {
-      if (ts.isTypeLiteralNode(node)) {
-        const propertyAssignments = Array.from(node.members || []).map(
-          (member) => {
-            const literalExpr = this.createDecoratorObjectLiteralExpr(
-              member as ts.PropertySignature,
-              typeChecker,
-              existingProperties,
-              hostFilename,
-              sourceFile,
-              pluginOptions,
-            );
-            return ts.createPropertyAssignment(
-              ts.createIdentifier(member.name.getText()),
-              literalExpr,
-            );
-          },
-        );
-        return ts.createPropertyAssignment(
-          key,
-          ts.createArrowFunction(
-            undefined,
-            undefined,
-            [],
-            undefined,
-            undefined,
-            ts.createParen(ts.createObjectLiteral(propertyAssignments)),
-          ),
-        );
-      } else if (ts.isUnionTypeNode(node)) {
-        const nullableType = findNullableTypeFromUnion(node, typeChecker);
-        const remainingTypes = node.types.filter(
-          (item) => item !== nullableType
-        );
-
-        if (remainingTypes.length === 1) {
-          return this.createTypePropertyAssignment(
-            remainingTypes[0],
-            typeChecker,
-            existingProperties,
-            hostFilename,
-          );
+        if (pluginOptions.introspectComments) {
+          description = getJSDocDescription(member);
+          deprecated = getJsDocDeprecation(member);
         }
+
+        const metadataDef: MetadataDef = {
+          propertyName: (member.name as Identifier).getText(),
+          type: metadataTypeDef,
+          nullable: member.questionToken ? true : undefined,
+          description,
+          deprecated,
+        };
+
+        propertiesMetadata.push(metadataDef);
       }
-    }
-
-    const type = typeChecker.getTypeAtLocation(node);
-    if (!type) {
-      return undefined;
-    }
-    
-    let typeReference = getTypeReferenceAsString(type, typeChecker);
-    if (!typeReference) {
-      return undefined;
-    }
-    typeReference = replaceImportPath(typeReference, hostFilename);
-    if (typeReference && typeReference.includes('require')) {
-      // add top-level import to eagarly load class metadata
-      const importPath = /\(\"([^)]).+(\")/.exec(typeReference)[0];
-      if (importPath) {
-        let importsToAdd = importsToAddPerFile.get(hostFilename);
-        if (!importsToAdd) {
-          importsToAdd = new Set();
-          importsToAddPerFile.set(hostFilename, importsToAdd);
-        }
-        importsToAdd.add(importPath.slice(2, importPath.length - 1));
-      }
-    }
-
-    return ts.createPropertyAssignment(
-      key,
-      ts.createArrowFunction(
-        undefined,
-        undefined,
-        [],
-        undefined,
-        undefined,
-        ts.createIdentifier(typeReference),
-      ),
-    );
-  }
-
-  addClassMetadata(
-    node: ts.PropertyDeclaration,
-    objectLiteral: ts.ObjectLiteralExpression,
-    sourceFile: ts.SourceFile,
-  ) {
-    const hostClass = node.parent;
-    const className = hostClass.name && hostClass.name.getText();
-    if (!className) {
-      return;
-    }
-    const existingMetadata = metadataHostMap.get(className) || {};
-    const propertyName = node.name && node.name.getText(sourceFile);
-    if (
-      !propertyName ||
-      (node.name && node.name.kind === ts.SyntaxKind.ComputedPropertyName)
-    ) {
-      return;
-    }
-    metadataHostMap.set(className, {
-      ...existingMetadata,
-      [propertyName]: objectLiteral,
     });
-  }
 
-  getClassMetadata(node: ts.ClassDeclaration) {
-    if (!node.name) {
-      return;
-    }
-    return metadataHostMap.get(node.name.getText());
-  }
-
-  updateImports(
-    sourceFile: ts.SourceFile,
-    pathsToImport: string[],
-  ): ts.SourceFile {
-    const [major, minor] = ts.versionMajorMinor?.split('.').map((x) => +x);
-    const IMPORT_PREFIX = 'eager_import_';
-    const importDeclarations = pathsToImport.map((path, index) => {
-      if (major == 4 && minor >= 2) {
-        // support TS v4.2+
-        return (ts.createImportEqualsDeclaration as any)(
-          undefined,
-          undefined,
-          false,
-          IMPORT_PREFIX + index,
-          ts.createExternalModuleReference(ts.createLiteral(path)),
-        );
-      }
-      return (ts.createImportEqualsDeclaration as any)(
-        undefined,
-        undefined,
-        IMPORT_PREFIX + index,
-        ts.createExternalModuleReference(ts.createLiteral(path)),
-      );
-    });
-    return ts.updateSourceFileNode(sourceFile, [
-      ...importDeclarations,
-      ...sourceFile.statements,
-    ]);
-  }
-
-  createDescriptionPropertyAssigment(
-    node: ts.PropertyDeclaration | ts.PropertySignature,
-    existingProperties: ts.NodeArray<ts.PropertyAssignment> = ts.createNodeArray(),
-    options: PluginOptions = {},
-    sourceFile?: ts.SourceFile,
-  ): ts.PropertyAssignment {
-    if (!options.introspectComments || !sourceFile) {
-      return;
-    }
-    const description = getDescriptionOfNode(node, sourceFile);
-
-    const keyOfComment = 'description';
-    if (!hasPropertyKey(keyOfComment, existingProperties) && description) {
-      const descriptionPropertyAssignment = ts.createPropertyAssignment(
-        keyOfComment,
-        ts.createLiteral(description),
-      );
-      return descriptionPropertyAssignment;
-    }
+    return propertiesMetadata;
   }
 }

--- a/tests/jest-e2e.json
+++ b/tests/jest-e2e.json
@@ -5,5 +5,10 @@
   "testRegex": ".spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "globals": {
+    "ts-jest": {
+      "tsconfig": "tsconfig.spec.json"
+    }
   }
 }

--- a/tests/plugin/__snapshots__/model-class-visitor.spec.ts.snap
+++ b/tests/plugin/__snapshots__/model-class-visitor.spec.ts.snap
@@ -1,0 +1,143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API model properties should add partial metadata factory when some decorators exist 1`] = `
+"var Status;
+(function (Status) {
+    Status[Status[\\"ENABLED\\"] = 0] = \\"ENABLED\\";
+    Status[Status[\\"DISABLED\\"] = 1] = \\"DISABLED\\";
+})(Status || (Status = {}));
+let CreateCatDto2 = class CreateCatDto2 {
+    constructor() {
+        this.age = 3;
+        this.status = Status.ENABLED;
+    }
+    static _GRAPHQL_METADATA_FACTORY() {
+        return {
+            name: { type: () => String, description: \\"name description\\" },
+            age: { type: () => Number, description: \\"test on age\\" },
+            tags: { type: () => [String] },
+            status: { type: () => Status },
+            breed: { type: () => String, nullable: true },
+            nodes: { type: () => [Object] },
+            alias: { type: () => Object },
+            numberAlias: { type: () => Number },
+            union: { type: () => Object },
+            intersection: { type: () => Object },
+            optionalBoolean: { type: () => Boolean, nullable: true },
+            nested: { type: () => Object },
+            prop: { type: () => Object },
+            tuple: { type: () => Object }
+        };
+    }
+};
+CreateCatDto2 = __decorate([
+    ObjectType()
+], CreateCatDto2);
+export { CreateCatDto2 };
+"
+`;
+
+exports[`API model properties should add the metadata factory when no decorators exist 1`] = `
+"var Status;
+(function (Status) {
+    Status[Status[\\"ENABLED\\"] = 0] = \\"ENABLED\\";
+    Status[Status[\\"DISABLED\\"] = 1] = \\"DISABLED\\";
+})(Status || (Status = {}));
+var OneValueEnum;
+(function (OneValueEnum) {
+    OneValueEnum[OneValueEnum[\\"ONE\\"] = 0] = \\"ONE\\";
+})(OneValueEnum || (OneValueEnum = {}));
+let CreateCatDto = class CreateCatDto {
+    constructor() {
+        this.age = 3;
+        this.status = Status.ENABLED;
+    }
+    static _GRAPHQL_METADATA_FACTORY() {
+        return {
+            name: { type: () => String, description: \\"description\\" },
+            age: { type: () => Number },
+            tags: { type: () => [String] },
+            status: { type: () => Status },
+            status2: { type: () => Status, nullable: true },
+            statusArr: { type: () => [Status], nullable: true },
+            breed: { type: () => String, nullable: true },
+            nodes: { type: () => [Object] },
+            date: { type: () => Date },
+            booleanProp: { type: () => Boolean },
+            stringUnion: { type: () => Object },
+            deprecatedField: { type: () => String, description: \\"Testing deprecated tag parsing\\", deprecationReason: \\"this message should go to decorator factory\\" }
+        };
+    }
+};
+__decorate([
+    HideField()
+], CreateCatDto.prototype, \\"hidden\\", void 0);
+__decorate([
+    ResolveField((type) => Float)
+], CreateCatDto, \\"explicitDecorated\\", void 0);
+CreateCatDto = __decorate([
+    ObjectType()
+], CreateCatDto);
+export { CreateCatDto };
+"
+`;
+
+exports[`API model properties should manage imports statements when code "downleveled" 1`] = `
+"\\"use strict\\";
+Object.defineProperty(exports, \\"__esModule\\", { value: true });
+exports.CreateCatDtoEs5 = void 0;
+var status_1 = require(\\"./status\\");
+var constants_1 = require(\\"./constants\\");
+var CreateCatDtoEs5 = /** @class */ (function () {
+    function CreateCatDtoEs5() {
+        this.name = constants_1.CONSTANT_STRING;
+        this.status = status_1.ImportedStatus.ENABLED;
+        this.obj = constants_1.CONSTANT_OBJECT;
+    }
+    CreateCatDtoEs5._GRAPHQL_METADATA_FACTORY = function () {
+        return {
+            name: { type: function () { return String; } },
+            status: { type: function () { return Object; } },
+            obj: { type: function () { return Object; } }
+        };
+    };
+    CreateCatDtoEs5 = __decorate([
+        ObjectType()
+    ], CreateCatDtoEs5);
+    return CreateCatDtoEs5;
+}());
+exports.CreateCatDtoEs5 = CreateCatDtoEs5;
+"
+`;
+
+exports[`API model properties should support & understand nullable type unions 1`] = `
+"var Status;
+(function (Status) {
+    Status[Status[\\"ENABLED\\"] = 0] = \\"ENABLED\\";
+    Status[Status[\\"DISABLED\\"] = 1] = \\"DISABLED\\";
+})(Status || (Status = {}));
+let NullableDto = class NullableDto {
+    constructor() {
+        this.age = 3;
+        this.status = Status.ENABLED;
+    }
+    static _GRAPHQL_METADATA_FACTORY() {
+        return {
+            name: { type: () => Object },
+            age: { type: () => Number },
+            tags: { type: () => [String] },
+            status: { type: () => Status },
+            status2: { type: () => Object, nullable: true },
+            statusArr: { type: () => [Status], nullable: true },
+            breed: { type: () => String, nullable: true },
+            nodes: { type: () => [Object] },
+            date: { type: () => Date }
+        };
+    }
+};
+NullableDto = __decorate([
+    ObjectType()
+], NullableDto);
+export { NullableDto };
+"
+`;

--- a/tests/plugin/fixtures/create-cat-alt.dto.ts
+++ b/tests/plugin/fixtures/create-cat-alt.dto.ts
@@ -13,6 +13,7 @@ type AliasedType = {
 };
 type NumberAlias = number;
 
+@ObjectType()
 export class CreateCatDto2 {
   /**
   * name description

--- a/tests/plugin/fixtures/create-cat.dto.ts
+++ b/tests/plugin/fixtures/create-cat.dto.ts
@@ -12,7 +12,11 @@ interface Node {
     id: number;
 }
 
+@ObjectType()
 export class CreateCatDto {
+/**
+* description
+*/
   name: string;
   age: number = 3;
   tags: string[];
@@ -22,11 +26,25 @@ export class CreateCatDto {
   readonly breed?: string;
   nodes: Node[];
   date: Date;
+  
+  booleanProp: boolean;
+  stringUnion: 'foo' | 'bar' | 'baz';
 
   @HideField()
   hidden: number;
 
+  @ResolveField((type) => Float)
+  static explicitDecorated: number;
+
+  private privateField: string;
   static staticProperty: string;
+  
+ 
+  /**
+    * Testing deprecated tag parsing
+    * @deprecated this message should go to decorator factory
+    */
+  deprecatedField: string;
 }
 `;
 

--- a/tests/plugin/fixtures/es5-class.dto.ts
+++ b/tests/plugin/fixtures/es5-class.dto.ts
@@ -1,10 +1,11 @@
 export const es5CreateCatDtoText = `
-import { Status } from './status';
+import { ImportedStatus } from './status';
 import { CONSTANT_STRING, CONSTANT_OBJECT } from './constants';
 
+@ObjectType()
 export class CreateCatDtoEs5 {
   name: string = CONSTANT_STRING;
-  status: Status = Status.ENABLED;
+  status = ImportedStatus.ENABLED;
   obj = CONSTANT_OBJECT;
 }
 `;

--- a/tests/plugin/fixtures/nullable.dto.ts
+++ b/tests/plugin/fixtures/nullable.dto.ts
@@ -4,6 +4,7 @@ enum Status {
     DISABLED
 }
 
+@ObjectType()
 export class NullableDto {
   name: string | null;
   age: number = 3;

--- a/tests/plugin/model-class-visitor.spec.ts
+++ b/tests/plugin/model-class-visitor.spec.ts
@@ -16,97 +16,323 @@ import {
   nullableDtoText,
   nullableDtoTextTranspiled,
 } from './fixtures/nullable.dto';
+import { PluginOptions } from '../../lib/plugin/merge-options';
+
+const defaultCompilerOptions: ts.CompilerOptions = {
+  module: ts.ModuleKind.ES2020,
+  target: ts.ScriptTarget.ES2020,
+  newLine: ts.NewLineKind.LineFeed,
+  noEmitHelpers: true,
+  strict: true,
+};
+
+function transpile(
+  source: string,
+  pluginOptions: PluginOptions,
+  compilerOptions = defaultCompilerOptions,
+): string {
+  const filename = 'create-cat.input.ts';
+  const fakeProgram = ts.createProgram([filename], compilerOptions);
+
+  const result = ts.transpileModule(source, {
+    compilerOptions: compilerOptions,
+    fileName: 'test.input.ts',
+    transformers: {
+      before: [before(pluginOptions, fakeProgram)],
+    },
+  });
+
+  return result.outputText;
+}
 
 describe('API model properties', () => {
   it('should add the metadata factory when no decorators exist', () => {
-    const options: ts.CompilerOptions = {
-      module: ts.ModuleKind.ES2020,
-      target: ts.ScriptTarget.ES2020,
-      newLine: ts.NewLineKind.LineFeed,
-      noEmitHelpers: true,
-      strict: true,
-    };
-    const filename = 'create-cat.input.ts';
-    const fakeProgram = ts.createProgram([filename], options);
-
-    const result = ts.transpileModule(createCatDtoText, {
-      compilerOptions: options,
-      fileName: filename,
-      transformers: {
-        before: [before({}, fakeProgram)],
-      },
-    });
-    expect(result.outputText).toEqual(createCatDtoTextTranspiled);
+    const actual = transpile(createCatDtoText, { introspectComments: true });
+    expect(actual).toMatchSnapshot();
   });
 
   it('should add partial metadata factory when some decorators exist', () => {
     const options: ts.CompilerOptions = {
-      module: ts.ModuleKind.ES2020,
-      target: ts.ScriptTarget.ES2020,
-      newLine: ts.NewLineKind.LineFeed,
-      noEmitHelpers: true,
-      strict: true,
+      ...defaultCompilerOptions,
       removeComments: true,
     };
-    const filename = 'create-cat.input.ts';
-    const fakeProgram = ts.createProgram([filename], options);
 
-    const result = ts.transpileModule(createCatDtoAltText, {
-      compilerOptions: options,
-      fileName: filename,
-      transformers: {
-        before: [
-          before(
-            {
-              introspectComments: true,
-            },
-            fakeProgram,
-          ),
-        ],
+    const actual = transpile(
+      createCatDtoAltText,
+      {
+        introspectComments: true,
       },
-    });
-    expect(result.outputText).toEqual(createCatDtoTextAltTranspiled);
+      options,
+    );
+
+    expect(actual).toMatchSnapshot();
   });
 
   it('should manage imports statements when code "downleveled"', () => {
     const options: ts.CompilerOptions = {
+      ...defaultCompilerOptions,
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES5,
-      newLine: ts.NewLineKind.LineFeed,
-      noEmitHelpers: true,
-      strict: true,
     };
-    const filename = 'es5-class.input.ts';
-    const fakeProgram = ts.createProgram([filename], options);
 
-    const result = ts.transpileModule(es5CreateCatDtoText, {
-      compilerOptions: options,
-      fileName: filename,
-      transformers: {
-        before: [before({}, fakeProgram)],
-      },
-    });
-    expect(result.outputText).toEqual(es5CreateCatDtoTextTranspiled);
+    const actual = transpile(es5CreateCatDtoText, {}, options);
+    expect(actual).toMatchSnapshot();
   });
 
   it('should support & understand nullable type unions', () => {
-    const options: ts.CompilerOptions = {
-      module: ts.ModuleKind.ES2020,
-      target: ts.ScriptTarget.ES2020,
-      newLine: ts.NewLineKind.LineFeed,
-      noEmitHelpers: true,
-      strict: true,
-    };
-    const filename = 'nullable.input.ts';
-    const fakeProgram = ts.createProgram([filename], options);
-
-    const result = ts.transpileModule(nullableDtoText, {
-      compilerOptions: options,
-      fileName: filename,
-      transformers: {
-        before: [before({}, fakeProgram)],
-      },
-    });
-    expect(result.outputText).toEqual(nullableDtoTextTranspiled);
+    const actual = transpile(nullableDtoText, {});
+    expect(actual).toMatchSnapshot();
   });
+
+  describe('JsDoc Introspection', () => {
+    it('Should parse jsDoc set right before property', () => {
+      const source = `
+@ObjectType()
+export class TestModel {
+  /**
+  * description
+  */
+  name: string;
+}
+      `;
+      const actual = transpile(source, { introspectComments: true });
+
+      expect(actual).toMatchInlineSnapshot(`
+        "let TestModel = class TestModel {
+            static _GRAPHQL_METADATA_FACTORY() {
+                return {
+                    name: { type: () => String, description: \\"description\\" }
+                };
+            }
+        };
+        TestModel = __decorate([
+            ObjectType()
+        ], TestModel);
+        export { TestModel };
+        "
+      `);
+    });
+
+    it('Should parse jsDoc when decorator set on member', async () => {
+      const source = `
+@ObjectType()
+export class TestModel {
+  /**
+  * description
+  */
+  @ResolveField(() => Type)
+  name: string;
+}
+`;
+      const actual = transpile(source, { introspectComments: true });
+
+      expect(actual).toMatchInlineSnapshot(`
+        "let TestModel = class TestModel {
+            static _GRAPHQL_METADATA_FACTORY() {
+                return {
+                    name: { type: () => String, description: \\"description\\" }
+                };
+            }
+        };
+        __decorate([
+            ResolveField(() => Type)
+        ], TestModel.prototype, \\"name\\", void 0);
+        TestModel = __decorate([
+            ObjectType()
+        ], TestModel);
+        export { TestModel };
+        "
+      `);
+    });
+
+    it('Should get deprecation reason from @deprecated tag', () => {
+      const source = `
+@ObjectType()
+export class TestModel {
+  /**
+  * description
+  * @deprecated our fancy deprecation message
+  */
+  @ResolveField(() => Type)
+  name: string;
+}
+`;
+      const actual = transpile(source, { introspectComments: true });
+
+      expect(actual).toMatchInlineSnapshot(`
+        "let TestModel = class TestModel {
+            static _GRAPHQL_METADATA_FACTORY() {
+                return {
+                    name: { type: () => String, description: \\"description\\", deprecationReason: \\"our fancy deprecation message\\" }
+                };
+            }
+        };
+        __decorate([
+            ResolveField(() => Type)
+        ], TestModel.prototype, \\"name\\", void 0);
+        TestModel = __decorate([
+            ObjectType()
+        ], TestModel);
+        export { TestModel };
+        "
+      `);
+    });
+
+    it('Should respect empty @deprecated tag', () => {
+      const source = `
+@ObjectType()
+export class TestModel {
+  /**
+  * description
+  * @deprecated
+  */
+  @ResolveField(() => Type)
+  name: string;
+}
+`;
+      const actual = transpile(source, { introspectComments: true });
+
+      expect(actual).toMatchInlineSnapshot(`
+        "let TestModel = class TestModel {
+            static _GRAPHQL_METADATA_FACTORY() {
+                return {
+                    name: { type: () => String, description: \\"description\\", deprecationReason: \\"deprecated\\" }
+                };
+            }
+        };
+        __decorate([
+            ResolveField(() => Type)
+        ], TestModel.prototype, \\"name\\", void 0);
+        TestModel = __decorate([
+            ObjectType()
+        ], TestModel);
+        export { TestModel };
+        "
+      `);
+    });
+
+    it('should not parse jsDoc when introspectComments = false', () => {
+      const source = `
+@ObjectType()
+export class TestModel {
+  /**
+  * description
+  * @deprecated
+  */
+  @ResolveField(() => Type)
+  name: string;
+}
+`;
+      const actual = transpile(source, { introspectComments: false });
+
+      expect(actual).toMatchInlineSnapshot(`
+        "let TestModel = class TestModel {
+            static _GRAPHQL_METADATA_FACTORY() {
+                return {
+                    name: { type: () => String }
+                };
+            }
+        };
+        __decorate([
+            ResolveField(() => Type)
+        ], TestModel.prototype, \\"name\\", void 0);
+        TestModel = __decorate([
+            ObjectType()
+        ], TestModel);
+        export { TestModel };
+        "
+      `);
+    });
+  });
+
+
+  describe('TypeChecker', () => {
+    it('Should resolve aliased type', () => {
+      const source = `
+      
+type NumberAlias = number;
+type Foo = {bar: 1};
+
+@ObjectType()
+export class TestModel {
+  // prop: NumberAlias;
+  prop2: number[];
+  prop2: Foo[];
+}
+`;
+      const actual = transpile(source, { introspectComments: true });
+
+      console.log(actual);
+      expect(true).toBeTruthy();
+    });
+
+    it('Should resolve optional array enum types in strict mode', () => {
+      const source = `
+enum Status {
+  ENABLED,
+  DISABLED
+}
+
+@ObjectType()
+export class TestModel {
+  statusArr?: Status[];
+}
+`;
+      const actual = transpile(source, { introspectComments: true });
+
+      console.log(actual);
+      expect(true).toBeTruthy();
+    });
+  });
+
+  it('Should properly pick parent enum type (not a property) when prop optional in strict mode', () => {
+    const source = `
+enum Status {
+  ENABLED,
+  DISABLED
+}
+
+@ObjectType()
+export class TestModel {
+  status2?: Status;
+}
+`;
+    const actual = transpile(source, { introspectComments: true });
+
+    expect(actual).toMatchInlineSnapshot(`
+"var Status;
+(function (Status) {
+    Status[Status[\\"ENABLED\\"] = 0] = \\"ENABLED\\";
+    Status[Status[\\"DISABLED\\"] = 1] = \\"DISABLED\\";
+})(Status || (Status = {}));
+let TestModel = class TestModel {
+    static _GRAPHQL_METADATA_FACTORY() {
+        return {
+            status2: { type: () => Status, nullable: true }
+        };
+    }
+};
+TestModel = __decorate([
+    ObjectType()
+], TestModel);
+export { TestModel };
+"
+`);
+  });
+
+  describe('Special virtual types for GraphQL', () => {
+    // todo ID / Float / Int
+  });
+
+
 });
+
+// todo:
+// repeat test cases for non-type checker implementation
+// - separate test-cases for complicated cases:
+//   - unions eq 'foo' | 'bar' and string | undefined
+//   - promise / observable / Partial
+
+// should throw error when no type checker passed but advancedTypeIntrospection: true
+// should work without typeChecker and Program when advancedTypeIntrospection: false
+// should skip files with name not matching pattern

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true,
+  },
+  "include": [],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:https://github.com/nestjs/graphql/issues/1346

## What is the new behavior?
This PR brings changes in how current ts transform plugin is working. 

To Do:
- [x] Option to work in isolatedModules (no typeChecker available)
- [x] Introspection for `@deprecated` jsdoc tag
- [ ] Support for GraphQL scalar types: Int, Float, ID (please refer to the issue https://github.com/nestjs/graphql/issues/1346 i rised a discussion there)
- [ ] Support more complicated cases in no-typechecker mode.
- [ ] More tests covering edge cases in no-typechecker mode. 

## What was changed internally: 
1. JSDoc Comments now parsed using Typescript AST (built-it typescript support) instead of regular expressions 
2. Removed code related to imports and merging existing factories (please see linked issue)
3.  Test rewritten, Jest Snapshots used

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
There is a defenetely changes which can impact users. 
TODO: eliminate them or at least find and clearly state what can go wrong. 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information