### PR TITLE
chore(graphql): expose boolean type as const named 'Boolean'

### DIFF
--- a/packages/graphql/lib/scalars/index.ts
+++ b/packages/graphql/lib/scalars/index.ts
@@ -1,4 +1,4 @@
-import { GraphQLFloat, GraphQLID, GraphQLInt } from 'graphql';
+import { GraphQLFloat, GraphQLID, GraphQLInt, GraphQLBoolean } from 'graphql';
 
 export * from './iso-date.scalar';
 export * from './timestamp.scalar';
@@ -6,3 +6,4 @@ export * from './timestamp.scalar';
 export const Int = GraphQLInt;
 export const Float = GraphQLFloat;
 export const ID = GraphQLID;
+export const Boolean = GraphQLBoolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If I want to use boolean types for annotations, I have to GraphQLBoolean directly.
This is confusing for me because boolean is the only primitive type that is not exposed as const from this package.

Issue Number: N/A

## What is the new behavior?
Expose GraphQLBoolean type as 'Boolean' on this package.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
