### PR TITLE
fix(code-first): Use base model field options with ResolveField()

### DIFF
--- a/packages/apollo/tests/code-first/recipes/ingredients.resolver.ts
+++ b/packages/apollo/tests/code-first/recipes/ingredients.resolver.ts
@@ -1,0 +1,20 @@
+import { ID, ResolveField, Resolver, Parent } from '@nestjs/graphql';
+import { Ingredient } from './models/ingredient';
+
+@Resolver((of) => Ingredient)
+export class IngredientsResolver {
+  @ResolveField(() => ID)
+  id(@Parent() { id }: Ingredient): string {
+    return id;
+  }
+
+  @ResolveField()
+  name(@Parent() { name }: Ingredient): string {
+    return name;
+  }
+
+  @ResolveField()
+  baseName(@Parent() { name }: Ingredient): string {
+    return name;
+  }
+}

--- a/packages/apollo/tests/code-first/recipes/models/ingredient.ts
+++ b/packages/apollo/tests/code-first/recipes/models/ingredient.ts
@@ -1,9 +1,28 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
-@ObjectType()
-export class Ingredient {
-  @Field((type) => ID)
-  id: string;
 
+class NodeIngredient {
+  // This does not apply since the class is not decorated with the @ObjectType decorator
+  @Field((type) => ID, {
+    defaultValue: 'Not applied',
+    description: 'Not applied',
+    deprecationReason: 'Not applied',
+  })
+  id: string;
+}
+
+@ObjectType({ isAbstract: true })
+class BaseIngredient extends NodeIngredient {
+  @Field({
+    defaultValue: 'default',
+    deprecationReason: 'is deprecated',
+    description: 'ingredient base name',
+    nullable: true,
+  })
+  baseName: string;
+}
+
+@ObjectType()
+export class Ingredient extends BaseIngredient {
   @Field({
     defaultValue: 'default',
     deprecationReason: 'is deprecated',
@@ -13,6 +32,7 @@ export class Ingredient {
   name: string;
 
   constructor(ingredient: Partial<Ingredient>) {
+    super();
     Object.assign(this, ingredient);
   }
 }

--- a/packages/apollo/tests/code-first/recipes/recipes.module.ts
+++ b/packages/apollo/tests/code-first/recipes/recipes.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { UnauthorizedFilter } from '../common/filters/unauthorized.filter';
 import { DateScalar } from '../common/scalars/date.scalar';
+import { IngredientsResolver } from './ingredients.resolver';
 import { IRecipesResolver } from './irecipes.resolver';
 import { RecipesResolver } from './recipes.resolver';
 import { RecipesService } from './recipes.service';
 
 @Module({
   providers: [
+    IngredientsResolver,
     RecipesResolver,
     IRecipesResolver,
     RecipesService,

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -17,6 +17,7 @@ import { DirectionsResolver } from '../code-first/directions/directions.resolver
 import { SampleOrphanedEnum } from '../code-first/enums/sample-orphaned.enum';
 import { AbstractResolver } from '../code-first/other/abstract.resolver';
 import { SampleOrphanedType } from '../code-first/other/sample-orphaned.type';
+import { IngredientsResolver } from '../code-first/recipes/ingredients.resolver';
 import { IRecipesResolver } from '../code-first/recipes/irecipes.resolver';
 import { Recipe } from '../code-first/recipes/models/recipe';
 import { RecipesResolver } from '../code-first/recipes/recipes.resolver';
@@ -48,6 +49,7 @@ describe('Code-first - schema factory', () => {
     beforeAll(async () => {
       schema = await schemaFactory.create(
         [
+          IngredientsResolver,
           RecipesResolver,
           DirectionsResolver,
           AbstractResolver,
@@ -206,6 +208,18 @@ describe('Code-first - schema factory', () => {
               description: 'ingredient name',
               isDeprecated: true,
               name: 'name',
+              type: {
+                kind: TypeKind.SCALAR,
+                name: 'String',
+                ofType: null,
+              },
+            },
+            {
+              args: [],
+              deprecationReason: 'is deprecated',
+              description: 'ingredient base name',
+              isDeprecated: true,
+              name: 'baseName',
               type: {
                 kind: TypeKind.SCALAR,
                 name: 'String',

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -40,17 +40,19 @@ type SampleOrphanedType {
   averageRating: Float!
 }
 
+type Ingredient {
+  """ingredient base name"""
+  baseName: String @deprecated(reason: "is deprecated")
+
+  """ingredient name"""
+  name: String @deprecated(reason: "is deprecated")
+  id: ID!
+}
+
 type Category {
   name: String!
   description: String!
   tags: [String!]!
-}
-
-type Ingredient {
-  id: ID!
-
-  """ingredient name"""
-  name: String @deprecated(reason: "is deprecated")
 }
 
 """orphaned enum"""
@@ -141,6 +143,8 @@ interface IRecipe {
 }
 
 type Ingredient {
+  """ingredient base name"""
+  baseName: String @deprecated(reason: "is deprecated")
   id: ID!
 
   """ingredient name"""


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #2331

## What is the new behavior?

Field options from model base classes are used when a `ResolveField()` is defined for those fields.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
