### PR TITLE
fix: metadata storage refactor caused a bug in field resolver

### DIFF
--- a/packages/graphql/lib/schema-builder/collections/metadata-by-name.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/metadata-by-name.collection.ts
@@ -3,7 +3,7 @@ export class MetadataByNameCollection<T> {
   protected all: (T extends any[] ? T[number] : T)[] = [];
 
   getAll() {
-    return this.all;
+    return [...this.all];
   }
 
   getByName(name: string) {


### PR DESCRIPTION
When creating a field resolver with an input we reached a bad edge case where the fields array was fetched via reference instead of an immutable array. This caused artifacts appearing in the array and bad metadata appeared when trying to parse the schema.

Returning a new array from the metadata instead of the reference for the existing array solves this issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
https://github.com/nestjs/graphql/issues/2360#issuecomment-1475362011

Issue Number: 2360


## What is the new behavior?
Fields resolver works correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
