### PR TITLE
build: add tslib dependency to the @nestjs/apollo package

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "iterall": "1.3.0",
-    "lodash.omit": "4.5.0"
+    "lodash.omit": "4.5.0",
+    "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "iterall": "1.3.0",
     "lodash.omit": "4.5.0",
-    "tslib": "^2.3.1"
+    "tslib": "2.3.1"
   },
   "peerDependencies": {
     "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9924,7 +9924,7 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.3.1, tslib@^2.1.0, tslib@~2.3.0:
+tslib@2.3.1, tslib@^2.1.0, tslib@^2.3.1, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Workspace `@nestjs/apollo` is missing dependency `tslib`.

Yarn berry (because berry is checking dependency tree) is throwing following error:
```
Error: @nestjs/apollo tried to access tslib, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: tslib
```


## What is the new behavior?
`tslib` is added into  `@nestjs/apollo` `package.json` file.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
