### PR TITLE
fix(graphql): similar directive sdls on multiple fields fail

### DIFF
--- a/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
@@ -4,9 +4,11 @@ import { MetadataListByNameCollection } from './metadata-list-by-name.collection
 export class FieldDirectiveCollection extends MetadataListByNameCollection<PropertyDirectiveMetadata> {
   sdls = new Set<string>();
   fieldNames = new Set<string>();
+  uniqueCombinations = new Set<string>();
 
   add(value: PropertyDirectiveMetadata) {
-    if (this.sdls.has(value.sdl) && this.fieldNames.has(value.fieldName)) {
+    const combinationKey = `${value.sdl}${value.fieldName}`;
+    if (this.uniqueCombinations.has(combinationKey)) {
       return;
     }
 
@@ -14,6 +16,7 @@ export class FieldDirectiveCollection extends MetadataListByNameCollection<Prope
 
     this.sdls.add(value.sdl);
     this.fieldNames.add(value.fieldName);
+    this.uniqueCombinations.add(combinationKey);
     this.globalArray?.push(value);
   }
 }

--- a/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
@@ -8,7 +8,9 @@ export class FieldDirectiveCollection extends MetadataListByNameCollection<Prope
 
   add(value: PropertyDirectiveMetadata) {
     const combinationKey = `${value.sdl}${value.fieldName}`;
-    if (this.uniqueCombinations.has(combinationKey))   return;
+    if (this.uniqueCombinations.has(combinationKey)) { 
+        return;
+    }
 
     super.add(value, value.fieldName);
 

--- a/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
@@ -9,7 +9,7 @@ export class FieldDirectiveCollection extends MetadataListByNameCollection<Prope
   add(value: PropertyDirectiveMetadata) {
     const combinationKey = `${value.sdl}${value.fieldName}`;
     if (this.uniqueCombinations.has(combinationKey)) { 
-        return;
+      return;
     }
 
     super.add(value, value.fieldName);

--- a/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/field-directive.collection.ts
@@ -8,9 +8,7 @@ export class FieldDirectiveCollection extends MetadataListByNameCollection<Prope
 
   add(value: PropertyDirectiveMetadata) {
     const combinationKey = `${value.sdl}${value.fieldName}`;
-    if (this.uniqueCombinations.has(combinationKey)) {
-      return;
-    }
+    if (this.uniqueCombinations.has(combinationKey))   return;
 
     super.add(value, value.fieldName);
 

--- a/packages/graphql/tests/schema-builder/storages/field-directive.collection.spec.ts
+++ b/packages/graphql/tests/schema-builder/storages/field-directive.collection.spec.ts
@@ -63,6 +63,27 @@ describe('FieldDirectiveCollection', () => {
     expect(map.getByName('bar')).toEqual([directive1Alt]);
   });
 
+  it('should add 2 different fields with the same directives', () => {
+    const map = new FieldDirectiveCollection();
+    const directive1Alt: PropertyDirectiveMetadata = {
+      fieldName: 'bar',
+      sdl: '@foo',
+      target: () => {},
+    };
+    const directive2Alt: PropertyDirectiveMetadata = {
+      fieldName: 'foo',
+      sdl: '@bar',
+      target: () => {},
+    };
+    map.add(directive1);
+    map.add(directive2);
+    map.add(directive1Alt);
+    map.add(directive2Alt);
+
+    expect(map.getByName('foo')).toEqual([directive1, directive2Alt]);
+    expect(map.getByName('bar')).toEqual([directive2, directive1Alt]);
+  });
+
   it('should NOT the same directive on the same field twice', () => {
     const map = new FieldDirectiveCollection();
     map.add(directive1);


### PR DESCRIPTION
Similar directive sdls on multiple fields fail if applied to the same target. I stumbled upon this while migrating from NestJS 8 to 9. It still baffles me how this could have happened from all the code I analysed and read, but I guess there's a good underlying reason for this bug.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
I ran into a problem in which the following code doesn't not register all applied directives:

```ts
@Resolver(() => TypeSomething)
export class TwoResolversWithSimilarDirectives {

	@Query((returns) => TypeSomething)
	@Directive('@hasPermission(permissions: APP_ACCOUNTS_READ)')
	@Directive('@limit')
	async resolver1() {
		return {}
	}

	@Query((returns) => TypeSomething)
	@Directive('@hasPermission(permissions: APP_ACCOUNTS_READ)')
	@Directive('@limit')
	async resolver2() {
		return {}
	}
}
```

As can be seen, I've got 2 resolver methods in 1 target both of which the same SDLs are applied to. Yet, what currently happens is that the second resolver only has one directive applied to the GraphQL schema and not both as intended. 

Issue Number: N/A


## What is the new behavior?
All expected directives are applied to the corresponding fields

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
