### PR TITLE
test(graphql): add function utils test

### DIFF
--- a/packages/graphql/lib/utils/get-number-of-arguments.util.ts
+++ b/packages/graphql/lib/utils/get-number-of-arguments.util.ts
@@ -1,15 +1,30 @@
+/**
+ * Counts the number of arguments for a given function. This algorithm isn't tested for all cases
+ * (check in the spec file), so use it carefully, since it relies on getting the function as a string.
+ * Note this also counts parameters with default initializers (as opposed to checking `function.length`)
+ * @param fn The function to get the number of arguments
+ * @returns the number of arguments in the function's signature
+ */
 export function getNumberOfArguments(fn: Function): number | undefined {
-  const functionAsString = fn.toString();
+  // Removing newlines is necessary to use easier regex and handle multi-line functions
+  const functionAsStringWithouNewLines = fn.toString().replace(/\n/g, '');
 
   const anythingEnclosedInParenthesesRegex = /\(.+\)/;
 
-  const parametersEnclosedInParentheses = functionAsString.match(
+  const regexMatchedArray = functionAsStringWithouNewLines.match(
     new RegExp(anythingEnclosedInParenthesesRegex),
   );
 
-  if (parametersEnclosedInParentheses) {
-    const matchString = parametersEnclosedInParentheses[0];
-    const argumentsArray = matchString.split(',');
+  if (regexMatchedArray) {
+    const functionParametersAsString = regexMatchedArray[0];
+
+    // Removing arrays and objects is also necessary because we count the number of commas in the string,
+    // and both could have commas and confuse the split process below.
+    const parametersWithReplacedArraysAndObjects = functionParametersAsString
+      .replace(/\[.+\]/g, '"array"')
+      .replace(/(\{.+\})/g, '"object"');
+
+    const argumentsArray = parametersWithReplacedArraysAndObjects.split(',');
     return argumentsArray.length;
   }
 

--- a/packages/graphql/tests/utils/function.utils.spec.ts
+++ b/packages/graphql/tests/utils/function.utils.spec.ts
@@ -1,0 +1,147 @@
+import { getNumberOfArguments } from '../../lib/utils';
+
+describe('getNumberOfArguments', () => {
+  describe('when using function', () => {
+    it('should return 0 for a 0-argument function', () => {
+      function zeroArgFunction() {}
+      expect(getNumberOfArguments(zeroArgFunction)).toBe(0);
+    });
+
+    it('should return 1 for a 1-argument function', () => {
+      function oneArgFunction(_arg1: any) {}
+      expect(getNumberOfArguments(oneArgFunction)).toBe(1);
+    });
+
+    it('should return 2 for a 2-argument function', () => {
+      function twoArgFunction(_arg1: any, _arg2: any) {}
+      expect(getNumberOfArguments(twoArgFunction)).toBe(2);
+    });
+
+    it('should return 2 for a 2-argument function, even if it has a default parameter', () => {
+      function twoArgFunction(_arg1: any, _arg2 = 'text') {}
+      expect(getNumberOfArguments(twoArgFunction)).toBe(2);
+    });
+  });
+
+  describe('when using arrow function', () => {
+    it('should return 0 for a 0-argument function', () => {
+      const zeroArgFunction = () => {};
+      expect(getNumberOfArguments(zeroArgFunction)).toBe(0);
+    });
+
+    it('should return 1 for a 1-argument function', () => {
+      const oneArgFunction = (_arg1: any) => {};
+      expect(getNumberOfArguments(oneArgFunction)).toBe(1);
+    });
+
+    it('should return 2 for a 2-argument function', () => {
+      const twoArgFunction = (_arg1: any, _arg2: any) => {};
+      expect(getNumberOfArguments(twoArgFunction)).toBe(2);
+    });
+
+    it('should return 2 for a 2-argument function, even if it has a default parameter', () => {
+      const twoArgFunction = (_arg1: any, _arg2 = 1) => {};
+      expect(getNumberOfArguments(twoArgFunction)).toBe(2);
+    });
+  });
+
+  describe('when using class method', () => {
+    class TestClass {
+      methodZeroArguments() {}
+
+      methodOneArgument(_arg: any) {}
+
+      methodTwoArguments(_arg1: any, _arg2: any) {}
+
+      methodTwoArgumentsOneOptional(_arg1: any, _arg2 = ['raw']) {}
+    }
+
+    const instance = new TestClass();
+
+    it('should return 0 for a 0-argument function', () => {
+      expect(getNumberOfArguments(instance.methodZeroArguments)).toBe(0);
+    });
+
+    it('should return 1 for a 1-argument function', () => {
+      expect(getNumberOfArguments(instance.methodOneArgument)).toBe(1);
+    });
+
+    it('should return 2 for a 2-argument function', () => {
+      expect(getNumberOfArguments(instance.methodTwoArguments)).toBe(2);
+    });
+
+    it('should return 2 for a 2-argument function, even if it has a default parameter', () => {
+      expect(getNumberOfArguments(instance.methodTwoArgumentsOneOptional)).toBe(
+        2,
+      );
+    });
+  });
+
+  describe('when using class static method', () => {
+    class TestStaticClass {
+      static methodZeroArguments() {}
+
+      static methodOneArgument(_arg: any) {}
+
+      static methodTwoArguments(_arg1: any, _arg2: any) {}
+
+      static methodTwoArgumentsOneOptional(_arg1: any, _arg2 = ['raw']) {}
+    }
+
+    it('should return 0 for a 0-argument function', () => {
+      expect(getNumberOfArguments(TestStaticClass.methodZeroArguments)).toBe(0);
+    });
+
+    it('should return 1 for a 1-argument function', () => {
+      expect(getNumberOfArguments(TestStaticClass.methodOneArgument)).toBe(1);
+    });
+
+    it('should return 2 for a 2-argument function', () => {
+      expect(getNumberOfArguments(TestStaticClass.methodTwoArguments)).toBe(2);
+    });
+
+    it('should return 2 for a 2-argument function, even if it has a default parameter', () => {
+      expect(
+        getNumberOfArguments(TestStaticClass.methodTwoArgumentsOneOptional),
+      ).toBe(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should not count an "empty" argument when the function ends with a comma', () => {
+      // prettier-ignore
+      function functionEndingWithComma(_arg1, _arg2,) {}
+
+      expect(getNumberOfArguments(functionEndingWithComma)).toBe(2);
+    });
+
+    it('should count correctly for multi-lined functions', () => {
+      // prettier-ignore
+      function multiLineFunction(
+        _arg1 = 1,
+        _arg2 = 2,
+        _arg3 = 3,
+      ) {}
+
+      expect(getNumberOfArguments(multiLineFunction)).toBe(3);
+    });
+
+    it('should count correctly for functions containing arrays as default values', () => {
+      function functionWithArray(_arg1 = 1, _arg2 = [1, 2, 3]) {}
+
+      expect(getNumberOfArguments(functionWithArray)).toBe(2);
+    });
+
+    it('should count correctly for functions containing objects as default values', () => {
+      function functionWithArray(_arg1 = 1, _arg2 = { a: 1, b: 2 }) {}
+
+      expect(getNumberOfArguments(functionWithArray)).toBe(2);
+    });
+
+    it('should count correctly for functions containing both objects and arrays as default values', () => {
+      function functionWithArray(_arg1 = [1, 2, 3], _arg2 = { a: 1, b: 2 }) {}
+
+      expect(getNumberOfArguments(functionWithArray)).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Tests

## What is the current behavior?
`getNumberOfArguments` utility function wasn't returning the correct number for edge cases:
1. When using arrays or objects as default arguments
2. When a function had multi-line declaration (the \n character wasn't being captured by regex)
3. When the function's parameters ended with a comma

Issue Number: N/A

## What is the new behavior?
The function now works correctly for aforementioned cases.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
## Other information
