### PR TITLE
Fix/apollo context

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -238,23 +238,26 @@ export abstract class ApolloBaseDriver<
     originalOptions: ApolloDriverConfig = { ...targetOptions },
   ) {
     if (!targetOptions.context) {
-      targetOptions.context = async ({ req, request }) => ({
-        req: req ?? request,
-      });
+      targetOptions.context = async (contextOrRequest) => {
+        return {
+          // New ApolloServer fastify integration has Request as first parameter to the Context function
+          req: contextOrRequest.req ?? contextOrRequest,
+        };
+      };
     } else if (isFunction(targetOptions.context)) {
       targetOptions.context = async (...args: unknown[]) => {
         const ctx = await (originalOptions.context as Function)(...args);
-        const { req, request } = args[0] as Record<string, unknown>;
-        return this.assignReqProperty(ctx, req ?? request);
+        const contextOrRequest = args[0] as Record<string, unknown>;
+        return this.assignReqProperty(
+          ctx,
+          contextOrRequest.req ?? contextOrRequest,
+        );
       };
     } else {
-      targetOptions.context = async ({
-        req,
-        request,
-      }: Record<string, unknown>) => {
+      targetOptions.context = async (contextOrRequest) => {
         return this.assignReqProperty(
           originalOptions.context as Record<string, any>,
-          req ?? request,
+          contextOrRequest.req ?? contextOrRequest,
         );
       };
     }

--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -133,7 +133,12 @@ export abstract class ApolloBaseDriver<
 
     await server.start();
 
-    app.use(path, expressMiddleware(server));
+    app.use(
+      path,
+      expressMiddleware(server, {
+        context: options.context,
+      }),
+    );
 
     this.apolloServer = server;
   }
@@ -171,7 +176,9 @@ export abstract class ApolloBaseDriver<
     app.route({
       url: path,
       method: ['GET', 'POST', 'OPTIONS'],
-      handler: fastifyApolloHandler(server),
+      handler: fastifyApolloHandler(server, {
+        context: options.context,
+      }),
     });
 
     this.apolloServer = server;

--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -238,7 +238,9 @@ export abstract class ApolloBaseDriver<
     originalOptions: ApolloDriverConfig = { ...targetOptions },
   ) {
     if (!targetOptions.context) {
-      targetOptions.context = ({ req, request }) => ({ req: req ?? request });
+      targetOptions.context = async ({ req, request }) => ({
+        req: req ?? request,
+      });
     } else if (isFunction(targetOptions.context)) {
       targetOptions.context = async (...args: unknown[]) => {
         const ctx = await (originalOptions.context as Function)(...args);
@@ -246,7 +248,10 @@ export abstract class ApolloBaseDriver<
         return this.assignReqProperty(ctx, req ?? request);
       };
     } else {
-      targetOptions.context = ({ req, request }: Record<string, unknown>) => {
+      targetOptions.context = async ({
+        req,
+        request,
+      }: Record<string, unknown>) => {
         return this.assignReqProperty(
           originalOptions.context as Record<string, any>,
           req ?? request,

--- a/packages/apollo/tests/e2e/custom-context.spec.ts
+++ b/packages/apollo/tests/e2e/custom-context.spec.ts
@@ -1,0 +1,52 @@
+import { INestApplication } from '@nestjs/common';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { CustomContextModule } from '../graphql/custom-context/custom-context.module';
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+
+describe('GraphQL (custom context)', () => {
+  let app: INestApplication;
+
+  describe.each([
+    ['Express', new ExpressAdapter()],
+    ['Fastify', new FastifyAdapter()],
+  ])('Custom context with %s', (_, adapter) => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [CustomContextModule],
+      }).compile();
+
+      app = module.createNestApplication(adapter);
+      await app.init();
+
+      const instance = app.getHttpAdapter().getInstance();
+      if ('ready' in instance && typeof instance.ready === 'function') {
+        await instance.ready();
+      }
+    });
+
+    it('should return query result', () => {
+      return request(app.getHttpServer())
+        .post('/graphql')
+        .send({
+          operationName: null,
+          variables: {},
+          query: `
+          {
+            fooFromContext
+          }
+          `,
+        })
+        .expect(200, {
+          data: {
+            fooFromContext: 'bar',
+          },
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+});

--- a/packages/apollo/tests/graphql/custom-context/custom-context.module.ts
+++ b/packages/apollo/tests/graphql/custom-context/custom-context.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriverConfig } from '../../../lib';
+import { ApolloDriver } from '../../../lib/drivers';
+import { CustomContextResolver } from './custom-context.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+      context: (request) => ({
+        foo: 'bar',
+        request,
+      }),
+    }),
+  ],
+  providers: [CustomContextResolver],
+})
+export class CustomContextModule {}

--- a/packages/apollo/tests/graphql/custom-context/custom-context.resolver.ts
+++ b/packages/apollo/tests/graphql/custom-context/custom-context.resolver.ts
@@ -1,0 +1,9 @@
+import { Resolver, Query, Context } from '@nestjs/graphql';
+
+@Resolver()
+export class CustomContextResolver {
+  @Query(() => String)
+  fooFromContext(@Context() ctx: Record<string, unknown>) {
+    return ctx.foo;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Using ApolloServer, the context function wasn't passed to either the Express middleware or the Fastify handler.

Also, the `FastifyRequest` object was not available in context while using Fastify due to how the new ApolloServer - Fastify integration expose it

## What is the new behavior?

Context function is picked by ApolloServer and available to every resolvers.
The request object is correctly available as `req` property to all contexts for both Express and Fastify.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
https://github.com/nestjs/graphql/pull/2636#discussion_r1110035919