### PR TITLE
fix(graphql): type helpers metadata inheriting

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -46,12 +46,20 @@
     "@apollo/subgraph": "^0.1.5 || ^0.3.0 || ^0.4.0 || ^2.0.0",
     "@nestjs/common": "^8.2.3 || ^9.0.0",
     "@nestjs/core": "^8.2.3 || ^9.0.0",
+    "class-transformer": "*",
+    "class-validator": "*",
     "graphql": "^15.8.0 || ^16.0.0",
     "reflect-metadata": "^0.1.13",
     "ts-morph": "^13.0.2 || ^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "peerDependenciesMeta": {
     "@apollo/subgraph": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    },
+    "class-validator": {
       "optional": true
     },
     "ts-morph": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Yarn PnP doesn't implicitly inherit transitive peer dependencies class-validator and class-transformer from @nestjs/mapped-types. Therefore @nestjs/mapped-types doesn't see class-validator/class-transform and doesn't inherit their metadata.

Similar to: https://github.com/nestjs/swagger/issues/2169

## What is the new behavior?

Specify class-validator and class-transformer as optional dependencies.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No