### PR TITLE
docs(graphql): added jsdoc for debug and introspection. closes #3142

### DIFF
--- a/packages/graphql/lib/interfaces/gql-module-options.interface.ts
+++ b/packages/graphql/lib/interfaces/gql-module-options.interface.ts
@@ -120,6 +120,20 @@ export interface GqlModuleOptions<TDriver extends GraphQLDriver = any> {
    * Extra static metadata to be loaded into the specification
    */
   metadata?: () => Promise<Record<string, any>>;
+
+  /**
+   * If `true`, enables development mode helpers and logs messages of all severity levels
+   * If `false`, only warn- and error-level messages are logged.
+   * @default true
+   */
+  debug?: boolean;
+
+  /**
+   * If `true`, enables schema introspection by clients. Default is `true` unless `NODE_ENV` is
+   * set to `production`
+   * @default true
+   */
+  introspection?: boolean;
 }
 
 export interface GqlOptionsFactory<

--- a/packages/graphql/lib/schema-builder/metadata/union.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/union.metadata.ts
@@ -1,7 +1,9 @@
 import { Type } from '@nestjs/common';
 import { ResolveTypeFn } from '../../interfaces';
 
-export interface UnionMetadata<T extends readonly Type<unknown>[] = readonly Type<unknown>[]> {
+export interface UnionMetadata<
+  T extends readonly Type<unknown>[] = readonly Type<unknown>[],
+> {
   name: string;
   typesFn: () => T;
   id?: symbol;

--- a/packages/graphql/lib/type-factories/create-union-type.factory.ts
+++ b/packages/graphql/lib/type-factories/create-union-type.factory.ts
@@ -13,7 +13,9 @@ import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.st
 /**
  * Interface defining options that can be passed to `createUnionType` function.
  */
-export interface UnionOptions<T extends readonly Type<unknown>[] = Type<unknown>[]> {
+export interface UnionOptions<
+  T extends readonly Type<unknown>[] = Type<unknown>[],
+> {
   /**
    * Name of the union.
    */
@@ -40,9 +42,9 @@ export type Union<T extends readonly any[]> = InstanceType<ArrayElement<T>>;
  * Creates a GraphQL union type composed of types references.
  * @param options
  */
-export function createUnionType<T extends readonly Type<unknown>[] = Type<unknown>[]>(
-  options: UnionOptions<T>,
-): Union<T> {
+export function createUnionType<
+  T extends readonly Type<unknown>[] = Type<unknown>[],
+>(options: UnionOptions<T>): Union<T> {
   const { name, description, types, resolveType } = options;
   const id = Symbol(name);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Added `debug` and `introspection` in `GqlModuleOptions`. Added relevant jsDocs for improved developer experience. Closes #3142 

Issue Number: #3142 


## What is the new behavior?
Auto-complete will now work in supported editors and developers will have an idea what `debug` and `introspection` are without referring to nest/apollo docs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
