### PR TITLE
fix(graphql): generate fields as optional when they contain arguments

### DIFF
--- a/packages/graphql/lib/graphql-ast.explorer.ts
+++ b/packages/graphql/lib/graphql-ast.explorer.ts
@@ -314,7 +314,8 @@ export class GraphQLAstExplorer {
     return {
       name: propertyName,
       type: this.addSymbolIfRoot(type),
-      hasQuestionToken: !required,
+      hasQuestionToken:
+        !required || (item as FieldDefinitionNode).arguments?.length > 0,
     };
   }
 

--- a/packages/graphql/tests/graphql-ast.explorer.spec.ts
+++ b/packages/graphql/tests/graphql-ast.explorer.spec.ts
@@ -1,0 +1,33 @@
+import { GraphQLAstExplorer } from '../lib';
+import { gql } from 'graphql-tag';
+
+describe('GraphQLAstExplorer', () => {
+  describe('explore', () => {
+    it('should generate fields as optional when they contain arguments', () => {
+      const astExplorer = new GraphQLAstExplorer();
+
+      const document = gql`
+        type Cat {
+          id: Int!
+          name: String!
+          weight(unit: String!): Int!
+        }
+
+        type Query {
+          cat(id: ID!): Cat
+        }
+      `;
+
+      astExplorer
+        .explore(document, '/dev/null', 'interface', {})
+        .then((sourceFile) => {
+          expect(
+            sourceFile
+              .getStructure()
+              .statements[0].properties.find((prop) => prop.name === 'weight')!
+              .hasQuestionToken,
+          ).toBe(true);
+        });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Fields with arguments are usually resolved using a separate method with the `@ResolveField()` annotation.
Having such field generated as a _required_ property thus proves quite cumbersome as it forces setting a value for this field in the result of parent `@Query()` method.

## What is the new behavior?

Fields with arguments are always generated as optional.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

## Other information

Using `/dev/null` as argument to `explore` looks unfortunate to me, please advise for a better solution.