### PR TITLE
Support using @apollo/subgraph 2.0.x

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -43,7 +43,7 @@
     "ts-morph": "14.0.0"
   },
   "peerDependencies": {
-    "@apollo/subgraph": "^0.1.5 || ^0.3.0 || ^0.4.0",
+    "@apollo/subgraph": "^0.1.5 || ^0.3.0 || ^0.4.0 || ^2.0.0",
     "@nestjs/common": "^8.2.3",
     "@nestjs/core": "^8.2.3",
     "graphql": "^15.8.0 || ^16.0.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features): N/A
- [x] Docs have been added / updated (for bug fixes / features): N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```
npm WARN Could not resolve dependency:
npm WARN peerOptional @apollo/subgraph@"^0.1.5 || ^0.3.0 || ^0.4.0" from @nestjs/graphql@10.0.10
npm WARN node_modules/@nestjs/graphql
npm WARN   @nestjs/graphql@"^10.0.10" from the root project
npm WARN   1 more (@nestjs/apollo)
```

## What is the new behavior?

Allows usage of `@apollo/subgraph` version `2.0.x` which supports federation v2 spec and is backwards compatible with federation v1

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
