### PR TITLE
feat(graphql): support resolverValidationOptions for schema first federation

### DIFF
--- a/packages/graphql/lib/federation/graphql-federation.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation.factory.ts
@@ -80,6 +80,7 @@ export class GraphQLFederationFactory {
 
     const resolvers = this.getResolvers(options.resolvers);
     return addResolversToSchema({
+      resolverValidationOptions: options.resolverValidationOptions,
       inheritResolversFromInterfaces: options.inheritResolversFromInterfaces,
       resolvers,
       schema: buildSubgraphSchema([


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The option for resolverValidationOptions isn't being passed along to addResolversToSchema despite it being included in graphql federation options and it being supported by addResolversToSchema.

Related to https://github.com/nestjs/graphql/pull/2994

Issue Number: N/A


## What is the new behavior?
Support resolverValidationOptions for schema first federation

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
