### PR TITLE
refactor(graphql): use context id factory

### DIFF
--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
 import {
+  ContextIdFactory,
   createContextId,
   MetadataScanner,
   ModuleRef,
@@ -172,24 +173,13 @@ export class ResolversExplorerService extends BaseExplorerService {
           undefined,
           args,
         );
-        let contextId: ContextId;
-        if (gqlContext && gqlContext[REQUEST_CONTEXT_ID]) {
-          contextId = gqlContext[REQUEST_CONTEXT_ID];
-        } else if (
-          gqlContext &&
-          gqlContext.req &&
-          gqlContext.req[REQUEST_CONTEXT_ID]
-        ) {
-          contextId = gqlContext.req[REQUEST_CONTEXT_ID];
-        } else {
-          contextId = createContextId();
-          Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {
-            value: contextId,
-            enumerable: false,
-            configurable: false,
-            writable: false,
-          });
-        }
+        const contextId = ContextIdFactory.getByRequest(gqlContext, ['req']);
+        Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {
+          value: contextId,
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        });
 
         this.registerContextProvider(gqlContext, contextId);
         const contextInstance = await this.injector.loadPerContext(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The [resolvers-explorer.service](https://github.com/nestjs/graphql/blob/890762d532c3824037fcfc2c1ef81c653bbd14e7/packages/graphql/lib/services/resolvers-explorer.service.ts#L175) currently isn't using the ContextIdFactory#getByRequest method to retrieve the contextId from the request. Instead, it is manually checking the gqlContext object and calling the createContextId() function. This is a problem if we plan to monkeypatch the ContextIdFactory to create the separate Dependency Trees.

Issue Number: N/A


## What is the new behavior?
Now we get the `contextId` from `ContextIdFactory#getByRequest()`, passing `req` as a property to be checked.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
