### PR TITLE
fix(graphql): allow resolvers to be registered in provider wrappers

### DIFF
--- a/packages/apollo/tests/code-first/cats/cats.module.ts
+++ b/packages/apollo/tests/code-first/cats/cats.module.ts
@@ -1,0 +1,45 @@
+import { Module } from '@nestjs/common';
+import { CatsResolver } from './cats.resolver';
+
+@Module({})
+export class CatsModule {
+  static register(resolverRegistrationMethod: 'useClass'|'useFactory'|'useValue') {
+    switch (resolverRegistrationMethod) {
+      case 'useClass':
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useClass: CatsResolver
+            },
+          ],
+        };
+
+      case 'useValue':
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useValue: new CatsResolver(),
+            },
+          ],
+        };
+
+      case 'useFactory':
+      default:
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useFactory() {
+                return new CatsResolver();
+              },
+            },
+          ],
+        };
+    }
+  }
+}

--- a/packages/apollo/tests/code-first/cats/cats.resolver.ts
+++ b/packages/apollo/tests/code-first/cats/cats.resolver.ts
@@ -1,0 +1,9 @@
+import { Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class CatsResolver {
+  @Query(returns => String)
+  getAnimalName(): string {
+    return 'cat';
+  }
+}

--- a/packages/apollo/tests/e2e/resolver-registration-methods.spec.ts
+++ b/packages/apollo/tests/e2e/resolver-registration-methods.spec.ts
@@ -1,0 +1,99 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { ApplicationModule } from '../code-first/app.module';
+import { CatsModule } from '../code-first/cats/cats.module';
+
+describe('GraphQL - Resolver registration methods', () => {
+    let app: INestApplication;
+  
+    describe('useClass', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useClass')],
+            }).compile();
+      
+            app = module.createNestApplication();
+            await app.init();
+        });
+
+        it('should return the cats result', async () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send({
+                    operationName: null,
+                    variables: {},
+                    query: 'query {\n  getAnimalName \n}\n',
+                })
+                .expect(200, {
+                    data: {
+                        getAnimalName: 'cat',
+                    }
+                });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+  
+    describe('useValue', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useValue')],
+            }).compile();
+  
+            app = module.createNestApplication();
+            await app.init();
+        });
+
+        it('should return the cats result', async () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send({
+                    operationName: null,
+                    variables: {},
+                    query: 'query {\n  getAnimalName \n}\n',
+                })
+                .expect(200, {
+                    data: {
+                        getAnimalName: 'cat',
+                    }
+                });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+  
+    describe('useFactory', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useFactory')],
+            }).compile();
+  
+            app = module.createNestApplication();
+            await app.init();
+        });
+  
+        it('should return the cats result', async () => {
+            return request(app.getHttpServer())
+                .post('/graphql')
+                .send({
+                    operationName: null,
+                    variables: {},
+                    query: 'query {\n  getAnimalName \n}\n',
+                })
+                .expect(200, {
+                    data: {
+                        getAnimalName: 'cat',
+                    }
+                });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+});

--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -279,12 +279,21 @@ export class ResolversExplorerService extends BaseExplorerService {
     };
   }
 
+  mapCtors(wrapper: InstanceWrapper): Function[] {
+    const { instance } = wrapper;
+    if (!instance) {
+      return undefined;
+    }
+
+    return instance.constructor;
+  }
+
   getAllCtors(): Function[] {
     const modules = this.getModules(
       this.modulesContainer,
       this.gqlOptions.include || [],
     );
-    const resolvers = this.flatMap(modules, (instance) => instance.metatype);
+    const resolvers = this.flatMap(modules, this.mapCtors).filter(Boolean);
     return resolvers;
   }
 

--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -279,22 +279,22 @@ export class ResolversExplorerService extends BaseExplorerService {
     };
   }
 
-  mapCtors(wrapper: InstanceWrapper): Function[] {
+  getAllCtors(): Function[] {
+    const modules = this.getModules(
+      this.modulesContainer,
+      this.gqlOptions.include || [],
+    );
+    const resolvers = this.flatMap(modules, this.mapToCtor).filter(Boolean);
+    return resolvers;
+  }
+
+  private mapToCtor(wrapper: InstanceWrapper): Function[] {
     const { instance } = wrapper;
     if (!instance) {
       return undefined;
     }
 
     return instance.constructor;
-  }
-
-  getAllCtors(): Function[] {
-    const modules = this.getModules(
-      this.modulesContainer,
-      this.gqlOptions.include || [],
-    );
-    const resolvers = this.flatMap(modules, this.mapCtors).filter(Boolean);
-    return resolvers;
   }
 
   private registerContextProvider<T = any>(request: T, contextId: ContextId) {

--- a/packages/mercurius/tests/code-first/cats/cats.module.ts
+++ b/packages/mercurius/tests/code-first/cats/cats.module.ts
@@ -1,0 +1,45 @@
+import { Module } from '@nestjs/common';
+import { CatsResolver } from './cats.resolver';
+
+@Module({})
+export class CatsModule {
+  static register(resolverRegistrationMethod: 'useClass'|'useFactory'|'useValue') {
+    switch (resolverRegistrationMethod) {
+      case 'useClass':
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useClass: CatsResolver
+            },
+          ],
+        };
+
+      case 'useValue':
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useValue: new CatsResolver(),
+            },
+          ],
+        };
+
+      case 'useFactory':
+      default:
+        return {
+          module: CatsModule,
+          providers: [
+            {
+              provide: CatsResolver,
+              useFactory() {
+                return new CatsResolver();
+              },
+            },
+          ],
+        };
+    }
+  }
+}

--- a/packages/mercurius/tests/code-first/cats/cats.resolver.ts
+++ b/packages/mercurius/tests/code-first/cats/cats.resolver.ts
@@ -1,0 +1,9 @@
+import { Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class CatsResolver {
+  @Query(returns => String)
+  getAnimalName(): string {
+    return 'cat';
+  }
+}

--- a/packages/mercurius/tests/e2e/resolver-registration-methods.spec.ts
+++ b/packages/mercurius/tests/e2e/resolver-registration-methods.spec.ts
@@ -1,0 +1,85 @@
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import mercurius from 'mercurius';
+import { ApplicationModule } from '../code-first/app.module';
+import { CatsModule } from '../code-first/cats/cats.module';
+
+describe('GraphQL - Resolver registration methods', () => {
+    let app: INestApplication;
+  
+    describe('useClass', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useClass')],
+            }).compile();
+      
+            app = module.createNestApplication(new FastifyAdapter());
+            await app.init();
+            await app.getHttpAdapter().getInstance().ready();
+        });
+
+        it('should return the cats result', async () => {
+            const fastifyInstance = app.getHttpAdapter().getInstance();
+            const response = await fastifyInstance.graphql(
+                'query {\n  getAnimalName \n}\n',
+            );
+
+            expect(response.data).toEqual({ getAnimalName: 'cat' });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+  
+    describe('useValue', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useValue')],
+            }).compile();
+      
+            app = module.createNestApplication(new FastifyAdapter());
+            await app.init();
+            await app.getHttpAdapter().getInstance().ready();
+        });
+
+        it('should return the cats result', async () => {
+            const fastifyInstance = app.getHttpAdapter().getInstance();
+            const response = await fastifyInstance.graphql(
+                'query {\n  getAnimalName \n}\n',
+            );
+
+            expect(response.data).toEqual({ getAnimalName: 'cat' });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+  
+    describe('useFactory', () => {
+        beforeEach(async () => {
+            const module = await Test.createTestingModule({
+                imports: [ApplicationModule, CatsModule.register('useFactory')],
+            }).compile();
+      
+            app = module.createNestApplication(new FastifyAdapter());
+            await app.init();
+            await app.getHttpAdapter().getInstance().ready();
+        });
+
+        it('should return the cats result', async () => {
+            const fastifyInstance = app.getHttpAdapter().getInstance();
+            const response = await fastifyInstance.graphql(
+                'query {\n  getAnimalName \n}\n',
+            );
+
+            expect(response.data).toEqual({ getAnimalName: 'cat' });
+        });
+
+        afterEach(async () => {
+            await app.close();
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Registration of a class marked with the Resolver() decorator fails silently when trying to pass the class to the providers array in a provider wrapper (e.g. { useFactory(){ ... } } or { useClass: ... })
This PR replaces #1733 and addresses issue #1700 

Issue Number: #1700 


## What is the new behavior?

Classes marked with the Resolver decorator behave in a way consistent with how classes marked with the Injectable decorator behave. You can provide a resolver by passing a reference to the class, a wrapper that specifies useFactory, a wrapper that specifies useClass or a wrapper that specifies useValue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A