### PR TITLE
Refactor/graphql context id factory

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@apollo/gateway": "0.51.0",
     "@nestjs/common": "8.4.5",
-    "@nestjs/core": "8.4.5",
+    "@nestjs/core": "8.4.6",
     "@nestjs/platform-express": "8.4.5",
     "@nestjs/platform-fastify": "8.4.5",
     "@nestjs/testing": "8.4.5",
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0 || ^0.49.0 || ^0.50.0 || ^2.0.0",
     "@nestjs/common": "^8.2.3",
-    "@nestjs/core": "^8.2.3",
+    "@nestjs/core": "^8.4.6",
     "@nestjs/graphql": "^10.0.0",
     "apollo-server-core": "^3.5.0",
     "apollo-server-express": "^3.5.0",

--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
 import {
+  ContextIdFactory,
   createContextId,
   MetadataScanner,
   ModuleRef,
@@ -172,24 +173,13 @@ export class ResolversExplorerService extends BaseExplorerService {
           undefined,
           args,
         );
-        let contextId: ContextId;
-        if (gqlContext && gqlContext[REQUEST_CONTEXT_ID]) {
-          contextId = gqlContext[REQUEST_CONTEXT_ID];
-        } else if (
-          gqlContext &&
-          gqlContext.req &&
-          gqlContext.req[REQUEST_CONTEXT_ID]
-        ) {
-          contextId = gqlContext.req[REQUEST_CONTEXT_ID];
-        } else {
-          contextId = createContextId();
-          Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {
-            value: contextId,
-            enumerable: false,
-            configurable: false,
-            writable: false,
-          });
-        }
+        const contextId = ContextIdFactory.getByRequest(gqlContext, ['req']);
+        Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {
+          value: contextId,
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
 
         this.registerContextProvider(gqlContext, contextId);
         const contextInstance = await this.injector.loadPerContext(

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@apollo/subgraph": "0.4.2",
     "@nestjs/common": "8.4.5",
-    "@nestjs/core": "8.4.5",
+    "@nestjs/core": "8.4.6",
     "@nestjs/testing": "8.4.5",
     "graphql": "15.8.0",
     "reflect-metadata": "0.1.13",
@@ -45,7 +45,7 @@
   "peerDependencies": {
     "@apollo/subgraph": "^0.1.5 || ^0.3.0 || ^0.4.0 || ^2.0.0",
     "@nestjs/common": "^8.2.3",
-    "@nestjs/core": "^8.2.3",
+    "@nestjs/core": "^8.4.6",
     "graphql": "^15.8.0 || ^16.0.0",
     "reflect-metadata": "^0.1.13",
     "ts-morph": "^13.0.2 || ^14.0.0 || ^15.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,19 +1924,6 @@
     tslib "2.4.0"
     uuid "8.3.2"
 
-"@nestjs/core@8.4.5":
-  version "8.4.5"
-  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-8.4.5.tgz#a419259f074a9a1b889540ce2ab46a87b85e9fbf"
-  integrity sha512-mT4MV2pEILu+Xy/deIvhb4JkIWaUU+yxssQqMScj8pWvAQ4+6sN52Sxl5NwLb6FTyZ8t5m8Qgr4yZPTmS+Y1Ig==
-  dependencies:
-    "@nuxtjs/opencollective" "0.3.2"
-    fast-safe-stringify "2.1.1"
-    iterare "1.2.1"
-    object-hash "3.0.0"
-    path-to-regexp "3.2.0"
-    tslib "2.4.0"
-    uuid "8.3.2"
-
 "@nestjs/core@8.4.6":
   version "8.4.6"
   resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-8.4.6.tgz#db1afa3202cddffa308c6f321e2e07ebcc05d513"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,6 +1937,19 @@
     tslib "2.4.0"
     uuid "8.3.2"
 
+"@nestjs/core@8.4.6":
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-8.4.6.tgz#db1afa3202cddffa308c6f321e2e07ebcc05d513"
+  integrity sha512-5zHpxTYV7HT3lfF7l/x0EWBfmuyuDOnGRcALf88tzDGs/7Q/VC6l65d6eFwDwI37NLtScqnmEkT9of8E3fT3mA==
+  dependencies:
+    "@nuxtjs/opencollective" "0.3.2"
+    fast-safe-stringify "2.1.1"
+    iterare "1.2.1"
+    object-hash "3.0.0"
+    path-to-regexp "3.2.0"
+    tslib "2.4.0"
+    uuid "8.3.2"
+
 "@nestjs/mapped-types@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz#78b62041c7a407db4a90eb140567321602bed18e"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The [resolvers-explorer.service](https://github.com/nestjs/graphql/blob/890762d532c3824037fcfc2c1ef81c653bbd14e7/packages/graphql/lib/services/resolvers-explorer.service.ts#L175) currently isn't using the ContextIdFactory#getByRequest method to retrieve the contextId from the request. Instead, it is manually checking the gqlContext object and calling the createContextId() function. This is a problem if we plan to monkeypatch the ContextIdFactory to create the separate Dependency Trees.

Issue Number: N/A


## What is the new behavior?
Now we get the `contextId` from `ContextIdFactory#getByRequest()`, passing `req` as a property to be checked.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I had to update the peer dependencies to match the newest `@nestjs/core` package (8.4.6) which provide the `ContextIdFactory` feature I used here.
