### PR TITLE
fix(@nestjs/apollo): Add in missing peer dependencies.

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -47,6 +47,7 @@
   },
   "peerDependencies": {
     "@apollo/gateway": "^0.44.1 || ^0.46.0 || ^0.48.0 || ^0.49.0 || ^0.50.0 || ^2.0.0",
+    "@apollo/subgraph": "^2.0.0",
     "@nestjs/common": "^8.2.3 || ^9.0.0",
     "@nestjs/core": "^8.2.3 || ^9.0.0",
     "@nestjs/graphql": "^10.0.0",
@@ -57,6 +58,9 @@
   },
   "peerDependenciesMeta": {
     "@apollo/gateway": {
+      "optional": true
+    },
+    "@apollo/subgraph": {
       "optional": true
     },
     "apollo-server-core": {

--- a/packages/mercurius/package.json
+++ b/packages/mercurius/package.json
@@ -35,10 +35,16 @@
     "mercurius-integration-testing": "6.0.1"
   },
   "peerDependencies": {
+    "@apollo/subgraph": "^2.0.0",
     "@nestjs/common": "^8.2.3 || ^9.0.0",
     "@nestjs/graphql": "^10.0.0",
     "fastify": "^3.25.0 || ^4.0.0",
     "graphql": "^15.8.0 || ^16.0.0",
     "mercurius": "^8.12.0 || ^9.0.0 || ^10.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@apollo/subgraph": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
The `@netsjs/apollo` and `@nestjs/mercurius` packages rely on using `loadPackage('@apollo/subgraph')` but this package isn't reflected in either's package.json. This is incompatible with `pnpm`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
