### PR TITLE
fix(apollo): Update resolveReference location

### DIFF
--- a/packages/graphql/lib/utils/transform-schema.util.ts
+++ b/packages/graphql/lib/utils/transform-schema.util.ts
@@ -1,6 +1,6 @@
-// This file is copied from `apollo-tooling`. The only difference is that it has a hack to not remove federation specific properties.
-// The changed lines are 31-40 and 85-87 and the original file can be found here:
-// https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-graphql/src/schema/transformSchema.ts
+// This file is copied from `apollographql/federation`. The only difference is
+// that it has a hack to not remove federation specific properties.
+// https://github.com/apollographql/federation/blob/main/subgraph-js/src/schema-helper/transformSchema.ts
 
 import {
   GraphQLDirective,
@@ -15,6 +15,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLOutputType,
+  GraphQLResolveInfo,
   GraphQLSchema,
   GraphQLType,
   GraphQLUnionType,
@@ -27,13 +28,33 @@ import {
   isUnionType,
 } from 'graphql';
 
+type GraphQLReferenceResolver<TContext> = (
+  reference: object,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => any;
+
+interface ApolloSubgraphExtensions<TContext> {
+  resolveReference?: GraphQLReferenceResolver<TContext>;
+}
+
 declare module 'graphql/type/definition' {
-  interface GraphQLObjectType {
-    resolveReference?: any;
+  interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
+    apollo?: {
+      subgraph?: ApolloSubgraphExtensions<_TContext>;
+    };
   }
 
-  interface GraphQLObjectTypeConfig<TSource, TContext> {
-    resolveReference?: any;
+  interface GraphQLInterfaceTypeExtensions<_TSource = any, _TContext = any> {
+    apollo?: {
+      subgraph?: ApolloSubgraphExtensions<_TContext>;
+    };
+  }
+
+  interface GraphQLUnionTypeExtensions<_TSource = any, _TContext = any> {
+    apollo?: {
+      subgraph?: ApolloSubgraphExtensions<_TContext>;
+    };
   }
 }
 
@@ -81,7 +102,27 @@ export function transformSchema(
         fields: () => replaceFields(config.fields),
       });
 
-      if (type.resolveReference) {
+      if (type.extensions.apollo?.subgraph?.resolveReference) {
+        objectType.extensions = {
+          ...objectType.extensions,
+          apollo: {
+            ...objectType.extensions.apollo,
+            subgraph: {
+              ...objectType.extensions.apollo.subgraph,
+              resolveReference:
+                type.extensions.apollo.subgraph.resolveReference,
+            },
+          },
+        };
+        /**
+         * Backcompat for old versions of @apollo/subgraph which didn't use
+         * `extensions` This can be removed when support for @apollo/subgraph <
+         * 0.4.2 is dropped Reference:
+         * https://github.com/apollographql/federation/pull/1747
+         */
+        // @ts-expect-error (explanation above)
+      } else if (type.resolveReference) {
+        // @ts-expect-error (explanation above)
         objectType.resolveReference = type.resolveReference;
       }
 

--- a/packages/mercurius/lib/utils/transform-schema.util.ts
+++ b/packages/mercurius/lib/utils/transform-schema.util.ts
@@ -145,11 +145,19 @@ export function transformFederatedSchema(schema: GraphQLSchema) {
             throw new MER_ERR_GQL_GATEWAY_INVALID_SCHEMA(__typename);
           }
 
-          const resolveReference = (type as any).resolveReference
-            ? (type as any).resolveReference
-            : function defaultResolveReference() {
-                return reference;
-              };
+          const resolveReference =
+            type.extensions?.apollo?.subgraph?.resolveReference ??
+            /**
+             * Backcompat for old versions of @apollo/subgraph which didn't use
+             * `extensions` This can be removed when support for
+             * @apollo/subgraph < 0.4.2 is dropped Reference:
+             * https://github.com/apollographql/federation/pull/1747
+             */
+            // @ts-expect-error (explanation above)
+            type.resolveReference ??
+            function defaultResolveReference() {
+              return reference;
+            };
 
           const result = resolveReference(reference, {}, context, info);
 


### PR DESCRIPTION
The location of `resolveReference` was updated in the `@apollo/subgraph` library to live on a type's `extensions` object rather than directly on the object itself. The `extensions` are treated as public API w.r.t. `graphql-js`.

Reference:
https://github.com/apollographql/federation/pull/1746
https://github.com/apollographql/federation/pull/1747

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

Issue Number: #2228

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No