### PR TITLE
chore(deps): update `@apollo/gateway` peer dependency

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -41,7 +41,7 @@
     "tslib": "2.4.0"
   },
   "peerDependencies": {
-    "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0 || ^0.49.0 || ^0.50.0",
+    "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0 || ^0.49.0 || ^0.50.0 || ^2.0.0",
     "@nestjs/common": "^8.2.3",
     "@nestjs/core": "^8.2.3",
     "@nestjs/graphql": "^10.0.0",


### PR DESCRIPTION
Updated the peer dependency in `@nestjs/apollo` to allow for a peer dependency of `@apollo/gateway` at version in the v2.x.x range while keeping backward compatibility with the 0.x.x releases.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: **Dependency update**

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current peer dependency does not follow the new semver release of `@apollo/gateway`.

Issue Number: N/A


## What is the new behavior?
Peer dependency now follows the v2.x.x releases of `@apollo/gateway`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
