### PR TITLE
feat(mercurius): add plugins option

### DIFF
--- a/packages/mercurius/lib/drivers/mercurius-gateway.driver.ts
+++ b/packages/mercurius/lib/drivers/mercurius-gateway.driver.ts
@@ -3,6 +3,7 @@ import { FastifyInstance, FastifyLoggerInstance } from 'fastify';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 import mercurius from 'mercurius';
 import { MercuriusDriverConfig } from '../interfaces/mercurius-driver-config.interface';
+import { registerMercuriusPlugin } from '../utils/register-mercurius-plugin.util';
 
 export class MercuriusGatewayDriver extends AbstractGraphQLDriver<MercuriusDriverConfig> {
   get instance(): FastifyInstance<
@@ -22,10 +23,12 @@ export class MercuriusGatewayDriver extends AbstractGraphQLDriver<MercuriusDrive
       throw new Error(`No support for current HttpAdapter: ${platformName}`);
     }
 
+    const { plugins, ...mercuriusOptions } = options;
     const app = httpAdapter.getInstance<FastifyInstance>();
     await app.register(mercurius, {
-      ...options,
+      ...mercuriusOptions,
     });
+    await registerMercuriusPlugin(app, plugins);
   }
 
   public async stop(): Promise<void> {}

--- a/packages/mercurius/lib/drivers/mercurius.driver.ts
+++ b/packages/mercurius/lib/drivers/mercurius.driver.ts
@@ -5,6 +5,7 @@ import { printSchema } from 'graphql';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 import mercurius from 'mercurius';
 import { MercuriusDriverConfig } from '../interfaces/mercurius-driver-config.interface';
+import { registerMercuriusPlugin } from '../utils/register-mercurius-plugin.util';
 
 export class MercuriusDriver extends AbstractGraphQLDriver<MercuriusDriverConfig> {
   get instance(): FastifyInstance<
@@ -17,7 +18,7 @@ export class MercuriusDriver extends AbstractGraphQLDriver<MercuriusDriverConfig
   }
 
   public async start(mercuriusOptions: MercuriusDriverConfig) {
-    const options =
+    const { plugins, ...options } =
       await this.graphQlFactory.mergeWithSchema<MercuriusDriverConfig>(
         mercuriusOptions,
       );
@@ -39,6 +40,7 @@ export class MercuriusDriver extends AbstractGraphQLDriver<MercuriusDriverConfig
     await app.register(mercurius, {
       ...options,
     });
+    await registerMercuriusPlugin(app, plugins);
   }
 
   public async stop(): Promise<void> {}

--- a/packages/mercurius/lib/interfaces/index.ts
+++ b/packages/mercurius/lib/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './mercurius-driver-config.interface';
 export * from './mercurius-federation-driver-config.interface';
 export * from './mercurius-gateway-driver-config.interface';
+export * from './mercurius-plugin.interface';

--- a/packages/mercurius/lib/interfaces/mercurius-driver-config.interface.ts
+++ b/packages/mercurius/lib/interfaces/mercurius-driver-config.interface.ts
@@ -4,8 +4,11 @@ import {
   GqlOptionsFactory,
 } from '@nestjs/graphql';
 import { MercuriusOptions } from 'mercurius';
+import { MercuriusPlugins } from './mercurius-plugin.interface';
 
-export type MercuriusDriverConfig = GqlModuleOptions & MercuriusOptions;
+export type MercuriusDriverConfig = GqlModuleOptions &
+  MercuriusOptions &
+  MercuriusPlugins;
 
 export type MercuriusDriverConfigFactory =
   GqlOptionsFactory<MercuriusDriverConfig>;

--- a/packages/mercurius/lib/interfaces/mercurius-gateway-driver-config.interface.ts
+++ b/packages/mercurius/lib/interfaces/mercurius-gateway-driver-config.interface.ts
@@ -4,10 +4,12 @@ import {
   GqlOptionsFactory,
 } from '@nestjs/graphql';
 import { MercuriusCommonOptions, MercuriusGatewayOptions } from 'mercurius';
+import { MercuriusPlugin } from './mercurius-plugin.interface';
 
 export type MercuriusGatewayDriverConfig = GqlModuleOptions &
   MercuriusCommonOptions &
-  MercuriusGatewayOptions;
+  MercuriusGatewayOptions &
+  MercuriusPlugin;
 
 export type MercuriusGatewayDriverConfigFactory =
   GqlOptionsFactory<MercuriusGatewayDriverConfig>;

--- a/packages/mercurius/lib/interfaces/mercurius-plugin.interface.ts
+++ b/packages/mercurius/lib/interfaces/mercurius-plugin.interface.ts
@@ -1,0 +1,24 @@
+import {
+  FastifyPluginAsync,
+  FastifyPluginCallback,
+  FastifyPluginOptions,
+  FastifyRegisterOptions,
+} from 'fastify';
+
+export interface MercuriusPlugin<
+  Options extends FastifyPluginOptions = unknown,
+> {
+  plugin:
+    | FastifyPluginCallback<Options>
+    | FastifyPluginAsync<Options>
+    | Promise<{
+        default: FastifyPluginCallback<Options>;
+      }>;
+  options?: FastifyRegisterOptions<Options>;
+}
+
+export interface MercuriusPlugins<
+  Options extends FastifyPluginOptions = unknown,
+> {
+  plugins?: MercuriusPlugin<Options>[];
+}

--- a/packages/mercurius/lib/utils/register-mercurius-plugin.util.ts
+++ b/packages/mercurius/lib/utils/register-mercurius-plugin.util.ts
@@ -1,0 +1,21 @@
+import { FastifyInstance } from 'fastify';
+import { MercuriusPlugin } from '../interfaces/mercurius-plugin.interface';
+import { isArray, isNull, isUndefined } from './validation.util';
+
+export async function registerMercuriusPlugin(
+  app: FastifyInstance,
+  plugins?: MercuriusPlugin[],
+): Promise<void> {
+  if (
+    isUndefined(plugins) ||
+    isNull(plugins) ||
+    !isArray(plugins) ||
+    plugins.length === 0
+  ) {
+    return;
+  }
+
+  for (const plugin of plugins) {
+    await app.register(plugin.plugin, plugin.options);
+  }
+}

--- a/packages/mercurius/lib/utils/validation.util.ts
+++ b/packages/mercurius/lib/utils/validation.util.ts
@@ -1,0 +1,9 @@
+export const isUndefined = (value: unknown): value is undefined => {
+  return typeof value === 'undefined';
+};
+
+export const isNull = (value: unknown): value is null => value === null;
+
+export const isArray = <T>(value: unknown): value is T[] => {
+  return Array.isArray(value);
+};

--- a/packages/mercurius/tests/e2e/code-first-plugin.spec.ts
+++ b/packages/mercurius/tests/e2e/code-first-plugin.spec.ts
@@ -1,0 +1,51 @@
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { FastifyInstance } from 'fastify';
+import { ApplicationModule } from '../plugins/code-first-plugin/app.module';
+import { NEW_PLUGIN_URL } from '../plugins/mocks/utils/constants';
+
+describe('Code-first with plugins', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
+
+    app = module.createNestApplication(new FastifyAdapter());
+    await app.init();
+  });
+
+  it('should get the plugin', async () => {
+    const fastifyInstance: FastifyInstance = app.getHttpAdapter().getInstance();
+    await fastifyInstance.ready();
+
+    const response = await fastifyInstance.inject({
+      method: 'GET',
+      url: NEW_PLUGIN_URL,
+    });
+    const data = JSON.parse(response.body);
+    expect(fastifyInstance.printPlugins().includes('mockPlugin')).toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(data.from).toBe(NEW_PLUGIN_URL);
+  });
+
+  it('it should query dog', async () => {
+    const fastifyInstance: FastifyInstance = app.getHttpAdapter().getInstance();
+    await fastifyInstance.ready();
+
+    const response = await fastifyInstance.graphql(`
+      {
+        getAnimalName
+      }
+    `);
+    expect(response.data).toEqual({
+      getAnimalName: 'dog',
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/mercurius/tests/e2e/graphql-federation-plugin.spec.ts
+++ b/packages/mercurius/tests/e2e/graphql-federation-plugin.spec.ts
@@ -1,0 +1,72 @@
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { FastifyInstance } from 'fastify';
+import { AppModule as PostsModule } from '../plugins/graphql-federation-plugin/posts-service/federation-posts.module';
+import { AppModule as UsersModule } from '../plugins/graphql-federation-plugin/users-service/federation-users.module';
+import {
+  BASE_PLUGIN_URL,
+  NEW_PLUGIN_URL,
+} from '../plugins/mocks/utils/constants';
+
+describe('GraphQL Federation with plugins', () => {
+  let app: INestApplication;
+
+  describe('UsersService', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [UsersModule],
+      }).compile();
+
+      app = module.createNestApplication(new FastifyAdapter());
+      await app.init();
+    });
+
+    it('should get the plugin for users', async () => {
+      const fastifyInstance: FastifyInstance = app
+        .getHttpAdapter()
+        .getInstance();
+      await fastifyInstance.ready();
+
+      const response = await fastifyInstance.inject({
+        method: 'GET',
+        url: NEW_PLUGIN_URL,
+      });
+      const data = JSON.parse(response.body);
+      expect(fastifyInstance.printPlugins().includes('mockPlugin')).toBe(true);
+      expect(response.statusCode).toBe(200);
+      expect(data.from).toBe(NEW_PLUGIN_URL);
+    });
+  });
+
+  describe('PostsService', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [PostsModule],
+      }).compile();
+
+      app = module.createNestApplication(new FastifyAdapter());
+      await app.init();
+    });
+
+    it('should get the plugin for posts', async () => {
+      const fastifyInstance: FastifyInstance = app
+        .getHttpAdapter()
+        .getInstance();
+      await fastifyInstance.ready();
+
+      const response = await fastifyInstance.inject({
+        method: 'GET',
+        url: BASE_PLUGIN_URL,
+      });
+      const data = JSON.parse(response.body);
+      expect(fastifyInstance.printPlugins().includes('mockPlugin')).toBe(true);
+      expect(response.statusCode).toBe(200);
+      expect(data.from).toBe(BASE_PLUGIN_URL);
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/mercurius/tests/e2e/graphql-gateway-plugin.spec.ts
+++ b/packages/mercurius/tests/e2e/graphql-gateway-plugin.spec.ts
@@ -1,0 +1,55 @@
+import { INestApplication } from '@nestjs/common';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule as PostsModule } from '../graphql-federation/posts-service/federation-posts.module';
+import { AppModule as UsersModule } from '../graphql-federation/users-service/federation-users.module';
+import { AppModule as GatewayModule } from '../plugins/graphql-federation-plugin/gateway/gateway.module';
+import { BASE_PLUGIN_URL } from '../plugins/mocks/utils/constants';
+
+describe('GraphQL Gateway', () => {
+  let postsApp: INestApplication;
+  let usersApp: INestApplication;
+  let gatewayApp: INestApplication;
+
+  beforeEach(async () => {
+    const usersModule = await Test.createTestingModule({
+      imports: [UsersModule],
+    }).compile();
+
+    usersApp = usersModule.createNestApplication(new FastifyAdapter());
+    await usersApp.listen(3011);
+
+    const postsModule = await Test.createTestingModule({
+      imports: [PostsModule],
+    }).compile();
+
+    postsApp = postsModule.createNestApplication(new FastifyAdapter());
+    await postsApp.listen(3012);
+
+    const gatewayModule = await Test.createTestingModule({
+      imports: [GatewayModule],
+    }).compile();
+
+    gatewayApp = gatewayModule.createNestApplication(new FastifyAdapter());
+    await gatewayApp.init();
+
+    await gatewayApp.getHttpAdapter().getInstance().ready();
+  });
+
+  it('should get the plugin url', () => {
+    return request(gatewayApp.getHttpServer())
+      .get(BASE_PLUGIN_URL)
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect({
+        from: BASE_PLUGIN_URL,
+      });
+  });
+
+  afterEach(async () => {
+    await postsApp.close();
+    await usersApp.close();
+    await gatewayApp.close();
+  });
+});

--- a/packages/mercurius/tests/plugins/code-first-plugin/app.module.ts
+++ b/packages/mercurius/tests/plugins/code-first-plugin/app.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { MercuriusDriverConfig } from '../../../lib';
+import { MercuriusDriver } from '../../../lib/drivers';
+import { mockPlugin } from '../mocks/mock.plugin';
+import { NEW_PLUGIN_URL } from '../mocks/utils/constants';
+import { DogsModule } from './dogs/dogs.module';
+
+@Module({
+  imports: [
+    DogsModule,
+    GraphQLModule.forRoot<MercuriusDriverConfig>({
+      driver: MercuriusDriver,
+      autoSchemaFile: true,
+      plugins: [
+        {
+          plugin: mockPlugin,
+          options: {
+            url: NEW_PLUGIN_URL,
+          },
+        },
+      ],
+    }),
+  ],
+})
+export class ApplicationModule {}

--- a/packages/mercurius/tests/plugins/code-first-plugin/dogs/dogs.module.ts
+++ b/packages/mercurius/tests/plugins/code-first-plugin/dogs/dogs.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { DogsResolver } from './dogs.resolver';
+
+@Module({
+  providers: [DogsResolver],
+})
+export class DogsModule {}

--- a/packages/mercurius/tests/plugins/code-first-plugin/dogs/dogs.resolver.ts
+++ b/packages/mercurius/tests/plugins/code-first-plugin/dogs/dogs.resolver.ts
@@ -1,0 +1,9 @@
+import { Query, Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class DogsResolver {
+  @Query((returns) => String)
+  getAnimalName(): string {
+    return 'dog';
+  }
+}

--- a/packages/mercurius/tests/plugins/code-first-plugin/main.ts
+++ b/packages/mercurius/tests/plugins/code-first-plugin/main.ts
@@ -1,0 +1,17 @@
+import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import mercurius from 'mercurius';
+import { ApplicationModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(ApplicationModule, new FastifyAdapter());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      exceptionFactory: (errors) =>
+        new mercurius.ErrorWithProps('Validation error', { errors }, 200),
+    }),
+  );
+  await app.listen(3010);
+}
+bootstrap();

--- a/packages/mercurius/tests/plugins/graphql-federation-plugin/gateway/gateway.module.ts
+++ b/packages/mercurius/tests/plugins/graphql-federation-plugin/gateway/gateway.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { MercuriusGatewayDriver } from '../../../../lib/drivers';
+import { mockPlugin } from '../../mocks/mock.plugin';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot({
+      driver: MercuriusGatewayDriver,
+      gateway: {
+        services: [
+          { name: 'users', url: 'http://localhost:3011/graphql' },
+          { name: 'posts', url: 'http://localhost:3012/graphql' },
+        ],
+      },
+      plugins: [
+        {
+          plugin: mockPlugin,
+        },
+      ],
+    }),
+  ],
+})
+export class AppModule {}

--- a/packages/mercurius/tests/plugins/graphql-federation-plugin/posts-service/federation-posts.module.ts
+++ b/packages/mercurius/tests/plugins/graphql-federation-plugin/posts-service/federation-posts.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
+import {
+  MercuriusDriverConfig,
+  MercuriusFederationDriver,
+} from '../../../../lib';
+import { PostsModule } from '../../../graphql-federation/posts-service/posts/posts.module';
+import { upperDirectiveTransformer } from '../../../graphql-federation/posts-service/posts/upper.directive';
+import { mockPlugin } from '../../mocks/mock.plugin';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<MercuriusDriverConfig>({
+      driver: MercuriusFederationDriver,
+      typePaths: [
+        join(
+          __dirname,
+          '../../../graphql-federation/posts-service',
+          '**/*.graphql',
+        ),
+      ],
+      transformSchema: (schema) => upperDirectiveTransformer(schema, 'upper'),
+      federationMetadata: true,
+      plugins: [
+        {
+          plugin: mockPlugin,
+        },
+      ],
+    }),
+    PostsModule,
+  ],
+})
+export class AppModule {}

--- a/packages/mercurius/tests/plugins/graphql-federation-plugin/users-service/federation-users.module.ts
+++ b/packages/mercurius/tests/plugins/graphql-federation-plugin/users-service/federation-users.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
+import {
+  MercuriusDriverConfig,
+  MercuriusFederationDriver,
+} from '../../../../lib';
+import { UsersModule } from '../../../graphql-federation/users-service/users/users.module';
+import { mockPlugin } from '../../mocks/mock.plugin';
+import { NEW_PLUGIN_URL } from '../../mocks/utils/constants';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<MercuriusDriverConfig>({
+      driver: MercuriusFederationDriver,
+      typePaths: [
+        join(
+          __dirname,
+          '../../../graphql-federation/users-service',
+          '**/*.graphql',
+        ),
+      ],
+      federationMetadata: true,
+      plugins: [
+        {
+          plugin: mockPlugin,
+          options: {
+            url: NEW_PLUGIN_URL,
+          },
+        },
+      ],
+    }),
+    UsersModule,
+  ],
+})
+export class AppModule {}

--- a/packages/mercurius/tests/plugins/mocks/interfaces/plugin-options.interface.ts
+++ b/packages/mercurius/tests/plugins/mocks/interfaces/plugin-options.interface.ts
@@ -1,0 +1,3 @@
+export interface PluginOptions {
+  url: string;
+}

--- a/packages/mercurius/tests/plugins/mocks/interfaces/plugin-response.interface.ts
+++ b/packages/mercurius/tests/plugins/mocks/interfaces/plugin-response.interface.ts
@@ -1,0 +1,3 @@
+export interface PluginResponse {
+  from: string;
+}

--- a/packages/mercurius/tests/plugins/mocks/mock.plugin.ts
+++ b/packages/mercurius/tests/plugins/mocks/mock.plugin.ts
@@ -1,0 +1,15 @@
+import { FastifyInstance } from 'fastify';
+import { PluginOptions } from './interfaces/plugin-options.interface';
+import { BASE_PLUGIN_URL } from './utils/constants';
+import { pluginResponse } from './utils/plugin-response';
+
+export async function mockPlugin(
+  fastify: FastifyInstance,
+  options?: PluginOptions,
+) {
+  const url = options?.url ?? BASE_PLUGIN_URL;
+
+  fastify.get(url, async (request, reply) => {
+    return pluginResponse(url);
+  });
+}

--- a/packages/mercurius/tests/plugins/mocks/utils/constants.ts
+++ b/packages/mercurius/tests/plugins/mocks/utils/constants.ts
@@ -1,0 +1,2 @@
+export const NEW_PLUGIN_URL = '/new-plugin-url';
+export const BASE_PLUGIN_URL = '/mock-plugin';

--- a/packages/mercurius/tests/plugins/mocks/utils/plugin-response.ts
+++ b/packages/mercurius/tests/plugins/mocks/utils/plugin-response.ts
@@ -1,0 +1,7 @@
+import { PluginResponse } from '../interfaces/plugin-response.interface';
+
+export function pluginResponse(url: string): PluginResponse {
+  return {
+    from: url,
+  };
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

There is no plugins options on the Mercurius Adapter.


## What is the new behavior?

Adds a plugins option, to be precise an array of the new `MercuriusPlugin` interface.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

So this is an update version of an old [PR](https://github.com/nestjs/graphql/pull/2106), what is different:

- Renamed `MercuriusDriverPlugin` to `MercuriusPlugin`;
- Removed repeated files in tests;
- Removed state from drivers (`delete options.plugins`);
- Uses `for of` instead of a normal for loop for readability.
