### PR TITLE
feat(federation): Update the Apollo Federation 2 `@link` imports

### DIFF
--- a/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
+++ b/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
@@ -11,6 +11,10 @@ export class TypeDefsFederation2Decorator {
         '@external',
         '@override',
         '@requires',
+        '@tag',
+        '@inaccessible',
+        '@extends',
+        '@provides',
       ],
       importUrl = 'https://specs.apollo.dev/federation/v2.0',
     } = config;

--- a/packages/graphql/lib/interfaces/schema-file-config.interface.ts
+++ b/packages/graphql/lib/interfaces/schema-file-config.interface.ts
@@ -10,7 +10,7 @@ export interface Federation2Config {
   version: 2;
   /**
    * The imported directives
-   * @default ['@key', '@shareable', '@external', '@override', '@requires']
+   * @default ['@key', '@shareable', '@external', '@override', '@requires', '@tag', '@inaccessible', '@extends', '@provides']
    */
   directives?: (string | AliasDirectiveImport)[];
   /**


### PR DESCRIPTION
Imports 4 additional Apollo Federation 2 directives to help ensure the generated `_service` `sdl` is fully Apollo Federation 2.0 spec compatible.

- [`@tag`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#tag)
- [`@inaccessible`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#inaccessible)
- [`@extends`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#extends)
- [`@provides`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#provides)