### PR TITLE
feat(graphql): add support for option newline at the end of schema file

### DIFF
--- a/packages/apollo/tests/e2e/graphql-sort-auto-schema.spec.ts
+++ b/packages/apollo/tests/e2e/graphql-sort-auto-schema.spec.ts
@@ -1,13 +1,16 @@
 import { INestApplication } from '@nestjs/common';
 import { GraphQLSchemaHost } from '@nestjs/graphql';
-import { GRAPHQL_SDL_FILE_HEADER } from '@nestjs/graphql/graphql.constants';
+import {
+  GRAPHQL_SDL_FILE_HEADER,
+  GRAPHQL_SDL_FILE_END,
+} from '@nestjs/graphql/graphql.constants';
 import { FileSystemHelper } from '@nestjs/graphql/schema-builder/helpers/file-system.helper';
 import { Test } from '@nestjs/testing';
 import { GraphQLSchema, printSchema } from 'graphql';
 import { SortAutoSchemaModule } from '../graphql/sort-auto-schema.module';
 import { sortedPrintedSchemaSnapshot } from '../utils/printed-schema.snapshot';
 
-describe('GraphQL sort autoSchemaFile schema', () => {
+describe('GraphQL sort autoSchemaFile and new line at the end of the schema', () => {
   let app: INestApplication;
   let schema: GraphQLSchema;
   let writeFileMock: jest.Mock;
@@ -38,7 +41,7 @@ describe('GraphQL sort autoSchemaFile schema', () => {
     expect(writeFileMock).toHaveBeenCalledTimes(1);
     expect(writeFileMock).toHaveBeenCalledWith(
       'schema.graphql',
-      sortedPrintedSchemaSnapshot,
+      sortedPrintedSchemaSnapshot + GRAPHQL_SDL_FILE_END,
     );
   });
 

--- a/packages/apollo/tests/graphql/sort-auto-schema.module.ts
+++ b/packages/apollo/tests/graphql/sort-auto-schema.module.ts
@@ -12,6 +12,9 @@ import { RecipesModule } from '../code-first/recipes/recipes.module';
       driver: ApolloDriver,
       autoSchemaFile: 'schema.graphql',
       sortSchema: true,
+      buildSchemaOptions: {
+        addNewlineAtEnd: true,
+      },
     }),
   ],
 })

--- a/packages/graphql/lib/graphql-schema.builder.ts
+++ b/packages/graphql/lib/graphql-schema.builder.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { isString } from '@nestjs/common/utils/shared.utils';
 import { GraphQLSchema, lexicographicSortSchema, printSchema } from 'graphql';
 import { resolve } from 'path';
-import { GRAPHQL_SDL_FILE_HEADER } from './graphql.constants';
+import {
+  GRAPHQL_SDL_FILE_HEADER,
+  GRAPHQL_SDL_FILE_END,
+} from './graphql.constants';
 import { AutoSchemaFileValue, GqlModuleOptions } from './interfaces';
 import { BuildSchemaOptions } from './interfaces/build-schema-options.interface';
 import { GraphQLSchemaFactory } from './schema-builder/graphql-schema.factory';
@@ -60,13 +63,18 @@ export class GraphQLSchemaBuilder {
       const transformedSchema = transformSchema
         ? await transformSchema(schema)
         : schema;
-      const fileContent =
+      let fileContent =
         GRAPHQL_SDL_FILE_HEADER +
         printSchema(
           sortSchema
             ? lexicographicSortSchema(transformedSchema)
             : transformedSchema,
         );
+
+      if (options.addNewlineAtEnd) {
+        fileContent = fileContent.concat(GRAPHQL_SDL_FILE_END);
+      }
+
       await this.fileSystemHelper.writeFile(filename, fileContent);
     }
     return schema;

--- a/packages/graphql/lib/graphql.constants.ts
+++ b/packages/graphql/lib/graphql.constants.ts
@@ -34,3 +34,5 @@ export const GRAPHQL_SDL_FILE_HEADER = `\
 # ------------------------------------------------------
 
 `;
+
+export const GRAPHQL_SDL_FILE_END = '\n';

--- a/packages/graphql/lib/interfaces/build-schema-options.interface.ts
+++ b/packages/graphql/lib/interfaces/build-schema-options.interface.ts
@@ -51,4 +51,9 @@ export interface BuildSchemaOptions {
    * Set to true if it should throw an error when the same Query / Mutation field is defined more than once
    */
   noDuplicatedFields?: boolean;
+
+  /**
+   * Add new line at the end of the generated GraphQL SDL file
+   */
+  addNewlineAtEnd?: boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2732


## What is the new behavior?

Added new option `addNewlineAtEnd` to `BuildSchemaOptions`, which appends a newline at the end of the generated GraphQL SDL file when set to `true`. If the option is set to `false` or omitted, the SDL file will be generated without adding an extra newline at the end.
This option is applicable only in the code-first approach.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
