### PR TITLE
fix(plugin): don't prefix absolute win paths

### DIFF
--- a/packages/graphql/lib/plugin/utils/plugin-utils.ts
+++ b/packages/graphql/lib/plugin/utils/plugin-utils.ts
@@ -1,5 +1,5 @@
 import { head } from 'lodash';
-import { posix } from 'path';
+import { isAbsolute, posix } from 'path';
 import * as ts from 'typescript';
 import {
   getText,
@@ -109,7 +109,10 @@ export function replaceImportPath(typeReference: string, fileName: string) {
   importPath = importPath.slice(2, importPath.length - 1);
 
   let relativePath = posix.relative(posix.dirname(fileName), importPath);
-  relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
+  relativePath =
+    !isAbsolute(relativePath) && relativePath[0] !== '.'
+      ? './' + relativePath
+      : relativePath;
 
   const nodeModulesText = 'node_modules';
   const nodeModulePos = relativePath.indexOf(nodeModulesText);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Compilation fails on Windows in certain cases when using the GraphQL plugin because absolute paths are prefixed with `./`.

Issue Number: #2661

## What is the new behavior?

Don't prefix absolute paths on Windows with `./`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I think this is a temporary solution at best. I'm not sure the `posix` version of `path` methods should be being used for all the logic in the plugin, since things like `posix.relative()` do not behave properly with windows paths. I could maybe create another pull request to switch to the non-posix path methods, but not sure if I'm missing an important reason it's in use.

I also wanted to add a test but it's tricky:

```ts
describe('plugin-utils', () => {
  describe('replaceImportPath', () => {
  
    it('should not replace path on windows', () => {
      const actual = replaceImportPath(
          'import("C:\\\\project\\\\src\\\\author.model").Author',
          'C:\\project\\src\\post.model.ts',
      );

      expect(actual).toStrictEqual({
        typeReference: '"require("C:\\\\project\\\\src\\\\author.model").Author',
        importPath: 'C:/project/src/author.model',
      });
    });
```    

This test fails if run on Linux, since `path.isAbsolute('C:/...')` only returns `true` when run on Windows. I didn't want to complicate things by using Jest to mock path functions. Something like [jest-os-detection](https://github.com/doctolib/jest-os-detection) allows specifying whether a test should be skipped/run depending on the OS, but this is only very useful if CI also runs the test suite on Windows, and I didn't want to make too many changes for this pull request.