### PR TITLE
fix: fixed assigning decorator when passed as class decorator factory

### DIFF
--- a/packages/graphql/lib/type-helpers/partial-type.helper.ts
+++ b/packages/graphql/lib/type-helpers/partial-type.helper.ts
@@ -45,6 +45,8 @@ export function PartialType<T>(
   if (isPartialTypeOptions(optionsOrDecorator)) {
     decorator = optionsOrDecorator.decorator;
     omitDefaultValues = optionsOrDecorator.omitDefaultValues;
+  } else {
+    decorator = optionsOrDecorator;
   }
 
   if (decorator) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [1 ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current issue with the partial type utility function in NestJS/GraphQL arises from the absence of a proper assignment of decorator variable when passed as a ClassDecoratorFactory.

Issue Number: N/A


## What is the new behavior?
Consider both scenarios: ClassDecoratorFactory and PartialTypeOptions.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. --> 

## Other information
