### PR TITLE
fix(graphql): Fix federation reference resolver context args

### DIFF
--- a/packages/graphql/lib/factories/params.factory.ts
+++ b/packages/graphql/lib/factories/params.factory.ts
@@ -7,6 +7,10 @@ export class GqlParamsFactory implements ParamsFactory {
     if (!args) {
       return null;
     }
+    // Reference resolver args don't have root argument
+    if (args.length === 3) {
+      args = [undefined, ...args];
+    }
     switch (type as GqlParamtype) {
       case GqlParamtype.ROOT:
         return args[0];

--- a/packages/graphql/lib/services/gql-execution-context.ts
+++ b/packages/graphql/lib/services/gql-execution-context.ts
@@ -11,8 +11,10 @@ export class GqlExecutionContext
 {
   static create(context: ExecutionContext): GqlExecutionContext {
     const type = context.getType();
+    const args = context.getArgs();
     const gqlContext = new GqlExecutionContext(
-      context.getArgs(),
+      // Reference resolver args don't have root argument
+      args.length === 3 ? [undefined, ...args] : args,
       context.getClass(),
       context.getHandler(),
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1238

Currently, when trying to use a request-scoped provider (that injects graphql context) inside a federation reference resolver, its initiated with a wong context instance due to the fact that reference resolvers are invoked with only 3 arguments. That's because `__resolveReference` isn't a `GraphQLFieldResolver`, it's a `GraphQLReferenceResolver` ([as defined in @apollo/subgraph](https://github.com/apollographql/federation/blob/947948f9fd37a64ec3b08d181ffa0c9fd7bda223/subgraph-js/src/schemaExtensions.ts#L3)).


```typescript
import { Inject, Injectable, Scope } from '@nestjs/common'
import { CONTEXT } from '@nestjs/graphql'

@Injectable({ scope: Scope.REQUEST })
export class ProductLoader {
  constructor(@Inject(CONTEXT) private context: any) {
   // context here is not a valid graphql context (its basically the graphql `info` argument)
   console.log(context)
  }
  
  load(id) {
    console.log(id)
  }
}

@Resolver(() => Product)
export class ProductResolver {
  constructor(private loader: ProductLoader) {}

  @ResolveReference()
  async resolveReference(reference) {
    return this.loader.load(reference.id)
  }
}
```

## What is the new behavior?
This pr fixes the issue by adding a root argument with `undefined` value to `args` array when its length is less than four, I am not sure if thats the correct way to fix this but it seems to be working.

I would love to add tests for this pr but would need some guidence on where to add them.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
