### PR TITLE
feat(graphql): Add omitDefaultValue option to PartialType

### DIFF
--- a/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
@@ -101,4 +101,31 @@ describe('PartialType', () => {
       });
     });
   });
+
+
+
+  describe('Remove defaultValue', () => {
+    @ObjectType()
+    class CreateFooDto {
+      @Field({ defaultValue: 'foo' })
+      name: string;
+    }
+
+    class UpdateFooDto extends PartialType(CreateFooDto, { omitDefaultValue: true }) {}
+
+    it('should remove defaultValue', async () => {
+      await metadataLoader.load(SERIALIZED_METADATA);
+  
+      const prototype = Object.getPrototypeOf(UpdateFooDto);
+      const { fields } = getFieldsAndDecoratorForType(prototype);
+      console.log(fields);
+  
+      expect(fields.length).toEqual(1);
+      expect(fields[0].name).toEqual("name");
+      expect(fields[0].options.nullable).toEqual(true);
+      expect(fields[0].options.defaultValue).toEqual(undefined);
+    });
+
+  });
+
 });

--- a/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
@@ -118,7 +118,6 @@ describe('PartialType', () => {
   
       const prototype = Object.getPrototypeOf(UpdateFooDto);
       const { fields } = getFieldsAndDecoratorForType(prototype);
-      console.log(fields);
   
       expect(fields.length).toEqual(1);
       expect(fields[0].name).toEqual("name");

--- a/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
@@ -102,8 +102,6 @@ describe('PartialType', () => {
     });
   });
 
-
-
   describe('omitDefaultValue', () => {
     @ObjectType()
     class CreateFooDto {

--- a/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
@@ -113,7 +113,7 @@ describe('PartialType', () => {
 
     class UpdateFooDto extends PartialType(CreateFooDto, { omitDefaultValue: true }) {}
 
-    it('should remove defaultValue', async () => {
+    it('should skip default values of inherited class', async () => {
       await metadataLoader.load(SERIALIZED_METADATA);
   
       const prototype = Object.getPrototypeOf(UpdateFooDto);

--- a/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/partial-type.helper.spec.ts
@@ -104,7 +104,7 @@ describe('PartialType', () => {
 
 
 
-  describe('Remove defaultValue', () => {
+  describe('omitDefaultValue', () => {
     @ObjectType()
     class CreateFooDto {
       @Field({ defaultValue: 'foo' })


### PR DESCRIPTION
This allows removing defaultValue for the optional properties. It doesn't make much sense to have a nullable field in an update dto that has a default value.



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
PartialType does keep defalutValue option. It doesn't make much sense to have a nullable field in an update dto that has a default value.

Issue Number: #1425


## What is the new behavior?
A new option is added (omitDefaultValue) that allows removing the defaultValue.

Also the current second argument (decorator) is converted into a optionsOrDecorator argument.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

The old behaviour is kept by default, so this is not a breaking change.