### PR TITLE
fix(@nestjs/graphql): need to properly close websocket servers

### DIFF
--- a/packages/apollo/tests/subscriptions/compat.spec.ts
+++ b/packages/apollo/tests/subscriptions/compat.spec.ts
@@ -169,7 +169,7 @@ describe('Use graphql-ws + subscriptions-transport-ws', () => {
     try {
       await wsClient?.dispose();
     } catch {}
-    await subWsClient?.close();
+    subWsClient?.close();
     await app.close();
     jest.clearAllMocks();
   });

--- a/packages/graphql/lib/services/gql-subscription.service.ts
+++ b/packages/graphql/lib/services/gql-subscription.service.ts
@@ -3,7 +3,11 @@ import {
   GraphQLSchema,
   subscribe as graphqlSubscribe,
 } from 'graphql';
-import { GRAPHQL_TRANSPORT_WS_PROTOCOL, ServerOptions } from 'graphql-ws';
+import {
+  Disposable,
+  GRAPHQL_TRANSPORT_WS_PROTOCOL,
+  ServerOptions,
+} from 'graphql-ws';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import {
   GRAPHQL_WS,
@@ -51,6 +55,8 @@ export interface GqlSubscriptionServiceOptions extends SubscriptionConfig {
 export class GqlSubscriptionService {
   private readonly wss: ws.Server;
   private readonly subTransWs: ws.Server;
+  private wsGqlDisposable: Disposable;
+  private subServer: SubscriptionServer;
 
   constructor(
     private readonly options: GqlSubscriptionServiceOptions,
@@ -83,7 +89,7 @@ export class GqlSubscriptionService {
       const graphqlWsOptions =
         this.options['graphql-ws'] === true ? {} : this.options['graphql-ws'];
       supportedProtocols.push(GRAPHQL_TRANSPORT_WS_PROTOCOL);
-      useServer(
+      this.wsGqlDisposable = useServer(
         {
           schema: this.options.schema,
           execute,
@@ -102,7 +108,7 @@ export class GqlSubscriptionService {
           : this.options['subscriptions-transport-ws'];
 
       supportedProtocols.push(GRAPHQL_WS);
-      SubscriptionServer.create(
+      this.subServer = SubscriptionServer.create(
         {
           schema: this.options.schema,
           execute,
@@ -139,11 +145,7 @@ export class GqlSubscriptionService {
   }
 
   async stop() {
-    for (const client of this.wss.clients) {
-      client.close(1001, 'Going away');
-    }
-    for (const client of this.subTransWs.clients) {
-      client.close(1001, 'Going away');
-    }
+    await this.wsGqlDisposable?.dispose();
+    this.subServer?.close();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, we do not properly shutdown the websocket transports (`graphql-ws` & `subscriptions-transport-ws`).

It looks like there was initially some logic removed [here (bottom of the graphql-ws-subscription.service.ts diff)](https://github.com/nestjs/graphql/commit/5641df041b091408f350ff05b7fa5552128c81c6#diff-92122dbb35799ddf65aac14829f8f43c39a67ef49b62fb5d74af57a427925faf) that mimicked [graphql-ws's tear-down logic](https://github.com/enisdenjo/graphql-ws/blob/6358a8fd794edba24e676a33e01c740170243006/src/use/ws.ts#L174). And that the net new logic dupe'd this same behavior (sending a `1001`) for tearing down `subscriptions-transport-ws`, which doesn't seem reflective of what [ApolloServer was doing](https://github.com/apollographql/apollo-server/blob/release-2.25.0/packages/apollo-server-core/src/ApolloServer.ts#L890) when they called `.close()` (back in V2) on the now-deprecated [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/server.ts#L186).

I noticed the behavior when my client was receiving the manually sent `1001`, but was still able to immediately reconnect. This led me to discovering that we were just sending that code without doing anything else beyond that. I have async tear-down logic in my own `OnModuleDestroy`'s, so the client being able to reconnect and request resources that I was actively trying to tear-down led to the discovery of these issues.

## What is the new behavior?

All this to say, I think it makes the most sense to defer the tear-down logic to the libraries themselves. I am very much open to feedback and discussion on this 👍🏻.

## Does this PR introduce a breaking change?

Unsure on this. If folks were relying on the server not being properly shut down, then maybe?

- [ ] Yes
- [ ] No
- [x] Maybe

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
