### PR TITLE
fix(graphql): add deprecationReason to ArgsOptions

### DIFF
--- a/packages/graphql/lib/decorators/args.decorator.ts
+++ b/packages/graphql/lib/decorators/args.decorator.ts
@@ -26,6 +26,10 @@ export type ArgsOptions<T = any> = BaseTypeOptions<T> & {
    */
   description?: string;
   /**
+   * Argument deprecation reason (if deprecated).
+   */
+  deprecationReason?: string;
+  /**
    * Function that returns a reference to the arguments host class.
    */
   type?: () => any;
@@ -118,6 +122,7 @@ export function Args(
           kind: 'arg',
           name: property,
           description: argOptions.description,
+          deprecationReason: argOptions.deprecationReason,
           ...metadata,
         });
       } else {

--- a/packages/graphql/lib/schema-builder/factories/args.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/args.factory.ts
@@ -25,6 +25,7 @@ export class ArgsFactory {
       if (param.kind === 'arg') {
         fieldConfigMap[param.name] = {
           description: param.description,
+          deprecationReason: param.deprecationReason,
           type: this.inputTypeFactory.create(
             param.name,
             param.typeFn(),
@@ -85,6 +86,7 @@ export class ArgsFactory {
       );
       fieldConfigMap[schemaName] = {
         description: field.description,
+        deprecationReason: field.deprecationReason,
         type,
         defaultValue: field.options.defaultValue,
         /**

--- a/packages/graphql/lib/schema-builder/metadata/param.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/param.metadata.ts
@@ -13,6 +13,7 @@ export interface ArgParamMetadata extends BaseArgMetadata {
   kind: 'arg';
   name: string;
   description?: string;
+  deprecationReason?: string;
 }
 
 export interface ArgsParamMetadata extends BaseArgMetadata {


### PR DESCRIPTION
The official document said that @Args option allowed deprecationReason, but it did not. GraphQL allows deprecation directives for arguments, so I made it allow deprecationReason.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3033 


## What is the new behavior?

I make changes to AuthorResolver of https://github.com/bodil-dev/nest-graphql-args-deprecated . Because, deprecated arguments required nullable or default value. (see https://spec.graphql.org/draft/#sec--deprecated)
And I add `@ArgsType` usage.

![image](https://github.com/nestjs/graphql/assets/133634392/424d28c5-504e-426d-b235-bcb81e3bc7a5)

Then, `@deprecated` will be given properly.

![image](https://github.com/nestjs/graphql/assets/133634392/27984426-78ca-4ece-8df9-c2cacc8ae855)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
