### PR TITLE
feat(code-first): Use capitalized case for enums in code-first

### DIFF
--- a/packages/apollo/tests/code-first/app.module.ts
+++ b/packages/apollo/tests/code-first/app.module.ts
@@ -11,7 +11,8 @@ import { RecipesModule } from './recipes/recipes.module';
     RecipesModule,
     DirectionsModule,
     CatsModule,
-    GraphQLModule.forRoot({
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
       debug: false,
       installSubscriptionHandlers: true,
       autoSchemaFile: true,

--- a/packages/apollo/tests/code-first/app.module.ts
+++ b/packages/apollo/tests/code-first/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriverConfig } from '../../lib';
 import { ApolloDriver } from '../../lib/drivers';
+import { CatsModule } from './cats/cats.module';
 import { DirectionsModule } from './directions/directions.module';
 import { RecipesModule } from './recipes/recipes.module';
 
@@ -9,8 +10,8 @@ import { RecipesModule } from './recipes/recipes.module';
   imports: [
     RecipesModule,
     DirectionsModule,
-    GraphQLModule.forRoot<ApolloDriverConfig>({
-      driver: ApolloDriver,
+    CatsModule,
+    GraphQLModule.forRoot({
       debug: false,
       installSubscriptionHandlers: true,
       autoSchemaFile: true,

--- a/packages/apollo/tests/code-first/cats/cats.resolver.ts
+++ b/packages/apollo/tests/code-first/cats/cats.resolver.ts
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 import { Query, Resolver, Args } from '@nestjs/graphql';
+=======
+import { Args, Query, Resolver } from '@nestjs/graphql';
+>>>>>>> 7624329 (chore(code-first): update imports to workspace paths)
 import { CatType } from '../enums/cat-type.enum';
 
 @Resolver()

--- a/packages/apollo/tests/code-first/cats/cats.resolver.ts
+++ b/packages/apollo/tests/code-first/cats/cats.resolver.ts
@@ -1,9 +1,19 @@
-import { Query, Resolver } from '@nestjs/graphql';
+import { Query, Resolver, Args } from '@nestjs/graphql';
+import { CatType } from '../enums/cat-type.enum';
 
 @Resolver()
 export class CatsResolver {
   @Query((returns) => String)
   getAnimalName(): string {
     return 'cat';
+  }
+
+  @Resolver()
+  @Query((returns) => CatType)
+  catType(
+    @Args({ name: 'catType', type: () => CatType })
+    catType: CatType,
+  ): CatType {
+    return catType;
   }
 }

--- a/packages/apollo/tests/code-first/cats/cats.resolver.ts
+++ b/packages/apollo/tests/code-first/cats/cats.resolver.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-import { Query, Resolver, Args } from '@nestjs/graphql';
-=======
 import { Args, Query, Resolver } from '@nestjs/graphql';
->>>>>>> 7624329 (chore(code-first): update imports to workspace paths)
 import { CatType } from '../enums/cat-type.enum';
 
 @Resolver()
@@ -12,7 +8,6 @@ export class CatsResolver {
     return 'cat';
   }
 
-  @Resolver()
   @Query((returns) => CatType)
   catType(
     @Args({ name: 'catType', type: () => CatType })

--- a/packages/apollo/tests/code-first/enums/cat-type.enum.ts
+++ b/packages/apollo/tests/code-first/enums/cat-type.enum.ts
@@ -1,5 +1,8 @@
 import { registerEnumType } from '@nestjs/graphql';
+<<<<<<< HEAD
 
+=======
+>>>>>>> 7624329 (chore(code-first): update imports to workspace paths)
 export enum CatType {
   PersianCat = 'persian-cat',
   MaineCoon = 'maine-coon',

--- a/packages/apollo/tests/code-first/enums/cat-type.enum.ts
+++ b/packages/apollo/tests/code-first/enums/cat-type.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum CatType {
+  PersianCat = 'persian-cat',
+  MaineCoon = 'maine-coon',
+  Ragdoll = 'ragdoll',
+}
+
+registerEnumType(CatType, {
+  name: 'CatType',
+  description: 'Distinguish cats',
+  mapToUppercase: true,
+});

--- a/packages/apollo/tests/code-first/enums/cat-type.enum.ts
+++ b/packages/apollo/tests/code-first/enums/cat-type.enum.ts
@@ -1,12 +1,11 @@
 import { registerEnumType } from '@nestjs/graphql';
-<<<<<<< HEAD
 
-=======
->>>>>>> 7624329 (chore(code-first): update imports to workspace paths)
 export enum CatType {
   PersianCat = 'persian-cat',
   MaineCoon = 'maine-coon',
   Ragdoll = 'ragdoll',
+  SomeNewAwesomeCat = 'some-new-awesome-cat',
+  SomeWEIRDCat = 'some-weird-cat',
 }
 
 registerEnumType(CatType, {

--- a/packages/apollo/tests/code-first/enums/cat-type.enum.ts
+++ b/packages/apollo/tests/code-first/enums/cat-type.enum.ts
@@ -6,6 +6,7 @@ export enum CatType {
   Ragdoll = 'ragdoll',
   SomeNewAwesomeCat = 'some-new-awesome-cat',
   SomeWEIRDCat = 'some-weird-cat',
+  anotherAwesomeCat = 'another-awesome-cat',
 }
 
 registerEnumType(CatType, {

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -29,6 +29,7 @@ import {
   getSubscriptionByName,
 } from '../utils/introspection-schema.utils';
 import { printedSchemaSnapshot } from '../utils/printed-schema.snapshot';
+import { CatsResolver } from '../code-first/cats/cats.resolver';
 
 describe('Code-first - schema factory', () => {
   let schemaFactory: GraphQLSchemaFactory;
@@ -50,6 +51,7 @@ describe('Code-first - schema factory', () => {
         [
           RecipesResolver,
           DirectionsResolver,
+          CatsResolver,
           AbstractResolver,
           IRecipesResolver,
         ],
@@ -68,10 +70,10 @@ describe('Code-first - schema factory', () => {
         printedSchemaSnapshot,
       );
     });
-    it('should define 5 queries', async () => {
+    it('should define 6 queries', async () => {
       const type = getQuery(introspectionSchema);
 
-      expect(type.fields.length).toEqual(5);
+      expect(type.fields.length).toEqual(6);
       expect(type.fields.map((item) => item.name)).toEqual(
         expect.arrayContaining([
           'recipes',
@@ -79,6 +81,7 @@ describe('Code-first - schema factory', () => {
           'categories',
           'move',
           'recipe',
+          'catType',
         ]),
       );
     });
@@ -148,6 +151,40 @@ describe('Code-first - schema factory', () => {
               description: null,
               isDeprecated: true,
               name: 'Sideways',
+            },
+          ],
+        }),
+      );
+    });
+
+    it('should define "CatType" enum to use CAPITALIZED_UNDERSCORE', () => {
+      const type = introspectionSchema.types.find(
+        ({ name }) => name === 'CatType',
+      );
+
+      expect(type).toEqual(
+        expect.objectContaining({
+          kind: TypeKind.ENUM,
+          name: 'CatType',
+          description: 'Distinguish cats',
+          enumValues: [
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'PERSIAN_CAT',
+            },
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'MAINE_COON',
+            },
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'RAGDOLL',
             },
           ],
         }),

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -70,10 +70,10 @@ describe('Code-first - schema factory', () => {
         printedSchemaSnapshot,
       );
     });
-    it('should define 6 queries', async () => {
+    it('should define 7 queries', async () => {
       const type = getQuery(introspectionSchema);
 
-      expect(type.fields.length).toEqual(6);
+      expect(type.fields.length).toEqual(7);
       expect(type.fields.map((item) => item.name)).toEqual(
         expect.arrayContaining([
           'recipes',
@@ -185,6 +185,18 @@ describe('Code-first - schema factory', () => {
               description: null,
               isDeprecated: false,
               name: 'RAGDOLL',
+            },
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'SOME_NEW_AWESOME_CAT',
+            },
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'SOME_WEIRD_CAT',
             },
           ],
         }),

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -198,6 +198,12 @@ describe('Code-first - schema factory', () => {
               isDeprecated: false,
               name: 'SOME_WEIRD_CAT',
             },
+            {
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'ANOTHER_AWESOME_CAT',
+            },
           ],
         }),
       );

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -20,6 +20,7 @@ import { SampleOrphanedType } from '../code-first/other/sample-orphaned.type';
 import { IRecipesResolver } from '../code-first/recipes/irecipes.resolver';
 import { Recipe } from '../code-first/recipes/models/recipe';
 import { RecipesResolver } from '../code-first/recipes/recipes.resolver';
+import { CatsResolver } from '../code-first/cats/cats.resolver';
 import {
   getMutation,
   getMutationByName,
@@ -29,7 +30,6 @@ import {
   getSubscriptionByName,
 } from '../utils/introspection-schema.utils';
 import { printedSchemaSnapshot } from '../utils/printed-schema.snapshot';
-import { CatsResolver } from '../code-first/cats/cats.resolver';
 
 describe('Code-first - schema factory', () => {
   let schemaFactory: GraphQLSchemaFactory;

--- a/packages/apollo/tests/graphql/sort-auto-schema.module.ts
+++ b/packages/apollo/tests/graphql/sort-auto-schema.module.ts
@@ -9,7 +9,7 @@ import { CatsModule } from '../code-first/cats/cats.module';
   imports: [
     RecipesModule,
     DirectionsModule,
-    CatsModule,
+    CatsModule.register('useClass'),
     GraphQLModule.forRoot({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.graphql',

--- a/packages/apollo/tests/graphql/sort-auto-schema.module.ts
+++ b/packages/apollo/tests/graphql/sort-auto-schema.module.ts
@@ -3,11 +3,13 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver } from '../../lib/drivers';
 import { DirectionsModule } from '../code-first/directions/directions.module';
 import { RecipesModule } from '../code-first/recipes/recipes.module';
+import { CatsModule } from '../code-first/cats/cats.module';
 
 @Module({
   imports: [
     RecipesModule,
     DirectionsModule,
+    CatsModule,
     GraphQLModule.forRoot({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.graphql',

--- a/packages/apollo/tests/graphql/transform-auto-schema-file.module.ts
+++ b/packages/apollo/tests/graphql/transform-auto-schema-file.module.ts
@@ -10,7 +10,7 @@ import { CatsModule } from '../code-first/cats/cats.module';
   imports: [
     RecipesModule,
     DirectionsModule,
-    CatsModule,
+    CatsModule.register('useClass'),
     GraphQLModule.forRoot({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.graphql',

--- a/packages/apollo/tests/graphql/transform-auto-schema-file.module.ts
+++ b/packages/apollo/tests/graphql/transform-auto-schema-file.module.ts
@@ -4,11 +4,13 @@ import { GraphQLSchema, lexicographicSortSchema } from 'graphql';
 import { ApolloDriver } from '../../lib/drivers';
 import { DirectionsModule } from '../code-first/directions/directions.module';
 import { RecipesModule } from '../code-first/recipes/recipes.module';
+import { CatsModule } from '../code-first/cats/cats.module';
 
 @Module({
   imports: [
     RecipesModule,
     DirectionsModule,
+    CatsModule,
     GraphQLModule.forRoot({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.graphql',

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -75,6 +75,7 @@ type Query {
     take: Int = 25
   ): [Recipe!]!
   move(direction: Direction!): Direction!
+  getAnimalName: String!
   catType(catType: CatType!): CatType!
 }
 
@@ -96,6 +97,8 @@ enum CatType {
   PERSIAN_CAT
   MAINE_COON
   RAGDOLL
+  SOME_NEW_AWESOME_CAT
+  SOME_WEIRD_CAT
 }
 
 type Mutation {
@@ -126,6 +129,8 @@ enum CatType {
   MAINE_COON
   PERSIAN_CAT
   RAGDOLL
+  SOME_NEW_AWESOME_CAT
+  SOME_WEIRD_CAT
 }
 
 type Category {
@@ -179,6 +184,7 @@ input NewRecipeInput {
 type Query {
   catType(catType: CatType!): CatType!
   categories: [Category!]!
+  getAnimalName: String!
   move(direction: Direction!): Direction!
 
   """get recipe by id"""

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -75,6 +75,7 @@ type Query {
     take: Int = 25
   ): [Recipe!]!
   move(direction: Direction!): Direction!
+  catType(catType: CatType!): CatType!
 }
 
 """Search result description"""
@@ -88,6 +89,13 @@ enum Direction {
   Left
   Right
   Sideways @deprecated(reason: "Replaced with Left or Right")
+}
+
+"""Distinguish cats"""
+enum CatType {
+  PERSIAN_CAT
+  MAINE_COON
+  RAGDOLL
 }
 
 type Mutation {
@@ -112,6 +120,13 @@ type Subscription {
 export const sortedPrintedSchemaSnapshot = `# ------------------------------------------------------
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
+
+"""Distinguish cats"""
+enum CatType {
+  MAINE_COON
+  PERSIAN_CAT
+  RAGDOLL
+}
 
 type Category {
   description: String!
@@ -162,6 +177,7 @@ input NewRecipeInput {
 }
 
 type Query {
+  catType(catType: CatType!): CatType!
   categories: [Category!]!
   move(direction: Direction!): Direction!
 

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -99,6 +99,7 @@ enum CatType {
   RAGDOLL
   SOME_NEW_AWESOME_CAT
   SOME_WEIRD_CAT
+  ANOTHER_AWESOME_CAT
 }
 
 type Mutation {
@@ -126,6 +127,7 @@ export const sortedPrintedSchemaSnapshot = `# ----------------------------------
 
 """Distinguish cats"""
 enum CatType {
+  ANOTHER_AWESOME_CAT
   MAINE_COON
   PERSIAN_CAT
   RAGDOLL

--- a/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
@@ -1,6 +1,10 @@
+import { upperCase } from 'lodash';
 import { Injectable } from '@nestjs/common';
 import { GraphQLEnumType } from 'graphql';
 import { EnumMetadata } from '../metadata';
+
+export const mapToUppercase = (value: string): string =>
+  upperCase(value).replace(' ', '_');
 
 export interface EnumDefinition {
   enumRef: object;
@@ -19,7 +23,13 @@ export class EnumDefinitionFactory {
         description: metadata.description,
         values: Object.keys(enumValues).reduce((prevValue, key) => {
           const valueMap = metadata.valuesMap[key];
-          prevValue[key] = {
+
+          let graphqlKey = key;
+          if (metadata.mapToUppercase) {
+            graphqlKey = mapToUppercase(key);
+          }
+
+          prevValue[graphqlKey] = {
             value: enumValues[key],
             description: valueMap?.description,
             deprecationReason: valueMap?.deprecationReason,

--- a/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
@@ -4,7 +4,7 @@ import { GraphQLEnumType } from 'graphql';
 import { EnumMetadata } from '../metadata';
 
 export const mapToUppercase = (value: string): string =>
-  upperCase(value).replace(' ', '_');
+  upperCase(value).replaceAll(' ', '_');
 
 export interface EnumDefinition {
   enumRef: object;

--- a/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
@@ -24,12 +24,12 @@ export class EnumDefinitionFactory {
         values: Object.keys(enumValues).reduce((prevValue, key) => {
           const valueMap = metadata.valuesMap[key];
 
-          let graphqlKey = key;
+          let enumKey = key;
           if (metadata.mapToUppercase) {
-            graphqlKey = mapToUppercase(key);
+            enumKey = mapToUppercase(key);
           }
 
-          prevValue[graphqlKey] = {
+          prevValue[enumKey] = {
             value: enumValues[key],
             description: valueMap?.description,
             deprecationReason: valueMap?.deprecationReason,

--- a/packages/graphql/lib/schema-builder/metadata/enum.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/enum.metadata.ts
@@ -12,4 +12,5 @@ export interface EnumMetadata<T extends object = any> {
   name: string;
   description?: string;
   valuesMap?: EnumMetadataValuesMap<T>;
+  mapToUppercase?: boolean;
 }

--- a/packages/graphql/lib/type-factories/register-enum-type.factory.ts
+++ b/packages/graphql/lib/type-factories/register-enum-type.factory.ts
@@ -25,6 +25,12 @@ export interface EnumOptions<T extends object = any> {
    * A map of options for the values of the enum.
    */
   valuesMap?: EnumMetadataValuesMap<T>;
+
+  /**
+   * Automatically map enum to UPPER_CASE in the schema.
+   * Defaults to `false`
+   */
+  mapToUppercase?: boolean;
 }
 
 /**
@@ -41,6 +47,7 @@ export function registerEnumType<T extends object = any>(
       name: options.name,
       description: options.description,
       valuesMap: options.valuesMap || {},
+      mapToUppercase: options.mapToUppercase || false,
     }),
   );
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1832 


## What is the new behavior?
`registerEnumType` now contains an optional parameter called `mapToUppercase`(defaults to `false` to avoid breaking changes). This option automatically converts enum to `CONST_CASE` in compliance with GraphQL best practices.
It means we can use `PascalCase` in `typescript` while using `CONST_CASE` in GraphQL.

```ts
export enum CatType {
  PersianCat = 'persian-cat',
  MaineCoon = 'maine-coon',
  Ragdoll = 'ragdoll',
}

registerEnumType(CatType, {
  name: 'CatType',
  description: 'Distinguish cats',
  mapToUppercase: true, 
});
```

Would produce the following enum type in schema
```gql
"""Distinguish cats"""
enum CatType {
  PERSIAN_CAT
  MAINE_COON
  RAGDOLL
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Since this is a norm in GraphQL world, from the next release I consider we should make `mapToUppercase` to `true` by default. So people can use natural `PascalCase` enum values in `typescript` and use `CONST_CASE` by default in `GraphQL`