### PR TITLE
fix(@nestjs/graphql): Fix generation of ArgsType metadata

### DIFF
--- a/packages/graphql/lib/plugin/visitors/model-class.visitor.ts
+++ b/packages/graphql/lib/plugin/visitors/model-class.visitor.ts
@@ -1,5 +1,6 @@
 import * as ts from 'typescript';
 import {
+  ArgsType,
   Field,
   HideField,
   InputType,
@@ -30,7 +31,12 @@ import {
   replaceImportPath,
 } from '../utils/plugin-utils';
 
-const CLASS_DECORATORS = [ObjectType.name, InterfaceType.name, InputType.name];
+const CLASS_DECORATORS = [
+  ObjectType.name,
+  InterfaceType.name,
+  InputType.name,
+  ArgsType.name,
+];
 
 export class ModelClassVisitor {
   private importsToAdd: Set<string>;

--- a/packages/graphql/tests/plugin/fixtures/create-cat.dto.ts
+++ b/packages/graphql/tests/plugin/fixtures/create-cat.dto.ts
@@ -29,6 +29,44 @@ export class CreateCatDto {
 
   static staticProperty: string;
 }
+
+@InputType()
+export class CreateCatInput {
+  name: string;
+  age: number = 3;
+  tags: string[];
+  status: Status = Status.ENABLED;
+  status2?: Status;
+  statusArr?: Status[];
+  readonly breed?: string;
+  nodes: Node[];
+  date: Date;
+
+  @HideField()
+  hidden: number;
+
+  static staticProperty: string;
+}
+
+@ArgsType()
+export class CreateCatArgs {
+  name: string;
+  age: number = 3;
+  tags: string[];
+  status: Status = Status.ENABLED;
+  status2?: Status;
+  statusArr?: Status[];
+  readonly breed?: string;
+  nodes: Node[];
+  date: Date;
+
+  @HideField()
+  hidden: number;
+
+  static staticProperty: string;
+
+  input: CreateCatInput;
+}
 `;
 
 export const createCatDtoTextTranspiled = `var Status;
@@ -56,4 +94,36 @@ CreateCatDto = __decorate([
     ObjectType()
 ], CreateCatDto);
 export { CreateCatDto };
+let CreateCatInput = class CreateCatInput {
+    constructor() {
+        this.age = 3;
+        this.status = Status.ENABLED;
+    }
+    static _GRAPHQL_METADATA_FACTORY() {
+        return { name: { type: () => String }, age: { type: () => Number }, tags: { type: () => [String] }, status: { type: () => Status }, status2: { nullable: true, type: () => Status }, statusArr: { nullable: true, type: () => [Status] }, breed: { nullable: true, type: () => String }, nodes: { type: () => [Object] }, date: { type: () => Date } };
+    }
+};
+__decorate([
+    HideField()
+], CreateCatInput.prototype, \"hidden\", void 0);
+CreateCatInput = __decorate([
+    InputType()
+], CreateCatInput);
+export { CreateCatInput };
+let CreateCatArgs = class CreateCatArgs {
+    constructor() {
+        this.age = 3;
+        this.status = Status.ENABLED;
+    }
+    static _GRAPHQL_METADATA_FACTORY() {
+        return { name: { type: () => String }, age: { type: () => Number }, tags: { type: () => [String] }, status: { type: () => Status }, status2: { nullable: true, type: () => Status }, statusArr: { nullable: true, type: () => [Status] }, breed: { nullable: true, type: () => String }, nodes: { type: () => [Object] }, date: { type: () => Date }, input: { type: () => require(\"./create-cat.input\").CreateCatInput } };
+    }
+};
+__decorate([
+    HideField()
+], CreateCatArgs.prototype, \"hidden\", void 0);
+CreateCatArgs = __decorate([
+    ArgsType()
+], CreateCatArgs);
+export { CreateCatArgs };
 `;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Fields in Args are not generated  by the graphQL typescript plugin

Issue Number: https://github.com/nestjs/graphql/pull/1757#issuecomment-1234388563


## What is the new behavior?
Fields in Args are generated  by the graphQL typescript plugin


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
