### PR TITLE
test: fix jest config for jest 29

### DIFF
--- a/packages/apollo/tests/jest-e2e-fed2.ts
+++ b/packages/apollo/tests/jest-e2e-fed2.ts
@@ -22,15 +22,10 @@ const config: Config.InitialOptions = {
     '^graphql/(.*)$': '<rootDir>/../../node_modules/graphql-16/$1',
   },
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
 };
 
 export default config;

--- a/packages/apollo/tests/jest-e2e.ts
+++ b/packages/apollo/tests/jest-e2e.ts
@@ -13,15 +13,10 @@ const config: Config.InitialOptions = {
   testPathIgnorePatterns: ['.fed([1-9]).spec.ts$'],
   moduleNameMapper,
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
 };
 
 export default config;

--- a/packages/graphql/tests/jest-e2e.json
+++ b/packages/graphql/tests/jest-e2e.json
@@ -4,11 +4,9 @@
   "testEnvironment": "node",
   "testRegex": ".spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  },
-  "globals": {
-    "ts-jest": {
-      "tsconfig": "<rootDir>/../tsconfig.spec.json"
-    }
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      { "tsconfig": "<rootDir>/../tsconfig.spec.json" }
+    ]
   }
 }

--- a/packages/mercurius/tests/jest-e2e.ts
+++ b/packages/mercurius/tests/jest-e2e.ts
@@ -12,15 +12,10 @@ const config: Config.InitialOptions = {
   testRegex: '.spec.ts$',
   moduleNameMapper,
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
 };
 
 export default config;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Jest 29 changed the config schema to no longer use `globals` with `ts-jest`. The `test:e2e` script fails with type issues.

## What is the new behavior?

This PR fixes the configs to longer fail on our `test:e2e` script.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
