### PR TITLE
fix(@nestjs/graphql): set unique ids on resolvers to fix cache errors

### DIFF
--- a/packages/apollo/tests/code-first-duplicate-resolvers/app.module.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/app.module.ts
@@ -1,0 +1,21 @@
+import { ApolloDriver } from '@nestjs/apollo';
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ModuleAModule } from './module-a/module-a.module';
+import { ModuleBModule } from './module-b/module-b.module';
+import { QueryResolver } from './query.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
+    ModuleAModule,
+    ModuleBModule,
+    QueryResolver,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/packages/apollo/tests/code-first-duplicate-resolvers/module-a/module-a.module.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/module-a/module-a.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleAModule {}

--- a/packages/apollo/tests/code-first-duplicate-resolvers/module-a/user.resolver.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/module-a/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation(() => String, { name: 'moduleALogin' })
+  login(@Args('code') code: string) {
+    return code;
+  }
+}

--- a/packages/apollo/tests/code-first-duplicate-resolvers/module-b/module-b.module.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/module-b/module-b.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleBModule {}

--- a/packages/apollo/tests/code-first-duplicate-resolvers/module-b/user.resolver.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/module-b/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation(() => String, { name: 'moduleBLogin' })
+  login(@Args('username') username: string) {
+    return username;
+  }
+}

--- a/packages/apollo/tests/code-first-duplicate-resolvers/query.resolver.ts
+++ b/packages/apollo/tests/code-first-duplicate-resolvers/query.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class QueryResolver {
+  @Query(() => Boolean, { name: '_' })
+  test() {
+    return true;
+  }
+}

--- a/packages/apollo/tests/duplicate-resolvers/app.module.ts
+++ b/packages/apollo/tests/duplicate-resolvers/app.module.ts
@@ -1,0 +1,20 @@
+import { ApolloDriver } from '@nestjs/apollo';
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
+import { ModuleAModule } from './module-a/module-a.module';
+import { ModuleBModule } from './module-b/module-b.module';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({
+      driver: ApolloDriver,
+      typePaths: [join(__dirname, '*.graphql')],
+    }),
+    ModuleAModule,
+    ModuleBModule,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/packages/apollo/tests/duplicate-resolvers/duplicate-resolver.graphql
+++ b/packages/apollo/tests/duplicate-resolvers/duplicate-resolver.graphql
@@ -1,0 +1,8 @@
+type Query {
+    _: Boolean
+}
+
+type Mutation {
+    moduleALogin(code: String): String
+    moduleBLogin(username: String): String
+}

--- a/packages/apollo/tests/duplicate-resolvers/module-a/module-a.module.ts
+++ b/packages/apollo/tests/duplicate-resolvers/module-a/module-a.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleAModule {}

--- a/packages/apollo/tests/duplicate-resolvers/module-a/user.resolver.ts
+++ b/packages/apollo/tests/duplicate-resolvers/module-a/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation('moduleALogin')
+  login(@Args('code') code: string) {
+    return code;
+  }
+}

--- a/packages/apollo/tests/duplicate-resolvers/module-b/module-b.module.ts
+++ b/packages/apollo/tests/duplicate-resolvers/module-b/module-b.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleBModule {}

--- a/packages/apollo/tests/duplicate-resolvers/module-b/user.resolver.ts
+++ b/packages/apollo/tests/duplicate-resolvers/module-b/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation('moduleBLogin')
+  login(@Args('username') username: string) {
+    return username;
+  }
+}

--- a/packages/apollo/tests/e2e/duplicate-resolvers.spec.ts
+++ b/packages/apollo/tests/e2e/duplicate-resolvers.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { ApolloServerBase } from 'apollo-server-core';
+import { gql } from 'graphql-tag';
+import { ApolloDriver } from '../../lib';
+import { AppModule as CodeFirstModule } from '../code-first-duplicate-resolvers/app.module';
+import { AppModule as SchemaFirstModule } from '../duplicate-resolvers/app.module';
+
+describe('Duplicate resolvers', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServerBase;
+
+  describe('code-first', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [CodeFirstModule],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+      const graphqlModule = app.get<GraphQLModule<ApolloDriver>>(GraphQLModule);
+      apolloClient = graphqlModule.graphQlAdapter?.instance;
+    });
+
+    it('should return results from both resolvers', async () => {
+      const response = await apolloClient.executeOperation({
+        query: gql`
+          mutation {
+            moduleALogin(code: "hello")
+            moduleBLogin(username: "bye")
+          }
+        `,
+      });
+
+      expect(response.data).toEqual({
+        moduleALogin: 'hello',
+        moduleBLogin: 'bye',
+      });
+    });
+  });
+
+  describe('schema-first', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [SchemaFirstModule],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+      const graphqlModule = app.get<GraphQLModule<ApolloDriver>>(GraphQLModule);
+      apolloClient = graphqlModule.graphQlAdapter?.instance;
+    });
+
+    it('should return results from both resolvers', async () => {
+      const response = await apolloClient.executeOperation({
+        query: gql`
+          mutation {
+            moduleALogin(code: "hello")
+            moduleBLogin(username: "bye")
+          }
+        `,
+      });
+
+      expect(response.data).toEqual({
+        moduleALogin: 'hello',
+        moduleBLogin: 'bye',
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -11,6 +11,7 @@ import {
 import { ExternalContextCreator } from '@nestjs/core/helpers/external-context-creator';
 import { ParamMetadata } from '@nestjs/core/helpers/interfaces/params-metadata.interface';
 import { Injector } from '@nestjs/core/injector/injector';
+import { CONTROLLER_ID_KEY } from '@nestjs/core/injector/constants';
 import {
   ContextId,
   InstanceWrapper,
@@ -110,6 +111,8 @@ export class ResolversExplorerService extends BaseExplorerService {
     return resolvers
       .filter((resolver) => !!resolver)
       .map((resolver) => {
+        this.assignResolverConstructorUniqueId(instance.constructor, moduleRef);
+
         const createContext = (transform?: Function) =>
           this.createContextCallback(
             instance,
@@ -379,5 +382,16 @@ export class ResolversExplorerService extends BaseExplorerService {
 
       return contextId;
     }
+  }
+
+  private assignResolverConstructorUniqueId(
+    resolverConstructor: any,
+    moduleRef: Module,
+  ) {
+    if (resolverConstructor.hasOwnProperty(CONTROLLER_ID_KEY)) {
+      return;
+    }
+
+    moduleRef.assignControllerUniqueId(resolverConstructor);
   }
 }

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/app.module.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { MercuriusDriverConfig } from '../../lib';
+import { MercuriusDriver } from '../../lib/drivers';
+import { ModuleAModule } from './module-a/module-a.module';
+import { ModuleBModule } from './module-b/module-b.module';
+import { QueryResolver } from './query.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<MercuriusDriverConfig>({
+      driver: MercuriusDriver,
+      autoSchemaFile: true,
+    }),
+    ModuleAModule,
+    ModuleBModule,
+    QueryResolver,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/module-a/module-a.module.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/module-a/module-a.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleAModule {}

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/module-a/user.resolver.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/module-a/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation(() => String, { name: 'moduleALogin' })
+  login(@Args('code') code: string) {
+    return code;
+  }
+}

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/module-b/module-b.module.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/module-b/module-b.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleBModule {}

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/module-b/user.resolver.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/module-b/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation(() => String, { name: 'moduleBLogin' })
+  login(@Args('username') username: string) {
+    return username;
+  }
+}

--- a/packages/mercurius/tests/code-first-duplicate-resolvers/query.resolver.ts
+++ b/packages/mercurius/tests/code-first-duplicate-resolvers/query.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class QueryResolver {
+  @Query(() => Boolean, { name: '_' })
+  test() {
+    return true;
+  }
+}

--- a/packages/mercurius/tests/duplicate-resolvers/app.module.ts
+++ b/packages/mercurius/tests/duplicate-resolvers/app.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
+import { MercuriusDriverConfig } from '../../lib';
+import { MercuriusDriver } from '../../lib/drivers';
+import { ModuleAModule } from './module-a/module-a.module';
+import { ModuleBModule } from './module-b/module-b.module';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<MercuriusDriverConfig>({
+      driver: MercuriusDriver,
+      typePaths: [join(__dirname, '*.graphql')],
+    }),
+    ModuleAModule,
+    ModuleBModule,
+  ],
+  controllers: [],
+  providers: [],
+})
+export class AppModule {}

--- a/packages/mercurius/tests/duplicate-resolvers/duplicate-resolver.graphql
+++ b/packages/mercurius/tests/duplicate-resolvers/duplicate-resolver.graphql
@@ -1,0 +1,8 @@
+type Query {
+    _: Boolean
+}
+
+type Mutation {
+    moduleALogin(code: String): String
+    moduleBLogin(username: String): String
+}

--- a/packages/mercurius/tests/duplicate-resolvers/module-a/module-a.module.ts
+++ b/packages/mercurius/tests/duplicate-resolvers/module-a/module-a.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleAModule {}

--- a/packages/mercurius/tests/duplicate-resolvers/module-a/user.resolver.ts
+++ b/packages/mercurius/tests/duplicate-resolvers/module-a/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation('moduleALogin')
+  login(@Args('code') code: string) {
+    return code;
+  }
+}

--- a/packages/mercurius/tests/duplicate-resolvers/module-b/module-b.module.ts
+++ b/packages/mercurius/tests/duplicate-resolvers/module-b/module-b.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserResolver],
+})
+export class ModuleBModule {}

--- a/packages/mercurius/tests/duplicate-resolvers/module-b/user.resolver.ts
+++ b/packages/mercurius/tests/duplicate-resolvers/module-b/user.resolver.ts
@@ -1,0 +1,9 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class UserResolver {
+  @Mutation('moduleBLogin')
+  login(@Args('username') username: string) {
+    return username;
+  }
+}

--- a/packages/mercurius/tests/e2e/duplicate-resolvers.spec.ts
+++ b/packages/mercurius/tests/e2e/duplicate-resolvers.spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { AppModule as CodeFirstModule } from '../code-first-duplicate-resolvers/app.module';
+import { AppModule as SchemaFirstModule } from '../duplicate-resolvers/app.module';
+
+describe('Duplicate resolvers', () => {
+  let app: INestApplication;
+
+  describe('code-first', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [CodeFirstModule],
+      }).compile();
+
+      app = module.createNestApplication(new FastifyAdapter());
+      await app.init();
+    });
+
+    it('should return results from both resolvers', async () => {
+      const fastifyInstance = app.getHttpAdapter().getInstance();
+      await fastifyInstance.ready();
+
+      const response = await fastifyInstance.graphql(`
+        mutation {
+          moduleALogin(code:"hello")
+          moduleBLogin(username:"bye")
+        }
+      `);
+
+      expect(response.data).toEqual({
+        moduleALogin: 'hello',
+        moduleBLogin: 'bye',
+      });
+    });
+  });
+
+  describe('schema-first', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [SchemaFirstModule],
+      }).compile();
+
+      app = module.createNestApplication(new FastifyAdapter());
+      await app.init();
+    });
+
+    it('should return results from both resolvers', async () => {
+      const fastifyInstance = app.getHttpAdapter().getInstance();
+      await fastifyInstance.ready();
+
+      const response = await fastifyInstance.graphql(`
+        mutation {
+          moduleALogin(code:"hello")
+          moduleBLogin(username:"bye")
+        }
+      `);
+
+      expect(response.data).toEqual({
+        moduleALogin: 'hello',
+        moduleBLogin: 'bye',
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The resolver metadata cache currently uses the resolver name for the key as shown below

https://github.com/nestjs/nest/blob/39ec4cda7363aac3551ff0f1b83feb41ba2f0bf6/packages/core/helpers/handler-metadata-storage.ts#L60-L63

This causes issues if we have two resolvers in different modules but with the same name and identical method signatures. For controllers, each controller gets a unique ID that is used as the key in the cache as shown below:

https://github.com/nestjs/nest/blob/39ec4cda7363aac3551ff0f1b83feb41ba2f0bf6/packages/core/injector/module.ts#L461-L462

Add code to set up unique IDs for resolvers as well so that cache retrieval is correct.

Issue Number: #1907


## What is the new behavior?

Each resolver gets a unique ID so that it can be retrieved correctly from the metadata cache. The solution re-uses the ID key that controllers also use so I worry that that may cause confusion. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
