### PR TITLE
fix: resolve type context args in request scoped providers

### DIFF
--- a/packages/graphql/lib/factories/params.factory.ts
+++ b/packages/graphql/lib/factories/params.factory.ts
@@ -1,16 +1,16 @@
 import { ParamData } from '@nestjs/common';
 import { ParamsFactory } from '@nestjs/core/helpers/external-context-creator';
 import { GqlParamtype } from '../enums/gql-paramtype.enum';
+import { normalizeResolverArgs } from '../utils/normalize-resolver-args';
 
 export class GqlParamsFactory implements ParamsFactory {
   exchangeKeyForValue(type: number, data: ParamData, args: any) {
     if (!args) {
       return null;
     }
-    // Reference resolver args don't have root argument
-    if (args.length === 3) {
-      args = [undefined, ...args];
-    }
+
+    args = normalizeResolverArgs(args);
+
     switch (type as GqlParamtype) {
       case GqlParamtype.ROOT:
         return args[0];

--- a/packages/graphql/lib/services/gql-execution-context.ts
+++ b/packages/graphql/lib/services/gql-execution-context.ts
@@ -1,6 +1,7 @@
 import { ContextType, ExecutionContext } from '@nestjs/common';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
 import { GraphQLArgumentsHost } from './gql-arguments-host';
+import { normalizeResolverArgs } from '../utils/normalize-resolver-args';
 
 export type GqlContextType = 'graphql' | ContextType;
 export type GraphQLExecutionContext = GqlExecutionContext;
@@ -11,10 +12,8 @@ export class GqlExecutionContext
 {
   static create(context: ExecutionContext): GqlExecutionContext {
     const type = context.getType();
-    const args = context.getArgs();
     const gqlContext = new GqlExecutionContext(
-      // Reference resolver args don't have root argument
-      args.length === 3 ? [undefined, ...args] : args,
+      normalizeResolverArgs(context.getArgs()),
       context.getClass(),
       context.getHandler(),
     );

--- a/packages/graphql/lib/utils/normalize-resolver-args.ts
+++ b/packages/graphql/lib/utils/normalize-resolver-args.ts
@@ -1,0 +1,16 @@
+import { isType } from 'graphql';
+
+export function normalizeResolverArgs(args: any[]) {
+  const newArgs = [...args];
+  // Reference resolver args don't have args argument
+  const isReferenceResolver = newArgs.length === 3;
+  // Resolve type args don't have args argument and the last argument is the parent object type
+  const isResolveType =
+    !isReferenceResolver && isType(newArgs[newArgs.length - 1]);
+
+  // Add an undefined args argument
+  if (isReferenceResolver || isResolveType) {
+    newArgs.splice(1, 0, undefined);
+  }
+  return newArgs;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Importing a request scoped provider in a Resolver that defines a `__resolveType` decorated with `@ResolveField()` wrongly creates multiple provider instances in a single request, this is because a resolveType function has not the same arguments as a normal field resolver function (it is missing the `arg` argument), thus the request id used to keep track of the request is wrongly stored in the `info` object instead of the `context` object.
https://github.com/nestjs/graphql/blob/master/packages/graphql/lib/services/resolvers-explorer.service.ts#L170

Issue Number: N/A

## What is the new behavior?

This PR adds an `undefined` argument where the `args` object should be for `__resolveType` field resolvers

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
