### PR TITLE
fix(graphql): get number of arguments

### DIFF
--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -35,6 +35,7 @@ import {
 } from '../graphql.constants';
 import { GqlModuleOptions } from '../interfaces';
 import { ResolverMetadata } from '../interfaces/resolver-metadata.interface';
+import { getNumberOfArguments } from '../utils';
 import { decorateFieldResolverWithMiddleware } from '../utils/decorate-field-resolver.util';
 import { extractMetadata } from '../utils/extract-metadata.util';
 import { BaseExplorerService } from './base-explorer.service';
@@ -331,7 +332,11 @@ export class ResolversExplorerService extends BaseExplorerService {
   }
 
   private getContextId(gqlContext: Record<string | symbol, any>): ContextId {
-    if (ContextIdFactory.getByRequest.length === 2) {
+    const numberOfArguments = getNumberOfArguments(
+      ContextIdFactory.getByRequest,
+    );
+
+    if (numberOfArguments === 2) {
       const contextId = ContextIdFactory.getByRequest(gqlContext, ['req']);
       if (!gqlContext[REQUEST_CONTEXT_ID as any]) {
         Object.defineProperty(gqlContext, REQUEST_CONTEXT_ID, {

--- a/packages/graphql/lib/utils/function-utils.ts
+++ b/packages/graphql/lib/utils/function-utils.ts
@@ -1,0 +1,17 @@
+export function getNumberOfArguments(fn: Function): number | undefined {
+  const functionAsString = fn.toString();
+
+  const anythingEnclosedInParenthesesRegex = /\(.+\)/;
+
+  const parametersEnclosedInParentheses = functionAsString.match(
+    new RegExp(anythingEnclosedInParenthesesRegex),
+  );
+
+  if (parametersEnclosedInParentheses) {
+    const matchString = parametersEnclosedInParentheses[0];
+    const argumentsArray = matchString.split(',');
+    return argumentsArray.length;
+  }
+
+  return 0;
+}

--- a/packages/graphql/lib/utils/index.ts
+++ b/packages/graphql/lib/utils/index.ts
@@ -3,3 +3,4 @@ export * from './extract-metadata.util';
 export * from './generate-token.util';
 export * from './normalize-route-path.util';
 export * from './remove-temp.util';
+export * from './function-utils';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
[resolvers-explorer.service](https://github.dev/nestjs/graphql/blob/671c713455cb80568b1e60b44ad260e6c68c0bf9/packages/graphql/lib/services/resolvers-explorer.service.ts#L334) is wrongly fetching the number of arguments of the `ContextIdFactory#getByRequest` method, relying on the function's length. This returns an invalid number in cases where we have a default parameter (in the [new implementation](https://github.com/nestjs/nest/blob/1ba99cc6d0ec7b01f0eeab2ccbf0ed6c61b4261a/packages/core/helpers/context-id-factory.ts#L30), we have the second parameter as optional, so it returns "1" as the length).

Issue Number: N/A


## What is the new behavior?
Now we correctly assert the number of arguments to decide the outcome of this private function.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Tests for the new utility function are coming soon!