### PR TITLE
feat(graphql): Allow ObjectType to inherit description

### DIFF
--- a/packages/graphql/lib/decorators/object-type.decorator.ts
+++ b/packages/graphql/lib/decorators/object-type.decorator.ts
@@ -27,6 +27,11 @@ export interface ObjectTypeOptions {
    * Interfaces implemented by this object type.
    */
   implements?: Function | Function[] | (() => Function | Function[]);
+  /**
+   * If `true`, direct descendant classes will inherit the parent's description if own description is not set.
+   * Also works on classes marked with `isAbstract: true`.
+   */
+  inheritDescription?: boolean;
 }
 
 /**
@@ -56,13 +61,20 @@ export function ObjectType(
     : [undefined, nameOrOptions];
 
   return (target) => {
+    const parentType = TypeMetadataStorage.getObjectTypeMetadataByTarget(
+      Object.getPrototypeOf(target),
+    );
+
     const addObjectTypeMetadata = () =>
       TypeMetadataStorage.addObjectTypeMetadata({
         name: name || target.name,
         target,
-        description: options.description,
+        description: parentType?.inheritDescription
+          ? options.description ?? parentType?.description
+          : options.description,
         interfaces: options.implements,
         isAbstract: options.isAbstract,
+        inheritDescription: options.inheritDescription,
       });
 
     // This function must be called eagerly to allow resolvers

--- a/packages/graphql/lib/schema-builder/metadata/class.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/class.metadata.ts
@@ -9,4 +9,5 @@ export interface ClassMetadata {
   directives?: DirectiveMetadata[];
   extensions?: Record<string, unknown>;
   properties?: PropertyMetadata[];
+  inheritDescription?: boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently there is no way to inherit the description from generic `ObjectType` marked with `isAbstract`. Which means for every new `ObjectType` that extends a generic we need to reuse the description from somewhere else in order to have a tidy documentation.

Issue Number: N/A


## What is the new behavior?

Introduces a new `inheritDescription` option to `ObjectTypeOptions`, when set to `true`, direct descendant classes will inherit the parent's description if own description is not set.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
