### PR TITLE
fix(graphql): fix directives on arguments

### DIFF
--- a/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
+++ b/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
@@ -1566,6 +1566,22 @@ exports[`Serialized graph should generate a post-initialization graph and match 
       },
       "id": "859295028"
     },
+    "878947487": {
+      "source": "1725932106",
+      "target": "-1155703408",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "GraphQLSchemaBuilderModule",
+        "sourceClassName": "ArgsFactory",
+        "targetClassName": "AstDefinitionNodeFactory",
+        "sourceClassToken": "ArgsFactory",
+        "targetClassToken": "AstDefinitionNodeFactory",
+        "targetModuleName": "GraphQLSchemaBuilderModule",
+        "keyOrIndex": 1,
+        "injectionType": "constructor"
+      },
+      "id": "878947487"
+    },
     "918694211": {
       "source": "954997704",
       "target": "951921130",

--- a/packages/graphql/lib/schema-builder/factories/ast-definition-node.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/ast-definition-node.factory.ts
@@ -130,6 +130,32 @@ export class AstDefinitionNodeFactory {
     };
   }
 
+  createArgNode(
+    name: string,
+    type: GraphQLInputType,
+    directiveMetadata?: DirectiveMetadata[],
+  ): InputValueDefinitionNode | undefined {
+    if (isEmpty(directiveMetadata)) {
+      return;
+    }
+
+    return {
+      kind: Kind.INPUT_VALUE_DEFINITION,
+      type: {
+        kind: Kind.NAMED_TYPE,
+        name: {
+          kind: Kind.NAME,
+          value: type.toString(),
+        },
+      },
+      name: {
+        kind: Kind.NAME,
+        value: name,
+      },
+      directives: directiveMetadata.map(this.createDirectiveNode),
+    };
+  }
+
   private createDirectiveNode(
     directive: DirectiveMetadata,
   ): ConstDirectiveNode {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
(not convinced this is needed for that, and no test already exists for it)
- [ ] Docs have been added / updated (for bug fixes / features)
(same as previous)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, a directive on a argument is entirely ignored and not run nor detected (I'm thinking specifically of fields in ArgsType classes).

## What is the new behavior?

Directives are properly detected and applied, even when using on arguments from ArgsType classes.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
