### PR TITLE
feat(graphql): Throw an error when multiple resolvers define the same field

### DIFF
--- a/packages/graphql/lib/interfaces/build-schema-options.interface.ts
+++ b/packages/graphql/lib/interfaces/build-schema-options.interface.ts
@@ -46,4 +46,9 @@ export interface BuildSchemaOptions {
    * Array of global field middleware functions
    */
   fieldMiddleware?: FieldMiddleware[];
+
+  /**
+   * Set to true if it should throw an error when the same Query / Mutation field is defined more than once
+   */
+  noDuplicateFields?: boolean;
 }

--- a/packages/graphql/lib/interfaces/build-schema-options.interface.ts
+++ b/packages/graphql/lib/interfaces/build-schema-options.interface.ts
@@ -50,5 +50,5 @@ export interface BuildSchemaOptions {
   /**
    * Set to true if it should throw an error when the same Query / Mutation field is defined more than once
    */
-  noDuplicateFields?: boolean;
+  noDuplicatedFields?: boolean;
 }

--- a/packages/graphql/lib/schema-builder/errors/multiple-fields-with-same-name.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/multiple-fields-with-same-name.error.ts
@@ -1,0 +1,7 @@
+export class MultipleFieldsWithSameNameError extends Error {
+  constructor(field: string, objectTypeName: string) {
+    super(
+      `Cannot define multiple fields with the same name "${field}" for type ${objectTypeName}`,
+    );
+  }
+}

--- a/packages/graphql/lib/schema-builder/errors/multiple-fields-with-same-name.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/multiple-fields-with-same-name.error.ts
@@ -1,7 +1,7 @@
 export class MultipleFieldsWithSameNameError extends Error {
   constructor(field: string, objectTypeName: string) {
     super(
-      `Cannot define multiple fields with the same name "${field}" for type ${objectTypeName}`,
+      `Cannot define multiple fields with the same name "${field}" for type "${objectTypeName}"`,
     );
   }
 }

--- a/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
@@ -69,7 +69,7 @@ export class RootTypeFactory {
 
         const key = handler.schemaName;
 
-        if (fieldConfigMap[key] && options.noDuplicateFields) {
+        if (fieldConfigMap[key] && options.noDuplicatedFields) {
           throw new MultipleFieldsWithSameNameError(key, objectTypeName);
         }
 

--- a/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
@@ -69,7 +69,7 @@ export class RootTypeFactory {
 
         const key = handler.schemaName;
 
-        if (fieldConfigMap[key]) {
+        if (fieldConfigMap[key] && options.noDuplicateFields) {
           throw new MultipleFieldsWithSameNameError(key, objectTypeName);
         }
 

--- a/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/root-type.factory.ts
@@ -6,6 +6,7 @@ import { OrphanedReferenceRegistry } from '../services/orphaned-reference.regist
 import { ArgsFactory } from './args.factory';
 import { AstDefinitionNodeFactory } from './ast-definition-node.factory';
 import { OutputTypeFactory } from './output-type.factory';
+import { MultipleFieldsWithSameNameError } from '../errors/multiple-fields-with-same-name.error';
 
 export type FieldsFactory<T = any, U = any> = (
   handlers: ResolverTypeMetadata[],
@@ -27,7 +28,7 @@ export class RootTypeFactory {
     objectTypeName: 'Subscription' | 'Mutation' | 'Query',
     options: BuildSchemaOptions,
     fieldsFactory: FieldsFactory = (handlers) =>
-      this.generateFields(handlers, options),
+      this.generateFields(handlers, options, objectTypeName),
   ): GraphQLObjectType {
     const handlers = typeRefs
       ? resolversMetadata.filter((query) => typeRefs.includes(query.target))
@@ -45,6 +46,7 @@ export class RootTypeFactory {
   generateFields<T = any, U = any>(
     handlers: ResolverTypeMetadata[],
     options: BuildSchemaOptions,
+    objectTypeName: string,
   ): GraphQLFieldConfigMap<T, U> {
     const fieldConfigMap: GraphQLFieldConfigMap<T, U> = {};
 
@@ -66,6 +68,11 @@ export class RootTypeFactory {
         );
 
         const key = handler.schemaName;
+
+        if (fieldConfigMap[key]) {
+          throw new MultipleFieldsWithSameNameError(key, objectTypeName);
+        }
+
         fieldConfigMap[key] = {
           type,
           args: this.argsFactory.create(handler.methodArgs, options),

--- a/packages/graphql/tests/schema-builder/factories/root-type.factory.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/root-type.factory.spec.ts
@@ -54,7 +54,7 @@ describe('RootTypeFactory', () => {
           expect(() =>
             rootTypeFactory.generateFields(
               metadata,
-              { noDuplicateFields: true },
+              { noDuplicatedFields: true },
               objectTypeName,
             ),
           ).toThrow(MultipleFieldsWithSameNameError);
@@ -63,7 +63,7 @@ describe('RootTypeFactory', () => {
         it('should create GraphQL fields with noDuplicateFields: false', () => {
           const fields = rootTypeFactory.generateFields(
             metadata,
-            { noDuplicateFields: false },
+            { noDuplicatedFields: false },
             objectTypeName,
           );
           expect(fields).toHaveProperty('bool');
@@ -94,7 +94,7 @@ describe('RootTypeFactory', () => {
 
         const fields = rootTypeFactory.generateFields(
           queriesMetadata,
-          { noDuplicateFields: true },
+          { noDuplicatedFields: true },
           'Query',
         );
 

--- a/packages/graphql/tests/schema-builder/factories/root-type.factory.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/root-type.factory.spec.ts
@@ -1,0 +1,119 @@
+import { Test } from '@nestjs/testing';
+import {
+  GraphQLSchemaBuilderModule,
+  Query,
+  Mutation,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../../lib';
+import { RootTypeFactory } from '../../../lib/schema-builder/factories/root-type.factory';
+import { LazyMetadataStorage } from '../../../lib/schema-builder/storages/lazy-metadata.storage';
+import { MultipleFieldsWithSameNameError } from '../../../lib/schema-builder/errors/multiple-fields-with-same-name.error';
+import { GraphQLNonNull } from 'graphql';
+
+describe('RootTypeFactory', () => {
+  let rootTypeFactory: RootTypeFactory;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    rootTypeFactory = module.get(RootTypeFactory);
+  });
+
+  afterEach(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  describe('generateFields', () => {
+    describe('when duplicate queries are defined', () => {
+      beforeEach(() => {
+        LazyMetadataStorage.load([
+          booleanResolverFactory(Query),
+          booleanResolverFactory(Query),
+        ]);
+        TypeMetadataStorage.compile();
+      });
+
+      it('should throw an error', () => {
+        const queriesMetadata = TypeMetadataStorage.getQueriesMetadata();
+
+        expect(() =>
+          rootTypeFactory.generateFields(queriesMetadata, {}, 'Query'),
+        ).toThrow(MultipleFieldsWithSameNameError);
+      });
+    });
+
+    describe('when duplicate mutations are defined', () => {
+      beforeEach(() => {
+        LazyMetadataStorage.load([
+          booleanResolverFactory(Mutation),
+          booleanResolverFactory(Mutation),
+        ]);
+        TypeMetadataStorage.compile();
+      });
+
+      it('should throw an error', () => {
+        const mutationsMetadata = TypeMetadataStorage.getMutationsMetadata();
+
+        expect(() =>
+          rootTypeFactory.generateFields(mutationsMetadata, {}, 'Mutation'),
+        ).toThrow(MultipleFieldsWithSameNameError);
+      });
+    });
+
+    describe('when no duplicate queries are found', () => {
+      beforeEach(() => {
+        LazyMetadataStorage.load([
+          booleanResolverFactory(Query),
+          StringResolver,
+        ]);
+        TypeMetadataStorage.compile();
+      });
+
+      it('should correctly create GraphQL fields', () => {
+        const queriesMetadata = TypeMetadataStorage.getQueriesMetadata();
+
+        const fields = rootTypeFactory.generateFields(
+          queriesMetadata,
+          {},
+          'Query',
+        );
+
+        expect(fields).toMatchObject({
+          bool: {
+            type: expect.any(GraphQLNonNull),
+            args: {},
+            resolve: undefined,
+          },
+          str: {
+            type: expect.any(GraphQLNonNull),
+            args: {},
+            resolve: undefined,
+          },
+        });
+      });
+    });
+  });
+});
+
+function booleanResolverFactory(Decorator: typeof Query | typeof Mutation) {
+  @Resolver()
+  class BooleanResolver {
+    @Decorator(() => Boolean)
+    bool() {
+      return true;
+    }
+  }
+
+  return BooleanResolver;
+}
+
+@Resolver()
+class StringResolver {
+  @Query(() => String)
+  str() {
+    return '';
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)

Closes #2143

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?

Issue Number: #2134

## What is the new behavior?

A new `buildSchemaOptions` field `noDuplicateFields` is added.
If it is set to `true`, an error is thrown when defining a Query/Mutation field multiple times

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
