### PR TITLE
fix(graphql): readonly arrays not allowed in decorator input

### DIFF
--- a/packages/graphql/lib/decorators/interface-type.decorator.ts
+++ b/packages/graphql/lib/decorators/interface-type.decorator.ts
@@ -11,6 +11,7 @@ import { ResolveTypeFn } from '../interfaces';
 import { LazyMetadataStorage } from '../schema-builder/storages/lazy-metadata.storage';
 import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.storage';
 import { addClassTypeMetadata } from '../utils/add-class-type-metadata.util';
+import type { Lazy, Many } from '../utils/types';
 
 /**
  * Interface defining options that can be passed to `@InterfaceType()` decorator.
@@ -31,7 +32,7 @@ export interface InterfaceTypeOptions {
   /**
    * Interfaces implemented by this interface.
    */
-  implements?: Function | Function[] | (() => Function | Function[]);
+  implements?: Lazy<Many<Function>>;
 }
 
 /**

--- a/packages/graphql/lib/decorators/object-type.decorator.ts
+++ b/packages/graphql/lib/decorators/object-type.decorator.ts
@@ -10,6 +10,7 @@ import { ClassType } from '../enums/class-type.enum';
 import { LazyMetadataStorage } from '../schema-builder/storages/lazy-metadata.storage';
 import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.storage';
 import { addClassTypeMetadata } from '../utils/add-class-type-metadata.util';
+import type { Lazy, Many } from '../utils/types';
 
 /**
  * Interface defining options that can be passed to `@ObjectType()` decorator
@@ -26,7 +27,7 @@ export interface ObjectTypeOptions {
   /**
    * Interfaces implemented by this object type.
    */
-  implements?: Function | Function[] | (() => Function | Function[]);
+  implements?: Lazy<Many<Function>>;
   /**
    * If `true`, direct descendant classes will inherit the parent's description if own description is not set.
    * Also works on classes marked with `isAbstract: true`.

--- a/packages/graphql/lib/decorators/resolve-field.decorator.ts
+++ b/packages/graphql/lib/decorators/resolve-field.decorator.ts
@@ -39,7 +39,7 @@ export type ResolveFieldOptions<T = any> = BaseTypeOptions<T> & {
   /**
    * Array of middleware to apply.
    */
-  middleware?: FieldMiddleware[];
+  middleware?: readonly FieldMiddleware[];
 };
 
 /**

--- a/packages/graphql/lib/schema-builder/metadata/interface.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/interface.metadata.ts
@@ -1,7 +1,8 @@
 import { ResolveTypeFn } from '../../interfaces';
+import type { Lazy, Many } from '../../utils/types';
 import { ClassMetadata } from './class.metadata';
 
 export interface InterfaceMetadata extends ClassMetadata {
   resolveType?: ResolveTypeFn;
-  interfaces?: Function | Function[] | (() => Function | Function[]);
+  interfaces?: Lazy<Many<Function>>;
 }

--- a/packages/graphql/lib/schema-builder/metadata/object-type.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/object-type.metadata.ts
@@ -1,5 +1,6 @@
+import type { Lazy, Many } from '../../utils/types';
 import { ClassMetadata } from './class.metadata';
 
 export interface ObjectTypeMetadata extends ClassMetadata {
-  interfaces?: Function | Function[] | (() => Function | Function[]);
+  interfaces?: Lazy<Many<Function>>;
 }

--- a/packages/graphql/lib/utils/types.ts
+++ b/packages/graphql/lib/utils/types.ts
@@ -1,0 +1,2 @@
+export type Many<T> = T | readonly T[];
+export type Lazy<T> = T | (() => T);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```ts

const interfaces = [A, B] as const;

@ObjectType({
  implements: interfaces, // error
})
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
