### PR TITLE
feat(apollo): subscription with initial data

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lerna": "8.1.5",
     "lerna-changelog": "2.2.0",
     "lint-staged": "15.2.7",
-    "prettier": "2.8.8",
+    "prettier": "3.2.5",
     "reflect-metadata": "0.2.2",
     "release-it": "17.1.1",
     "rimraf": "5.0.7",

--- a/packages/apollo/lib/utils/async-iterator-with-initial-data.util.ts
+++ b/packages/apollo/lib/utils/async-iterator-with-initial-data.util.ts
@@ -1,0 +1,17 @@
+export const createIteratorWithInitialData = async <T = any>(
+  iterator: AsyncIterator<T>,
+  initialData: T[],
+): Promise<AsyncIterableIterator<T>> => {
+  return (async function* () {
+    for (const data of initialData) {
+      yield data;
+    }
+    while (true) {
+      const entry = await iterator.next();
+      if (entry.done) {
+        return;
+      }
+      yield entry.value;
+    }
+  })();
+};

--- a/packages/apollo/lib/utils/async-iterator-with-initial-data.util.ts
+++ b/packages/apollo/lib/utils/async-iterator-with-initial-data.util.ts
@@ -1,17 +1,17 @@
-export const createIteratorWithInitialData = async <T = any>(
-  iterator: AsyncIterator<T>,
+export const createIteratorWithInitialData = <T = any>(
+  iterator: AsyncIterator<T, any, undefined>,
   initialData: T[],
-): Promise<AsyncIterableIterator<T>> => {
+): AsyncIterableIterator<T> => {
   return (async function* () {
     for (const data of initialData) {
       yield data;
     }
     while (true) {
-      const entry = await iterator.next();
-      if (entry.done) {
-        return;
+      const { value, done } = await iterator.next();
+      if (done) {
+        break;
       }
-      yield entry.value;
+      yield value;
     }
   })();
 };

--- a/packages/apollo/lib/utils/index.ts
+++ b/packages/apollo/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './get-apollo-server';
+export * from './async-iterator-with-initial-data.util';

--- a/packages/apollo/tests/subscriptions/async-iterator-with-initial-data.spec.ts
+++ b/packages/apollo/tests/subscriptions/async-iterator-with-initial-data.spec.ts
@@ -2,11 +2,11 @@ import { createIteratorWithInitialData } from '../../lib/utils/async-iterator-wi
 
 it('Should serve initial data followed by live upates', async () => {
   const initialData: Array<number> = [1, 2, 3];
-  const asyncIterator = {
-    next: jest.fn().mockResolvedValueOnce({ value: 4, done: false }),
+  const asyncIterator = async function* () {
+    yield 4;
   };
   const iterator = await createIteratorWithInitialData<number>(
-    asyncIterator,
+    asyncIterator(),
     initialData,
   );
   const result: Array<number> = [];

--- a/packages/apollo/tests/subscriptions/async-iterator-with-initial-data.spec.ts
+++ b/packages/apollo/tests/subscriptions/async-iterator-with-initial-data.spec.ts
@@ -1,0 +1,17 @@
+import { createIteratorWithInitialData } from '../../lib/utils/async-iterator-with-initial-data.util';
+
+it('Should serve initial data followed by live upates', async () => {
+  const initialData: Array<number> = [1, 2, 3];
+  const asyncIterator = {
+    next: jest.fn().mockResolvedValueOnce({ value: 4, done: false }),
+  };
+  const iterator = await createIteratorWithInitialData<number>(
+    asyncIterator,
+    initialData,
+  );
+  const result: Array<number> = [];
+  for await (const value of iterator) {
+    result.push(value);
+  }
+  expect(result).toEqual([1, 2, 3, 4]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9181,10 +9181,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 pretty-format@^29.0.0, pretty-format@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Subscriptions created by utilizing the @nestjs/graphql related libs only serve updates triggered by the `PubSub.asyncIterator` while in some circumstances a subscription may serve initial data to avoid a Query + Subscription scenario resulting in complicated merges within the clients' business logic.

Issue Number: N/A


## What is the new behavior?
A utils function has been added which can be used to combine an `AsyncIterator` with an array of existing data returning an `AsyncIterableIterator` which does satisfy the `AsyncIterator` interface - meaning that existing code / frameworks will not be broken if employed - while serving the list of initial entries first, followed by all real-time updates triggered via the PubSub iterator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The `apollo` package may not be the right place to store such utils, feedback would be highly appreciated!
Furthermore, an update to linting related dependencies had to be made in order to run the husky pre-commit locally.