### PR TITLE
fix(graphql): ensure scalarsMap in buildSchemaOptions is respected

### DIFF
--- a/packages/graphql/lib/graphql-schema.builder.ts
+++ b/packages/graphql/lib/graphql-schema.builder.ts
@@ -31,7 +31,10 @@ export class GraphQLSchemaBuilder {
         autoSchemaFile,
         {
           ...buildSchemaOptions,
-          scalarsMap,
+          scalarsMap: [
+            ...(buildSchemaOptions.scalarsMap ?? []),
+            ...scalarsMap.filter(({ type }) => buildSchemaOptions.scalarsMap?.every((item) => item.type !== type) ?? true),
+          ],
         },
         options.sortSchema,
         options.transformAutoSchemaFile && options.transformSchema,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `scalarsMap` in `buildSchemaOptions` was not used even though it was defined.

This PR also fixes issues like #3204 by correctly merging the `scalarsMap`, ensuring that duplicate `ScalarsTypeMap` entries are ignored by their `type`. e.g.

```ts
buildSchemaOptions: {
  numberScalarMode: 'integer',
  scalarsMap: [
    {
      type: Date,
      scalar: GraphQLDateTime,
    },
  ],
}
```


## What is the new behavior?

This PR ensures that the `scalarsMap` in `buildSchemaOptions` is respected and correctly merged with the `scalarsMap` from `ScalarsExplorerService`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
