### PR TITLE
feat(federation): Update Apollo Federation v2.3 `@link` imports

### DIFF
--- a/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
+++ b/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
@@ -6,17 +6,19 @@ export class TypeDefsFederation2Decorator {
   decorate(typeDefs: string, config: Federation2Config = { version: 2 }) {
     const {
       directives = [
-        '@key',
-        '@shareable',
-        '@external',
-        '@override',
-        '@requires',
-        '@tag',
-        '@inaccessible',
+        '@composeDirective',
         '@extends',
+        '@external',
+        '@inaccessible',
+        '@interfaceObject',
+        '@key',
+        '@override',
         '@provides',
+        '@requires',
+        '@shareable',
+        '@tag',
       ],
-      importUrl = 'https://specs.apollo.dev/federation/v2.0',
+      importUrl = 'https://specs.apollo.dev/federation/v2.3',
     } = config;
     const mappedDirectives = directives
       .map((directive) => {

--- a/packages/graphql/lib/interfaces/schema-file-config.interface.ts
+++ b/packages/graphql/lib/interfaces/schema-file-config.interface.ts
@@ -10,12 +10,12 @@ export interface Federation2Config {
   version: 2;
   /**
    * The imported directives
-   * @default ['@key', '@shareable', '@external', '@override', '@requires', '@tag', '@inaccessible', '@extends', '@provides']
+   * @default ['@composeDirective', '@extends', '@external', '@inaccessible', '@interfaceObject', '@key', '@override', '@provides', '@requires', '@shareable', '@tag']
    */
   directives?: (string | AliasDirectiveImport)[];
   /**
    * The import link
-   * @default 'https://specs.apollo.dev/federation/v2.0'
+   * @default 'https://specs.apollo.dev/federation/v2.3'
    */
   importUrl?: string;
 }


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using code-first solution, `nest-js/graphql` module will auto import Federation v2.0 directives. Federation spec is evolving and additional `@composeDirective` and `@interfaceObject` were added in the subsequent minor versions.

Users can explicitly add new directives but it is an unnecessary extra step

```javascript
GraphQLModule.forRoot<ApolloFederationDriverConfig>({
  driver: ApolloFederationDriver,
  autoSchemaFile: {
    federation: {
      version: 2,
      directives: [
        '@composeDirective',
        '@extends',
        '@external',
        '@inaccessible',
        '@interfaceObject',
        '@key',
        '@override',
        '@provides',
        '@requires',
        '@shareable',
        '@tag',
      ],
      importUrl: 'https://specs.apollo.dev/federation/v2.3'
    }
  }
}),
``` 

Issue Number: https://github.com/nestjs/graphql/issues/2659

## What is the new behavior?

Adds following Apollo Federation auto imports:

* [`@composeDirective`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#composedirective)
* [`@interfaceObject`](https://www.apollographql.com/docs/federation/federated-types/federated-directives#interfaceobject)

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
While this PR does not change any API, it could be considered a breaking change as code-first users will be automatically upgraded to the latest version of the federation spec (`v2.3`) which requires usage of a compatible supergraph composition version and Gateway/Router (i.e. users won't be able to create their supergraph until both router and composition are updated to compatible version).

Users can still opt-in to a specific federation version by explicitly providing `FederationConfig`, i.e. they will still be able to downgrade to old spec import (i.e. the reverse of current behavior where they have to explicitly opt-in to new spec version).

## Other information

This PR adds auto import of `@composeDirective` but it does not address the https://github.com/nestjs/graphql/issues/2539 which most likely requires some additional changes.
