### PR TITLE
fix: enable non-nullable, defaulted fields in code-first schema

### DIFF
--- a/packages/apollo/tests/code-first/recipes/dto/new-recipe.input.ts
+++ b/packages/apollo/tests/code-first/recipes/dto/new-recipe.input.ts
@@ -12,6 +12,9 @@ export class NewRecipeInput {
   @Length(30, 255)
   description?: string;
 
+  @Field({ nullable: false, defaultValue: 'published' })
+  status: string;
+
   @Type(() => String)
   @Field((type) => [String])
   ingredients: string[];

--- a/packages/apollo/tests/code-first/recipes/dto/recipes.args.ts
+++ b/packages/apollo/tests/code-first/recipes/dto/recipes.args.ts
@@ -2,11 +2,14 @@ import { ArgsType, Field, Int } from '@nestjs/graphql';
 import { Max, Min } from 'class-validator';
 @ArgsType()
 export class RecipesArgs {
-  @Field((type) => Int, { description: 'number of items to skip' })
+  @Field((type) => Int, {
+    description: 'number of items to skip',
+    nullable: true,
+  })
   @Min(0)
   skip: number = 0;
 
-  @Field((type) => Int)
+  @Field((type) => Int, { nullable: true })
   @Min(1)
   @Max(50)
   take: number = 25;

--- a/packages/apollo/tests/code-first/recipes/recipes.resolver.ts
+++ b/packages/apollo/tests/code-first/recipes/recipes.resolver.ts
@@ -31,6 +31,7 @@ export class RecipesResolver {
     @Args('id', {
       defaultValue: '1',
       description: 'recipe id',
+      nullable: true,
     })
     id: string,
   ): Promise<IRecipe> {

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -652,6 +652,20 @@ describe('Code-first - schema factory', () => {
               type: { kind: TypeKind.SCALAR, name: 'String', ofType: null },
             },
             {
+              defaultValue: '"published"',
+              description: null,
+              name: 'status',
+              type: {
+                kind: TypeKind.NON_NULL,
+                name: null,
+                ofType: {
+                  kind: TypeKind.SCALAR,
+                  name: 'String',
+                  ofType: null,
+                },
+              },
+            },
+            {
               defaultValue: null,
               description: null,
               name: 'ingredients',

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -105,6 +105,7 @@ input NewRecipeInput {
   """recipe title"""
   title: String!
   description: String
+  status: String! = "published"
   ingredients: [String!]!
 }
 
@@ -163,6 +164,7 @@ type Mutation {
 input NewRecipeInput {
   description: String
   ingredients: [String!]!
+  status: String! = "published"
 
   """recipe title"""
   title: String!

--- a/packages/graphql/lib/schema-builder/factories/input-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type.factory.ts
@@ -38,7 +38,6 @@ export class InputTypeFactory {
       hostType,
       inputType,
       typeOptions,
-      true,
     );
   }
 }

--- a/packages/graphql/lib/schema-builder/factories/output-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/output-type.factory.ts
@@ -32,11 +32,6 @@ export class OutputTypeFactory {
         throw new CannotDetermineOutputTypeError(hostType);
       }
     }
-    return this.typeMapperService.mapToGqlType(
-      hostType,
-      gqlType,
-      typeOptions,
-      false,
-    );
+    return this.typeMapperService.mapToGqlType(hostType, gqlType, typeOptions);
   }
 }

--- a/packages/graphql/lib/schema-builder/services/type-mapper.service.ts
+++ b/packages/graphql/lib/schema-builder/services/type-mapper.service.ts
@@ -67,18 +67,7 @@ export class TypeMapperSevice {
       );
     }
 
-    let isNotNullable: boolean;
-    if (isInputTypeCtx) {
-      /**
-       * The input values (e.g., args) remain "nullable"
-       * even if the "defaultValue" is specified.
-       */
-      isNotNullable =
-        isUndefined(options.defaultValue) &&
-        (!options.nullable || options.nullable === 'items');
-    } else {
-      isNotNullable = !options.nullable || options.nullable === 'items';
-    }
+    const isNotNullable = !options.nullable || options.nullable === 'items';
     return isNotNullable
       ? (new GraphQLNonNull(graphqlType) as T)
       : (graphqlType as T);

--- a/packages/graphql/lib/schema-builder/services/type-mapper.service.ts
+++ b/packages/graphql/lib/schema-builder/services/type-mapper.service.ts
@@ -54,7 +54,6 @@ export class TypeMapperSevice {
     hostType: string,
     typeRef: T,
     options: TypeOptions,
-    isInputTypeCtx: boolean,
   ): T {
     this.validateTypeOptions(hostType, options);
     let graphqlType: T | GraphQLList<T> | GraphQLNonNull<T> = typeRef;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a not-nullable field has a defaultValue it generates a nullable input field:
```typescript
@InputType()
export class AcmeInput {
  @Field({ nullable: false, defaultValue: 'foo' })
  bar: string;
}
```
it generates:
```gql
input AcmeInput {
  bar: String = "foo"
}
```


## What is the new behavior?
The above will generate this schema:
```gql
input AcmeInput {
  bar: String! = "foo"
}
```

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Some of the tests (e.g. the snapshots) capture the erroneous functionality, so to keep this PR specific to the change, some existing fields had `nullable: true` set to match the existing tests.