### PR TITLE
fix(graphql): fix case of generated method return and parameter types

### DIFF
--- a/packages/graphql/lib/graphql-ast.explorer.ts
+++ b/packages/graphql/lib/graphql-ast.explorer.ts
@@ -394,7 +394,7 @@ export class GraphQLAstExplorer {
   getType(typeName: string, options: DefinitionsGeneratorOptions): string {
     const defaults = this.getDefaultTypes(options);
     const isDefault = defaults[typeName];
-    return isDefault ? defaults[typeName] : typeName;
+    return isDefault ? defaults[typeName] : upperFirst(typeName);
   }
 
   getDefaultTypes(options: DefinitionsGeneratorOptions): {


### PR DESCRIPTION
In the generated typescript (schema-first), classes and interfaces for types are upper cased, but remained in the original case when referenced in method arguments and return types.
This is a fix for this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3147


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
