### PR TITLE
fix(@nestjs/graphql): plugin windows paths

### DIFF
--- a/packages/graphql/lib/plugin/utils/plugin-utils.ts
+++ b/packages/graphql/lib/plugin/utils/plugin-utils.ts
@@ -109,7 +109,6 @@ export function replaceImportPath(typeReference: string, fileName: string) {
   importPath = importPath.slice(2, importPath.length - 1);
 
   let relativePath = posix.relative(posix.dirname(fileName), importPath);
-  relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
 
   const nodeModulesText = 'node_modules';
   const nodeModulePos = relativePath.indexOf(nodeModulesText);


### PR DESCRIPTION
removed the addition of a '.' suffix so paths
are not broken on windows anymore

fixes nestjs/graphql#2661

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently a suffix is added for relative paths not starting with a `.` which breaks imports on only on Windows.

Issue Number: N/A


## What is the new behavior?
The suffix isn't added anymore.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
