### PR TITLE
fix(apollo): add global plugins for apollo gateway driver

### DIFF
--- a/packages/apollo/lib/drivers/apollo-gateway.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-gateway.driver.ts
@@ -1,11 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
+import { ModulesContainer } from '@nestjs/core';
+import { extend } from '@nestjs/graphql';
 import { ApolloGatewayDriverConfig } from '../interfaces';
+import { PluginsExplorerService } from '../services/plugins-explorer.service';
 import { ApolloBaseDriver } from './apollo-base.driver';
 
 @Injectable()
 export class ApolloGatewayDriver extends ApolloBaseDriver<ApolloGatewayDriverConfig> {
+  private readonly pluginsExplorerService: PluginsExplorerService;
+
+  constructor(modulesContainer: ModulesContainer) {
+    super();
+    this.pluginsExplorerService = new PluginsExplorerService(modulesContainer);
+  }
+
   public async start(options: ApolloGatewayDriverConfig): Promise<void> {
+    options.server.plugins = extend(
+      options.server.plugins || [],
+      this.pluginsExplorerService.explore(options),
+    );
+
     const { ApolloGateway } = loadPackage(
       '@apollo/gateway',
       'ApolloGateway',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
A custom ApolloServerPlugin annotated with @Plugin is not registered in the the Apollo Gateway driver.


## What is the new behavior?
Plugins are now added in options.server.plugins of the ApolloGatewayDriver

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
