### PR TITLE
fix(schema-first): merge duplicate IQuery interface

### DIFF
--- a/packages/apollo/tests/e2e/generated-definitions.spec.ts
+++ b/packages/apollo/tests/e2e/generated-definitions.spec.ts
@@ -339,4 +339,23 @@ describe('Generated Definitions', () => {
   afterEach(async () => {
     await app.close();
   });
+
+  it('should generate for a federated graph with partial query definition', async () => {
+    const outputFile = generatedDefinitions(
+      'federation-partial-query.test-definitions.ts',
+    );
+    const factory = new GraphQLFederationDefinitionsFactory();
+    await factory.generate({
+      typePaths: [generatedDefinitions('federation-partial-query.graphql')],
+      path: outputFile,
+      outputAs: 'interface',
+    });
+
+    expect(
+      await readFile(
+        generatedDefinitions('federation-partial-query.fixture.ts'),
+        'utf8',
+      ),
+    ).toBe(await readFile(outputFile, 'utf8'));
+  });
 });

--- a/packages/apollo/tests/generated-definitions/federation-partial-query.fixture.ts
+++ b/packages/apollo/tests/generated-definitions/federation-partial-query.fixture.ts
@@ -1,0 +1,15 @@
+
+/*
+ * -------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+
+export interface IQuery {
+    foo(): Nullable<boolean> | Promise<Nullable<boolean>>;
+}
+
+type Nullable<T> = T | null;

--- a/packages/apollo/tests/generated-definitions/federation-partial-query.graphql
+++ b/packages/apollo/tests/generated-definitions/federation-partial-query.graphql
@@ -1,0 +1,3 @@
+extend type Query {
+    foo: Boolean
+}

--- a/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
@@ -37,6 +37,9 @@ export class GraphQLFederationDefinitionsFactory extends GraphQLDefinitionsFacto
       },
     ]);
 
+    // buildSubgraphSchema fills empty Query definition if there is `extend type Query` definition without original `type Query` definition.
+    // This causes duplicate IQuery interfaces.
+    // see: https://github.com/nestjs/graphql/issues/2344
     const mergedDefinition = mergeTypeDefs([printSubgraphSchema(schema)], {
       useSchemaDefinition: false,
       throwOnConflict: true,

--- a/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
@@ -3,6 +3,7 @@ import { gql } from 'graphql-tag';
 import { DefinitionsGeneratorOptions } from '../graphql-ast.explorer';
 import { GraphQLDefinitionsFactory } from '../graphql-definitions.factory';
 import { extend } from '../utils';
+import { mergeTypeDefs } from '@graphql-tools/merge';
 
 export class GraphQLFederationDefinitionsFactory extends GraphQLDefinitionsFactory {
   protected async exploreAndEmit(
@@ -35,9 +36,17 @@ export class GraphQLFederationDefinitionsFactory extends GraphQLDefinitionsFacto
         resolvers: {},
       },
     ]);
+
+    const mergedDefinition = mergeTypeDefs([printSubgraphSchema(schema)], {
+      useSchemaDefinition: false,
+      throwOnConflict: true,
+      commentDescriptions: true,
+      reverseDirectives: true,
+    });
+
     const tsFile = await this.gqlAstExplorer.explore(
       gql`
-        ${printSubgraphSchema(schema)}
+        ${mergedDefinition}
       `,
       path,
       outputAs,

--- a/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
@@ -37,9 +37,9 @@ export class GraphQLFederationDefinitionsFactory extends GraphQLDefinitionsFacto
       },
     ]);
 
-    // buildSubgraphSchema fills empty Query definition if there is `extend type Query` definition without original `type Query` definition.
-    // This causes duplicate IQuery interfaces.
-    // see: https://github.com/nestjs/graphql/issues/2344
+    // "buildSubgraphSchema" generates an empty Query definition if there is the `extend type Query` statement
+    // This leads to duplicated IQuery interfaces
+    // see: https://github.com//issues/2344
     const mergedDefinition = mergeTypeDefs([printSubgraphSchema(schema)], {
       useSchemaDefinition: false,
       throwOnConflict: true,


### PR DESCRIPTION
Fixes #2344 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2344 

As described in the issue, `GraphQLFederationDefinitionsFactory` emits duplicate IQuery interface.

This is caused by `buildSubgraphSchema`, which fills empty Query definition when there is no original  `type Query` definition and there is `extend type Query` definition.


## What is the new behavior?
Duplicate IQuery interface will be merged.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
