### PR TITLE
fix(graphql): update formatting of http errors to graphql

### DIFF
--- a/lib/utils/merge-defaults.util.ts
+++ b/lib/utils/merge-defaults.util.ts
@@ -128,10 +128,16 @@ function createTransformHttpErrorFn() {
   return (originalError: any): GraphQLFormattedError => {
     const exceptionRef = originalError?.extensions?.exception;
     const isHttpException =
-      exceptionRef?.response?.statusCode && exceptionRef?.status;
-
+      exceptionRef?.response?.statusCode || exceptionRef?.status;
     if (!isHttpException) {
       return originalError as GraphQLFormattedError;
+    }
+    if (
+      exceptionRef?.response &&
+      !exceptionRef?.response?.statusCode &&
+      exceptionRef?.status
+    ) {
+      exceptionRef.response.statusCode = exceptionRef?.status;
     }
     let error: ApolloError;
 

--- a/lib/utils/merge-defaults.util.ts
+++ b/lib/utils/merge-defaults.util.ts
@@ -127,17 +127,17 @@ function wrapFormatErrorFn(options: GqlModuleOptions) {
 function createTransformHttpErrorFn() {
   return (originalError: any): GraphQLFormattedError => {
     const exceptionRef = originalError?.extensions?.exception;
-    const isHttpException =
-      exceptionRef?.response?.statusCode || exceptionRef?.status;
-    if (!isHttpException) {
-      return originalError as GraphQLFormattedError;
-    }
     if (
       exceptionRef?.response &&
       !exceptionRef?.response?.statusCode &&
       exceptionRef?.status
     ) {
       exceptionRef.response.statusCode = exceptionRef?.status;
+    }
+    const isHttpException =
+      exceptionRef?.response?.statusCode && exceptionRef?.status;
+    if (!isHttpException) {
+      return originalError as GraphQLFormattedError;
     }
     let error: ApolloError;
 

--- a/tests/code-first/recipes/recipes.service.ts
+++ b/tests/code-first/recipes/recipes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { NewRecipeInput } from './dto/new-recipe.input';
 import { RecipesArgs } from './dto/recipes.args';
 import { Recipe } from './models/recipe';
@@ -12,6 +12,12 @@ export class RecipesService {
    */
 
   async create(data: NewRecipeInput): Promise<Recipe> {
+    if (data.title === 'unallowed-title') {
+      throw new BadRequestException({
+        message: 'Unallowed title',
+        mutation: 'addRecipe',
+      });
+    }
     return {
       id: 3,
       ...data,

--- a/tests/e2e/error-format.spec.ts
+++ b/tests/e2e/error-format.spec.ts
@@ -1,0 +1,51 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { ApplicationModule } from '../code-first/app.module';
+
+describe('GraphQL - Error format', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+  });
+
+  it(`should throw an error`, () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        operationName: null,
+        variables: {},
+        query:
+          'mutation {\n  addRecipe(newRecipeData: {title: "unallowed-title", ' +
+          'description:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ' +
+          'ingredients: []}) {\n    id\n  }\n}\n',
+      })
+      .expect(200, {
+        data: null,
+        errors: [
+          {
+            extensions: {
+              code: 'BAD_USER_INPUT',
+              response: {
+                message: 'Unallowed title',
+                mutation: 'addRecipe',
+                statusCode: 400,
+              },
+            },
+            message: 'Unallowed title',
+          },
+        ],
+      });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
update formatting of nest js http errors, that accept message as object to graphql

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using graphql application and throwing errors with object as a message, Internal_Server_Error will be result in any type of error.
`throw new BadRequestException({message:'Some', payload:'Some'})`
results to ApolloServer InternalServerException, but `throw new BadRequestException('Some')` results to USER_BAD_INPUT


Issue Number: N/A


## What is the new behavior?
When using graphql application and throwing errors with object as a message, correctly mapped error type will be returned. `throw new BadRequestException({message:'Some', payload:'Some'})`
results to USER_BAD_INPUT and `throw new BadRequestException('Some')` results to USER_BAD_INPUT

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information