### PR TITLE
feat(types): Type check Field defaultValue

### DIFF
--- a/packages/graphql/lib/interfaces/base-type-options.interface.ts
+++ b/packages/graphql/lib/interfaces/base-type-options.interface.ts
@@ -1,5 +1,5 @@
 export type NullableList = 'items' | 'itemsAndList';
-export interface BaseTypeOptions {
+export interface BaseTypeOptions<T = any> {
   /**
    * Determines whether field/argument/etc is nullable.
    */
@@ -7,5 +7,5 @@ export interface BaseTypeOptions {
   /**
    * Default value.
    */
-  defaultValue?: any;
+  defaultValue?: T;
 }

--- a/packages/graphql/lib/interfaces/return-type-func.interface.ts
+++ b/packages/graphql/lib/interfaces/return-type-func.interface.ts
@@ -1,11 +1,13 @@
 import { Type } from '@nestjs/common';
 import { GraphQLScalarType } from 'graphql';
 
-export type GqlTypeReference =
-  | Type<any>
+export type GqlTypeReference<T = any> =
+  | Type<T>
   | GraphQLScalarType
   | Function
   | object
   | symbol;
 export type ReturnTypeFuncValue = GqlTypeReference | [GqlTypeReference];
-export type ReturnTypeFunc = (returns?: void) => ReturnTypeFuncValue;
+export type ReturnTypeFunc<T extends ReturnTypeFuncValue = any> = (
+  returns?: void,
+) => T;

--- a/packages/graphql/lib/interfaces/type-options.interface.ts
+++ b/packages/graphql/lib/interfaces/type-options.interface.ts
@@ -1,6 +1,6 @@
 import { BaseTypeOptions } from './base-type-options.interface';
 
-export interface TypeOptions extends BaseTypeOptions {
+export interface TypeOptions<T = any> extends BaseTypeOptions<T> {
   isArray?: boolean;
   arrayDepth?: number;
 }

--- a/packages/graphql/tests/plugin/decorators/field.decorator.spec.ts
+++ b/packages/graphql/tests/plugin/decorators/field.decorator.spec.ts
@@ -1,0 +1,41 @@
+import { Field } from '../../../lib/decorators';
+
+class Inner {
+  test: string;
+}
+
+// It should expect the right primitive as defaultValue
+class WrongPrimitive {
+  // @ts-expect-error The defaultValue should be a boolean
+  @Field(() => Boolean, { defaultValue: 'true' })
+  bool: boolean;
+}
+
+class CorrectPrimitive {
+  @Field(() => Boolean, { defaultValue: true })
+  bool: boolean;
+}
+
+// It should expect the right object as defaultValue
+class WrongObject {
+  // @ts-expect-error The defaultValue should be of the shape of Inner
+  @Field(() => Inner, { defaultValue: { success: true } })
+  inner: Inner;
+}
+
+class CorrectObject {
+  @Field(() => Inner, { defaultValue: { test: 'hello' } })
+  inner: Inner;
+}
+
+// It should expect an Array as defaultValue
+class WrongArray {
+  // @ts-expect-error The defaultValue should be an Array
+  @Field(() => [Inner], { defaultValue: { test: 'test' } })
+  inners: Inner[];
+}
+
+class CorrectArray {
+  @Field(() => [Inner], { defaultValue: [{ test: 'test' }] })
+  inner: Inner;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other: Typing improvement

## What is the current behavior?

Currently, when using `@Field(() => MyType, { defaultValue: ... })`, the `defaultValue` type is not checked as `MyType` at compile time. It can lead to runtime errors if you refactor `MyType` but forget to update the default value.


## What is the new behavior?

When using the `@Field(() => MyType, { defaultValue: ... })` or the array one `@Field(() => [MyType], { defaultValue: ... })`, the `defaultValue` type is checked and there is a Typescript error if it's not `MyType` or `MyType[]` respectively.

The feature is not available when using `@Field({ defaultValue: ... })`, it defaults to the current behavior of allowing `any` value. 


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

I think it doesn't, given there is an any fallback, but I may need to test more thoroughly (I don't know how to add type tests in the test suite). 


## Other information

The same behavior could be implemented for others decorators to some extend.
