### PR TITLE
fix(graphql): Set defaultaValue type nullable

### DIFF
--- a/packages/graphql/lib/decorators/args.decorator.ts
+++ b/packages/graphql/lib/decorators/args.decorator.ts
@@ -16,7 +16,7 @@ import { addPipesMetadata } from './param.utils';
 /**
  * Interface defining options that can be passed to `@Args()` decorator.
  */
-export interface ArgsOptions extends BaseTypeOptions {
+export type ArgsOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the argument.
    */
@@ -29,7 +29,7 @@ export interface ArgsOptions extends BaseTypeOptions {
    * Function that returns a reference to the arguments host class.
    */
   type?: () => any;
-}
+};
 
 /**
  * Resolver method parameter decorator. Extracts the arguments

--- a/packages/graphql/lib/decorators/field.decorator.ts
+++ b/packages/graphql/lib/decorators/field.decorator.ts
@@ -21,7 +21,7 @@ import { reflectTypeFromMetadata } from '../utils/reflection.utilts';
 /**
  * Interface defining options that can be passed to `@Field()` decorator.
  */
-export interface FieldOptions<T = any> extends BaseTypeOptions<T> {
+export type FieldOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the field.
    */
@@ -42,7 +42,7 @@ export interface FieldOptions<T = any> extends BaseTypeOptions<T> {
    * Array of middleware to apply.
    */
   middleware?: FieldMiddleware[];
-}
+};
 
 type FieldOptionsExtractor<T> = T extends [GqlTypeReference<infer P>]
   ? FieldOptions<P[]>

--- a/packages/graphql/lib/decorators/mutation.decorator.ts
+++ b/packages/graphql/lib/decorators/mutation.decorator.ts
@@ -15,7 +15,7 @@ import { addResolverMetadata } from './resolvers.utils';
 /**
  * Interface defining options that can be passed to `@Mutation()` decorator.
  */
-export interface MutationOptions extends BaseTypeOptions {
+export type MutationOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the mutation.
    */
@@ -32,7 +32,7 @@ export interface MutationOptions extends BaseTypeOptions {
    * Mutation complexity options.
    */
   complexity?: Complexity;
-}
+};
 
 /**
  * Mutation handler (method) Decorator. Routes specified mutation to this method.

--- a/packages/graphql/lib/decorators/query.decorator.ts
+++ b/packages/graphql/lib/decorators/query.decorator.ts
@@ -15,7 +15,7 @@ import { addResolverMetadata } from './resolvers.utils';
 /**
  * Interface defining options that can be passed to `@Query()` decorator.
  */
-export interface QueryOptions extends BaseTypeOptions {
+export type QueryOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the query.
    */
@@ -32,7 +32,7 @@ export interface QueryOptions extends BaseTypeOptions {
    * Query complexity options.
    */
   complexity?: Complexity;
-}
+};
 
 /**
  * Query handler (method) Decorator. Routes specified query to this method.

--- a/packages/graphql/lib/decorators/resolve-field.decorator.ts
+++ b/packages/graphql/lib/decorators/resolve-field.decorator.ts
@@ -19,7 +19,7 @@ import { reflectTypeFromMetadata } from '../utils/reflection.utilts';
 /**
  * Interface defining options that can be passed to `@ResolveField()` decorator.
  */
-export interface ResolveFieldOptions extends BaseTypeOptions {
+export type ResolveFieldOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the field.
    */
@@ -40,7 +40,7 @@ export interface ResolveFieldOptions extends BaseTypeOptions {
    * Array of middleware to apply.
    */
   middleware?: FieldMiddleware[];
-}
+};
 
 /**
  * Field resolver (method) Decorator.

--- a/packages/graphql/lib/decorators/subscription.decorator.ts
+++ b/packages/graphql/lib/decorators/subscription.decorator.ts
@@ -14,7 +14,7 @@ import { addResolverMetadata } from './resolvers.utils';
 /**
  * Interface defining options that can be passed to `@Subscription()` decorator.
  */
-export interface SubscriptionOptions extends BaseTypeOptions {
+export type SubscriptionOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Name of the subscription.
    */
@@ -44,7 +44,7 @@ export interface SubscriptionOptions extends BaseTypeOptions {
     context: any,
     info: any,
   ) => any | Promise<any>;
-}
+};
 
 /**
  * Subscription handler (method) Decorator. Routes subscriptions to this method.

--- a/packages/graphql/lib/interfaces/base-type-options.interface.ts
+++ b/packages/graphql/lib/interfaces/base-type-options.interface.ts
@@ -1,11 +1,27 @@
 export type NullableList = 'items' | 'itemsAndList';
-export interface BaseTypeOptions<T = any> {
+
+type NonNullableBaseType<T = any> = {
   /**
    * Determines whether field/argument/etc is nullable.
    */
-  nullable?: boolean | NullableList;
+  nullable?: false | NullableList;
+  /**
+   * Default value.
+   */
+  defaultValue?: T;
+};
+
+type NullableBaseType<T = any> = {
+  /**
+   * Determines whether field/argument/etc is nullable.
+   */
+  nullable: true;
   /**
    * Default value.
    */
   defaultValue?: T | null;
-}
+};
+
+export type BaseTypeOptions<T = any> =
+  | NonNullableBaseType<T>
+  | NullableBaseType<T>;

--- a/packages/graphql/lib/interfaces/base-type-options.interface.ts
+++ b/packages/graphql/lib/interfaces/base-type-options.interface.ts
@@ -7,5 +7,5 @@ export interface BaseTypeOptions<T = any> {
   /**
    * Default value.
    */
-  defaultValue?: T;
+  defaultValue?: T | null;
 }

--- a/packages/graphql/lib/interfaces/type-options.interface.ts
+++ b/packages/graphql/lib/interfaces/type-options.interface.ts
@@ -1,6 +1,6 @@
 import { BaseTypeOptions } from './base-type-options.interface';
 
-export interface TypeOptions<T = any> extends BaseTypeOptions<T> {
+export type TypeOptions<T = any> = BaseTypeOptions<T> & {
   isArray?: boolean;
   arrayDepth?: number;
-}
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cannot set defaultValue to null value for `@Field` decorator with `{nullable: true}` option.
```
class User {
  @Field(() => String, { nullable: true, defaultValue: null }) # Type 'null' is not assignable to type 'String | undefined'.ts(2322)
  name!: string | null;
}
```

Issue Number: https://github.com/nestjs/graphql/issues/2995

## What is the new behavior?
Can set defaultValue to null value for `@Field` decorator with `{nullable: true}` option.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
