### PR TITLE
fix(graphql): prevent potential memory leak for mostly falsy filter function

### DIFF
--- a/packages/apollo/tests/subscriptions/async-iterator.spec.ts
+++ b/packages/apollo/tests/subscriptions/async-iterator.spec.ts
@@ -1,0 +1,59 @@
+// Old implementation of with-filter was leaking memory with was visible
+// in case with long lived subscriptions where filter is skipping most of messages
+
+import { $$asyncIterator } from 'iterall';
+import { setFlagsFromString } from 'v8';
+import { runInNewContext } from 'vm';
+import {
+  AsyncIterator,
+  createAsyncIterator,
+} from '../../lib/utils/async-iterator.util';
+
+setFlagsFromString('--expose_gc');
+const gc = runInNewContext('gc');
+
+// https://github.com/apollographql/graphql-subscriptions/issues/212
+it('does not leak memory with promise chain #memory', async function () {
+  jest.setTimeout(5000);
+
+  let stopped = false;
+  let index = 0;
+  const asyncIterator: AsyncIterator<any> = {
+    async next() {
+      if (stopped) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+      index += 1;
+      return new Promise((resolve) => setImmediate(resolve)).then(() => ({
+        done: false,
+        value: index,
+      }));
+    },
+    return() {
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw(error) {
+      return Promise.reject(error);
+    },
+    [$$asyncIterator]() {
+      return this;
+    },
+  };
+
+  const filteredAsyncIterator = await createAsyncIterator(
+    Promise.resolve(asyncIterator),
+    () => stopped,
+  );
+
+  gc();
+  const heapUsed = process.memoryUsage().heapUsed;
+  const nextPromise = filteredAsyncIterator.next();
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  gc();
+  const heapUsed2 = process.memoryUsage().heapUsed;
+  stopped = true;
+  await nextPromise;
+
+  // Heap memory goes up for less than 1%
+  expect(Math.max(0, heapUsed2 - heapUsed) / heapUsed).toBeLessThan(0.01);
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

As https://github.com/apollographql/graphql-subscriptions/pull/209 saids, a filter function that returns mostly false can cause loops in Promises. This leads to a memory leak.

Issue Number: N/A
Relevant Issue: https://github.com/apollographql/graphql-subscriptions/issues/212


## What is the new behavior?

Applied changes of above PR to existing function `createAsyncIterator`.
Now it does not stack up awaiting Promises.

Credit to. @urossmolnik


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
