### PR TITLE
fix(graphql): Support @Field of list type in IntersectionType

### DIFF
--- a/packages/graphql/lib/type-helpers/intersection-type.helper.ts
+++ b/packages/graphql/lib/type-helpers/intersection-type.helper.ts
@@ -1,4 +1,5 @@
 import { Type } from '@nestjs/common';
+import { isFunction } from '@nestjs/common/utils/shared.utils';
 import {
   inheritPropertyInitializers,
   inheritTransformationMetadata,
@@ -37,6 +38,14 @@ export function IntersectionType<A, B>(
   inheritTransformationMetadata(classBRef, IntersectionObjectType);
 
   fields.forEach((item) => {
+    if (isFunction(item.typeFn)) {
+      /**
+       * Execute type function eagarly to update the type options object (before "clone" operation)
+       * when the passed function (e.g., @Field(() => Type)) lazily returns an array.
+       */
+      item.typeFn();
+    }
+
     Field(item.typeFn, { ...item.options })(
       IntersectionObjectType.prototype,
       item.name,

--- a/packages/graphql/tests/plugin/type-helpers/intersection-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/intersection-type.helper.spec.ts
@@ -29,6 +29,9 @@ describe('IntersectionType', () => {
 
     firstName?: string;
 
+    @Field(() => [String])
+    hobbies?: string[];
+
     static [METADATA_FACTORY_NAME]() {
       return {
         firstName: { nullable: true, type: () => String },
@@ -41,11 +44,13 @@ describe('IntersectionType', () => {
   it('should inherit all fields from two types', () => {
     const prototype = Object.getPrototypeOf(UpdateUserDto);
     const { fields } = getFieldsAndDecoratorForType(prototype);
-    expect(fields.length).toEqual(4);
+    expect(fields.length).toEqual(5);
     expect(fields[0].name).toEqual('login');
     expect(fields[1].name).toEqual('password');
     expect(fields[2].name).toEqual('lastName');
-    expect(fields[3].name).toEqual('firstName');
+    expect(fields[3].name).toEqual('hobbies');
+    expect(fields[3].options).toEqual({ isArray: true, arrayDepth: 1 });
+    expect(fields[4].name).toEqual('firstName');
     expect(fields[0].directives.length).toEqual(1);
     expect(fields[0].directives).toContainEqual({
       fieldName: 'login',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1420


## What is the new behavior?

`IntersectionType`
Fix @Field of List type in IntersectionType.
Previously array wrapper was ignored and GraphQL List wrapper was not applied:
```typescript
// [String] was interpreted as String
@Field(() => [String])
```
In suggested changes `IntersectionType` executes type function to support GraphQL List types.
Other helpers (`PickType`, `OmitType`) are using same approach.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Previous PR (#1420) executed type functions eagerly, so could not be merged.
Furthermore it was abandoned more than a year ago, closed for commenting and modification.
