### PR TITLE
fix(graphql): correct argument mapping in resolve-field-decorator

### DIFF
--- a/packages/apollo/tests/code-first/recipes/recipes.resolver.ts
+++ b/packages/apollo/tests/code-first/recipes/recipes.resolver.ts
@@ -86,6 +86,20 @@ export class RecipesResolver {
     return 10;
   }
 
+  @ResolveField(undefined, {
+    middleware: [async (_, next) => (await next()).trim()],
+  })
+  tips1(): string {
+    return ' use oil sparingly ';
+  }
+
+  @ResolveField('tips2', {
+    middleware: [async (_, next) => (await next()).trim()],
+  })
+  tipsSecond(): string {
+    return ' add salt gradually ';
+  }
+
   @Mutation((returns) => Boolean)
   async removeRecipe(@Args('id') id: string) {
     return this.recipesService.remove(id);

--- a/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
+++ b/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
@@ -2707,6 +2707,28 @@ exports[`Serialized graph should generate a post-initialization graph and match 
         }
       },
       {
+        "id": "327064966_tips1",
+        "type": "graphql-entrypoint",
+        "methodName": "tips1",
+        "className": "RecipesResolver",
+        "classNodeId": "327064966",
+        "metadata": {
+          "key": "tips1",
+          "parentType": "Recipe"
+        }
+      },
+      {
+        "id": "327064966_tipsSecond",
+        "type": "graphql-entrypoint",
+        "methodName": "tipsSecond",
+        "className": "RecipesResolver",
+        "classNodeId": "327064966",
+        "metadata": {
+          "key": "tips2",
+          "parentType": "Recipe"
+        }
+      },
+      {
         "id": "327064966_removeRecipe",
         "type": "graphql-entrypoint",
         "methodName": "removeRecipe",

--- a/packages/apollo/tests/e2e/code-first-schema.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-schema.spec.ts
@@ -437,6 +437,30 @@ describe('Code-first - schema factory', () => {
                 ofType: { kind: TypeKind.SCALAR, name: 'Float', ofType: null },
               },
             },
+            {
+              args: [],
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'tips1',
+              type: {
+                kind: TypeKind.NON_NULL,
+                name: null,
+                ofType: { kind: TypeKind.SCALAR, name: 'String', ofType: null },
+              },
+            },
+            {
+              args: [],
+              deprecationReason: null,
+              description: null,
+              isDeprecated: false,
+              name: 'tips2',
+              type: {
+                kind: TypeKind.NON_NULL,
+                name: null,
+                ofType: { kind: TypeKind.SCALAR, name: 'String', ofType: null },
+              },
+            },
           ],
         }),
       );

--- a/packages/apollo/tests/e2e/code-first.spec.ts
+++ b/packages/apollo/tests/e2e/code-first.spec.ts
@@ -83,6 +83,8 @@ describe('Code-first', () => {
               name
             }
             rating
+            tips1
+            tips2
             interfaceResolver
             averageRating
           }
@@ -100,6 +102,8 @@ describe('Code-first', () => {
             },
           ],
           rating: 10,
+          tips1: 'use oil sparingly',
+          tips2: 'add salt gradually',
           interfaceResolver: true,
           averageRating: 0.5,
         },
@@ -112,6 +116,8 @@ describe('Code-first', () => {
             },
           ],
           rating: 10,
+          tips1: 'use oil sparingly',
+          tips2: 'add salt gradually',
           interfaceResolver: true,
           averageRating: 0.5,
         },
@@ -130,6 +136,8 @@ describe('Code-first', () => {
             }
             rating
             averageRating
+            tips1
+            tips2
           }
         }
       `,
@@ -145,6 +153,8 @@ describe('Code-first', () => {
           ],
           rating: 10,
           averageRating: 0.5,
+          tips1: 'use oil sparingly',
+          tips2: 'add salt gradually',
         },
         {
           id: '2',
@@ -155,6 +165,8 @@ describe('Code-first', () => {
           ],
           rating: 10,
           averageRating: 0.5,
+          tips1: 'use oil sparingly',
+          tips2: 'add salt gradually',
         },
       ],
     });

--- a/packages/apollo/tests/utils/printed-schema.snapshot.ts
+++ b/packages/apollo/tests/utils/printed-schema.snapshot.ts
@@ -24,6 +24,8 @@ type Recipe implements IRecipe {
   ingredients: [Ingredient!]!
   count(type: String, status: String): Float!
   rating: Float!
+  tips1: String!
+  tips2: String!
 }
 
 """
@@ -200,6 +202,8 @@ type Recipe implements IRecipe {
   lastRate: Float
   rating: Float!
   tags: [String!]!
+  tips1: String!
+  tips2: String!
   title: String!
 }
 

--- a/packages/graphql/lib/decorators/resolve-field.decorator.ts
+++ b/packages/graphql/lib/decorators/resolve-field.decorator.ts
@@ -1,5 +1,9 @@
 import { SetMetadata, Type } from '@nestjs/common';
-import { isFunction, isObject } from '@nestjs/common/utils/shared.utils';
+import {
+  isFunction,
+  isObject,
+  isString,
+} from '@nestjs/common/utils/shared.utils';
 import {
   FIELD_RESOLVER_MIDDLEWARE_METADATA,
   RESOLVER_NAME_METADATA,
@@ -70,12 +74,17 @@ export function ResolveField(
     key?: string,
     descriptor?: any,
   ) => {
-    // eslint-disable-next-line prefer-const
-    let [propertyName, typeFunc, options] = isFunction(propertyNameOrFunc)
-      ? typeFuncOrOptions && typeFuncOrOptions.name
-        ? [typeFuncOrOptions.name, propertyNameOrFunc, typeFuncOrOptions]
-        : [undefined, propertyNameOrFunc, typeFuncOrOptions]
-      : [propertyNameOrFunc, typeFuncOrOptions, resolveFieldOptions];
+    const propertyName = isString(propertyNameOrFunc)
+      ? propertyNameOrFunc
+      : typeFuncOrOptions?.name;
+    const typeFunc = isFunction(propertyNameOrFunc)
+      ? propertyNameOrFunc
+      : isFunction(typeFuncOrOptions)
+      ? typeFuncOrOptions
+      : undefined;
+    let options = isFunction(typeFuncOrOptions)
+      ? resolveFieldOptions
+      : typeFuncOrOptions;
 
     SetMetadata(RESOLVER_NAME_METADATA, propertyName)(target, key, descriptor);
     SetMetadata(RESOLVER_PROPERTY_METADATA, true)(target, key, descriptor);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In the code-first approach, when specifying undefined as the first argument and passing the ResolveFieldOptions object as the second argument to the @ResolveField function, as shown below:
```
@ResolveField(undefined, {
    nullable: true
  })
  count(): string {
    return 10;
  }
```

An error occurred during schema generation like this:
```
TypeError: explicitTypeFn is not a function

             47 |   if (
             48 |     (!explicitTypeFn && (!implicitType || isNotAllowed)) ||
           > 49 |     (!implicitType && !explicitTypeFn)
                |                                 ^
             50 |   ) {
             51 |     throw new UndefinedTypeError(
             52 |       get(prototype, 'constructor.name'),

             at ../graphql/lib/utils/reflection.utilts.ts:49:33
             at ../graphql/lib/schema-builder/factories/object-type-definition.factory.ts:70:108
                 at Array.forEach (<anonymous>)
             at ObjectTypeDefinitionFactory.generateFields (../graphql/lib/schema-builder/factories/object-type-definition.factory.ts:70:29)
             at ObjectTypeDefinitionFactory.create (../graphql/lib/schema-builder/factories/object-type-definition.factory.ts:48:30)
             at ../graphql/lib/schema-builder/type-definitions.generator.ts:37:92
                 at Array.map (<anonymous>)
             at TypeDefinitionsGenerator.generateObjectTypeDefs (../graphql/lib/schema-builder/type-definitions.generator.ts:37:41)
             at TypeDefinitionsGenerator.generate (../graphql/lib/schema-builder/type-definitions.generator.ts:27:14)
             at GraphQLSchemaFactory.create (../graphql/lib/schema-builder/graphql-schema.factory.ts:39:39)
```

Issue Number: #2587 (although the bug behavior is slightly different)

## What is the new behavior?
The cause of the issue was that the ResolveFieldOptions object passed as an argument was incorrectly assigned to explicitTypeFn due to a bug. This has been fixed to properly map the options.

With this definition:
```
@ResolveField(undefined, {
    nullable: true
  })
  count(): number {
    return 10;
  }
```

The following correct schema is generated:
```
count: Float
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Ideally, it might be better to reconsider the type definition of ResolveField so that it doesn't need to accept 'undefined'. However, I am avoiding this approach as it could lead to breaking changes.

Please let me know if I've made any mistakes or if there's a better way to address this issue! I apologize in advance if I've misunderstood anything.