### PR TITLE
fix(@nestjs/grahphql): Build schema even if http adapter is not present

### DIFF
--- a/lib/graphql.module.ts
+++ b/lib/graphql.module.ts
@@ -132,10 +132,6 @@ export class GraphQLModule implements OnModuleInit, OnModuleDestroy {
     if (!this.httpAdapterHost) {
       return;
     }
-    const httpAdapter = this.httpAdapterHost.httpAdapter;
-    if (!httpAdapter) {
-      return;
-    }
     const typeDefs =
       (await this.graphqlTypesLoader.mergeTypesByPaths(
         this.options.typePaths,
@@ -155,6 +151,10 @@ export class GraphQLModule implements OnModuleInit, OnModuleDestroy {
       );
     }
 
+    const httpAdapter = this.httpAdapterHost.httpAdapter;
+    if (!httpAdapter) {
+      return;
+    }
     await this.registerGqlServer(apolloOptions);
     if (
       this.options.installSubscriptionHandlers ||


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently GraphQL schema (from `GraphQLSchemaHost`) cannot be referenced / it's not created when there is no `HttpAdapter`. This happens for me when using `nestjs-console`.

## What is the new behavior?

Always build schema & generate type definitions regardless of HTTP server status. Now only gql server & subscription service are skipped when http adapter is missing.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
