### PR TITLE
chore(deps): set @apollo/subgraph as optional

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -56,6 +56,9 @@
     "@apollo/gateway": {
       "optional": true
     },
+    "@apollo/subgraph": {
+      "optional": true
+    },
     "@as-integrations/fastify": {
       "optional": true
     }


### PR DESCRIPTION
Set `@apollo/subgraph` as an optional peer dependency in `@nestjs/apollo`

`@apollo/subgraph` should only be needed if using Apollo Federation/Apollo Gateway.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@apollo/subgraph` is installed regardless if you are using Apollo Federation or not

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

By setting `@apollo/subgraph` to optional those that are relying it being installed as a non-optional peer dependency will need to install it in their packages.

## Other information

`@apollo/subgraph` is already correctly set as an optional peer dependency in `@nestjs/graphql`: https://github.com/nestjs/graphql/blob/master/packages/graphql/package.json#L56-L58