### PR TITLE
refactor(graphql): add abstract context id factory

### DIFF
--- a/packages/graphql/lib/factories/context-id-factory.ts
+++ b/packages/graphql/lib/factories/context-id-factory.ts
@@ -1,0 +1,28 @@
+import { ContextId, createContextId } from '@nestjs/core';
+import { REQUEST_CONTEXT_ID } from '@nestjs/core/router/request/request-constants';
+
+export abstract class ContextIdFactory {
+  abstract create(): ContextId;
+
+  abstract getByRequest<T extends Record<any, any> = any>(
+    request: T,
+  ): ContextId;
+}
+
+export class GraphqlContextIdFactory implements ContextIdFactory {
+  create(): ContextId {
+    return createContextId();
+  }
+  getByRequest<T extends Record<any, any> = any>(gqlContext: T): ContextId {
+    if (!gqlContext) {
+      return this.create();
+    }
+    if (gqlContext[REQUEST_CONTEXT_ID as any]) {
+      return gqlContext[REQUEST_CONTEXT_ID as any];
+    }
+    if (gqlContext.req && gqlContext.req[REQUEST_CONTEXT_ID]) {
+      return gqlContext.req[REQUEST_CONTEXT_ID];
+    }
+    return createContextId();
+  }
+}

--- a/packages/graphql/lib/graphql.module.ts
+++ b/packages/graphql/lib/graphql.module.ts
@@ -24,6 +24,7 @@ import {
 import { GraphQLSchemaBuilderModule } from './schema-builder/schema-builder.module';
 import { ResolversExplorerService, ScalarsExplorerService } from './services';
 import { extend, generateString } from './utils';
+import { GraphqlContextIdFactory } from './factories/context-id-factory';
 
 @Module({
   imports: [GraphQLSchemaBuilderModule],
@@ -37,19 +38,23 @@ import { extend, generateString } from './utils';
     GraphQLSchemaBuilder,
     GraphQLSchemaHost,
     GraphQLFederationFactory,
+    GraphqlContextIdFactory,
   ],
   exports: [
     GraphQLTypesLoader,
     GraphQLAstExplorer,
     GraphQLSchemaHost,
     GraphQLFederationFactory,
+    GraphqlContextIdFactory,
   ],
 })
 export class GraphQLModule<
   TAdapter extends AbstractGraphQLDriver = AbstractGraphQLDriver,
 > implements OnModuleInit, OnModuleDestroy
 {
-  private static readonly logger = new Logger(GraphQLModule.name, { timestamp: true });
+  private static readonly logger = new Logger(GraphQLModule.name, {
+    timestamp: true,
+  });
 
   get graphQlAdapter(): TAdapter {
     return this._graphQlAdapter as TAdapter;
@@ -160,7 +165,9 @@ export class GraphQLModule<
     });
 
     if (options.path) {
-      GraphQLModule.logger.log(ROUTE_MAPPED_MESSAGE(options.path, RequestMethod.POST));
+      GraphQLModule.logger.log(
+        ROUTE_MAPPED_MESSAGE(options.path, RequestMethod.POST),
+      );
     }
   }
 


### PR DESCRIPTION
change resolvers-explorer service to use an abstract contextId factory

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The [resolvers-explorer.service](https://github.com/nestjs/graphql/blob/890762d532c3824037fcfc2c1ef81c653bbd14e7/packages/graphql/lib/services/resolvers-explorer.service.ts#L175) currently isn't using the `ContextIdFactory#getByRequest` method to retrieve the contextId from the request. Instead, it is manually checking the `gqlContext` object and calling the `createContextId()` function. This is a problem if we plan to monkeypatch the `ContextIdFactory` to create the separate Dependency Trees.

Issue Number: N/A


## What is the new behavior?

Now, `ContextIdFactory` is an abstract class and we have a GraphQL implementation for it. Although this class is defined in the graphql package, ideally it should reside in the `common` or `core` from the main repo. I only added it here to showcase what we could do.

Now, if we want to provide a specific implementation of ContextIdFactory for our needs, we can override it by ourselves.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
