### PR TITLE
fix(@nestjs/graphql): always add scalars to generated schema

### DIFF
--- a/packages/apollo/tests/code-first/other/sample-scalar.ts
+++ b/packages/apollo/tests/code-first/other/sample-scalar.ts
@@ -1,0 +1,30 @@
+import { CustomScalar, Scalar } from '@nestjs/graphql';
+import { Kind } from 'graphql';
+
+@Scalar('SampleScalar')
+export class SampleScalar implements CustomScalar<string, string> {
+  description = 'A sample scalar';
+
+  parseValue(value: unknown): string {
+    if (typeof value !== 'string') {
+      throw new Error(`Expected a string, but got ${value}.`);
+    }
+    return value;
+  }
+
+  serialize(obj: unknown): string {
+    if (typeof obj !== 'string') {
+      throw new Error(`Expected a string, but got ${obj}.`);
+    }
+    return obj;
+  }
+
+  parseLiteral(ast: any): string {
+    if (ast.kind === Kind.STRING) {
+      return ast.value;
+    }
+    throw new Error(
+      `Expected value of kind 'STRING', but got kind '${ast.kind}'.`,
+    );
+  }
+}

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -17,6 +17,7 @@ import { DirectionsResolver } from '../code-first/directions/directions.resolver
 import { SampleOrphanedEnum } from '../code-first/enums/sample-orphaned.enum';
 import { AbstractResolver } from '../code-first/other/abstract.resolver';
 import { SampleOrphanedType } from '../code-first/other/sample-orphaned.type';
+import { SampleScalar } from '../code-first/other/sample-scalar';
 import { IngredientsResolver } from '../code-first/recipes/ingredients.resolver';
 import { IRecipesResolver } from '../code-first/recipes/irecipes.resolver';
 import { Recipe } from '../code-first/recipes/models/recipe';
@@ -55,6 +56,7 @@ describe('Code-first - schema factory', () => {
           AbstractResolver,
           IRecipesResolver,
         ],
+        [SampleScalar],
         { orphanedTypes: [SampleOrphanedType, SampleOrphanedEnum] },
       );
 
@@ -68,6 +70,21 @@ describe('Code-first - schema factory', () => {
     it('should match schema snapshot', () => {
       expect(GRAPHQL_SDL_FILE_HEADER + printSchema(schema)).toEqual(
         printedSchemaSnapshot,
+      );
+    });
+    it('should add scalar to schema', () => {
+      // makeExecutableSchema throws if a resolver is defined without being
+      // present in the schema. We should include scalars even if they're not
+      // used by any field (yet)
+      const type = introspectionSchema.types.find(
+        ({ name }) => name === 'SampleScalar',
+      );
+      expect(type).toEqual(
+        expect.objectContaining({
+          description: 'A sample scalar',
+          kind: 'SCALAR',
+          name: 'SampleScalar',
+        }),
       );
     });
     it('should define 5 queries', async () => {

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -63,6 +63,9 @@ enum SampleOrphanedEnum {
   White
 }
 
+"""A sample scalar"""
+scalar SampleScalar
+
 type Query {
   """get recipe by id"""
   recipe(

--- a/packages/graphql/lib/schema-builder/graphql-schema.factory.ts
+++ b/packages/graphql/lib/schema-builder/graphql-schema.factory.ts
@@ -70,7 +70,10 @@ export class GraphQLSchemaFactory {
       mutation: this.mutationTypeFactory.create(resolvers, options),
       query: this.queryTypeFactory.create(resolvers, options),
       subscription: this.subscriptionTypeFactory.create(resolvers, options),
-      types: this.orphanedTypesFactory.create(options.orphanedTypes),
+      types: [
+        ...this.orphanedTypesFactory.create(options.orphanedTypes),
+        ...(options.scalarsMap ?? []).map(({ scalar }) => scalar),
+      ],
       directives: [...specifiedDirectives, ...(options.directives ?? [])],
     });
 


### PR DESCRIPTION
`makeExecutableSchema` throws if a resolver is defined without being present in the schema. We should include scalars even if they're not used by any field (yet)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If an app uses GraphQL code-first schema generation and had a scalar without referencing this from any resolver, the app will throw an error upon startup: `Error: "XYZ" defined in resolvers, but not in schema`

Issue Number: #2255 

## What is the new behavior?

Always include scalars in the generated schema by explicitly adding them to the list of types, instead of relying on the implicit inclusion via a resolver in- or output.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A