### PR TITLE
Fix schema definition for federation 2 @link in schema-first

### DIFF
--- a/packages/apollo/tests/generated-definitions/federation-partial-query.fixture.ts
+++ b/packages/apollo/tests/generated-definitions/federation-partial-query.fixture.ts
@@ -12,4 +12,8 @@ export interface IQuery {
     foo(): Nullable<boolean> | Promise<Nullable<boolean>>;
 }
 
+export interface ISchema {
+    Query: IQuery;
+}
+
 type Nullable<T> = T | null;

--- a/packages/apollo/tests/generated-definitions/federation-typedef.fixture.ts
+++ b/packages/apollo/tests/generated-definitions/federation-typedef.fixture.ts
@@ -33,4 +33,8 @@ export class User {
     posts?: Nullable<Nullable<Post>[]>;
 }
 
+export class ISchema {
+    Query: IQuery;
+}
+
 type Nullable<T> = T | null;

--- a/packages/apollo/tests/generated-definitions/federation.fixture.ts
+++ b/packages/apollo/tests/generated-definitions/federation.fixture.ts
@@ -28,4 +28,8 @@ export class User {
     posts?: Nullable<Nullable<Post>[]>;
 }
 
+export class ISchema {
+    Query: IQuery;
+}
+
 type Nullable<T> = T | null;

--- a/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation-definitions.factory.ts
@@ -41,7 +41,8 @@ export class GraphQLFederationDefinitionsFactory extends GraphQLDefinitionsFacto
     // This leads to duplicated IQuery interfaces
     // see: https://github.com//issues/2344
     const mergedDefinition = mergeTypeDefs([printSubgraphSchema(schema)], {
-      useSchemaDefinition: false,
+      // schema-first requires the schema definition to be included for federation 2 @link to function
+      useSchemaDefinition: true,
       throwOnConflict: true,
       commentDescriptions: true,
       reverseDirectives: true,


### PR DESCRIPTION
Update graphql-federation-definitions.factory.ts

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
schema definition and use of `@link` is not included in the SDL for the schema in schema-first approach

Issue Number: N/A


## What is the new behavior?
schema definition and use of `@link` is properly included in the SDL for the subgraph

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
