### PR TITLE
fix(graphql): required exports for testing

### DIFF
--- a/packages/graphql/lib/index.ts
+++ b/packages/graphql/lib/index.ts
@@ -7,6 +7,7 @@ export * from './graphql-schema.host';
 export * from './graphql-types.loader';
 export * from './graphql.factory';
 export * from './graphql.module';
+export * from './graphql.constants';
 export * from './interfaces';
 export * from './scalars';
 export * from './schema-builder';

--- a/packages/graphql/lib/schema-builder/index.ts
+++ b/packages/graphql/lib/schema-builder/index.ts
@@ -1,3 +1,4 @@
 export * from './storages';
 export * from './graphql-schema.factory';
 export * from './schema-builder.module';
+export * from './helpers/file-system.helper';


### PR DESCRIPTION
Hi @kamilmysliwiec,

In the motivation to implement the GraphQL Yoga Driver in a separate repository (previous discussion: #2145), we need the following exports to be available outside of the package for testing purposes: `GRAPHQL_SDL_FILE_HEADER` (schema generation test), `FileSystemHelper` (mocking for schema DSL file loading).

Example of an Apollo test that won't work if moved outside of this monorepo:

https://github.com/nestjs/graphql/blob/42704556db2e492b218a98091d97bfb3bbca607f/packages/apollo/tests/e2e/graphql-sort-auto-schema.spec.ts#L1-L8



