### PR TITLE
feat(): Log the mounted path when starting GraphQL server

### DIFF
--- a/packages/graphql/lib/graphql.module.ts
+++ b/packages/graphql/lib/graphql.module.ts
@@ -1,4 +1,4 @@
-import { Inject, Logger, Module } from '@nestjs/common';
+import { Inject, Logger, Module, RequestMethod } from '@nestjs/common';
 import {
   DynamicModule,
   OnModuleDestroy,
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common/interfaces';
 import { HttpAdapterHost } from '@nestjs/core';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
+import { ROUTE_MAPPED_MESSAGE } from '@nestjs/core/helpers/messages';
 import { AbstractGraphQLDriver } from './drivers/abstract-graphql.driver';
 import { GraphQLFederationFactory } from './federation/graphql-federation.factory';
 import { GraphQLAstExplorer } from './graphql-ast.explorer';
@@ -48,7 +49,7 @@ export class GraphQLModule<
   TAdapter extends AbstractGraphQLDriver = AbstractGraphQLDriver,
 > implements OnModuleInit, OnModuleDestroy
 {
-  private static readonly logger = new Logger('GraphQLModule');
+  private static readonly logger = new Logger(GraphQLModule.name, { timestamp: true });
 
   get graphQlAdapter(): TAdapter {
     return this._graphQlAdapter as TAdapter;
@@ -157,6 +158,7 @@ export class GraphQLModule<
       ...options,
       typeDefs: mergedTypeDefs,
     });
+    GraphQLModule.logger.log(ROUTE_MAPPED_MESSAGE(options.path, RequestMethod.POST));
   }
 
   private static assertDriver(options: Record<string, any>) {

--- a/packages/graphql/lib/interfaces/gql-module-options.interface.ts
+++ b/packages/graphql/lib/interfaces/gql-module-options.interface.ts
@@ -13,6 +13,11 @@ export type Enhancer = 'guards' | 'interceptors' | 'filters';
  */
 export interface GqlModuleOptions<TDriver extends GraphQLDriver = any> {
   /**
+   * Path to mount GraphQL API
+   */
+  path?: string;
+
+  /**
    * Type definitions
    */
   typeDefs?: string | string[];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #115


## What is the new behavior?

When the GraphQL server is started, it logs the mounted path as follows.

```shell
[Nest] 98082  - 2022/02/26 4:25:48     LOG [GraphQLModule] Mapped {/graphql, POST} route +82ms
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
