### PR TITLE
fix(graphql): avoid partial field declarations from inherited metadata with cli plugin

### DIFF
--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -226,10 +226,13 @@ export class TypeMetadataStorageHost {
       if (!prototype.constructor) {
         return;
       }
-      if (!prototype.constructor[METADATA_FACTORY_NAME]) {
+      const metadata = Object.getOwnPropertyDescriptor(
+        prototype.constructor,
+        METADATA_FACTORY_NAME,
+      )?.value?.();
+      if (!metadata) {
         continue;
       }
-      const metadata = prototype.constructor[METADATA_FACTORY_NAME]();
       const properties = Object.keys(metadata);
       properties.forEach((key) => {
         if (metadata[key].type) {

--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -216,16 +216,23 @@ export class TypeMetadataStorageHost {
   }
 
   loadClassPluginMetadata(metadata: ClassMetadata[]) {
+    const loadedClasses = new Set<Function>();
     metadata
       .filter((item) => item?.target)
-      .forEach((item) => this.applyPluginMetadata(item.target.prototype));
+      .forEach((item) => this.applyPluginMetadata(item.target.prototype, loadedClasses));
   }
 
-  applyPluginMetadata(prototype: Function) {
+  applyPluginMetadata(prototype: Function, loadedClasses = new Set<Function>()) {
     do {
       if (!prototype.constructor) {
         return;
       }
+      // Skip redundant metadata merges for common parents.
+      if (loadedClasses.has(prototype.constructor)) {
+        return;
+      }
+      loadedClasses.add(prototype.constructor);
+
       const metadata = Object.getOwnPropertyDescriptor(
         prototype.constructor,
         METADATA_FACTORY_NAME,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The former logic was accessing the inherited metadata factory, I guess when the current class didn't have one.
The parent class could have fields that the plugin cannot determine, and are explicitly declared with `@Field` decorators.
The partial info & the type from decorator are merged together for that base type.
But here when the subclass was redefining this field it only had partial info, no type.
This caused the complication logic to fail, because the `typeFn` would be missing.
Instead, we only want to look for the _own_ metadata factory, and ignore if there is none.
Just to note: inherited fields are merged elsewhere (in factories), so this doesn't need to try.

A minimal reproduction is
```ts
// Base class that the plugin will generate metadata for, but it will be missing
// the `type` because it cannot be resolved by TS.
@ObjectType({ isAbstract: true })
export class Entity {
  @Field(() => String)
  id: unknown;
}

// In the middle is a non-exported / or dynamic class that the plugin ignores
// MetadataLoader will not assign a _GRAPHQL_METADATA_FACTORY property to this object
// because of that.
export function LivingBeing() {
  @ObjectType({ isAbstract: true })
  class LivingBeingClass extends Entity {}
  return LivingBeingClass;
}

// A concrete type that acts as the entrypoint for the bug.
@ObjectType()
export class Person extends LivingBeing() {}
```
With this example, `Person` & `Entity` will have metadata loaded / `_GRAPHQL_METADATA_FACTORY` property assigned.
The problem is that
```ts
LivingBeingClass.constructor[METADATA_FACTORY_NAME]
```
resolves to `Entity`'s `_GRAPHQL_METADATA_FACTORY` 💥 , but it's registered as the `LivingBeingClass` type.
⭐ The logic should be to skip because no `_GRAPHQL_METADATA_FACTORY` is declared for `LivingBeingClass`.

`Entity`'s metadata is merged with the decorator, so the plugin doesn't provide the `type`, but the decorator does.
However, `LivingBeingClass` does not have this field metadata merged since the `Entity.id` decorator is not its own (guessing on why).
The factories [throw](https://github.com/nestjs/graphql/blob/79c9e561bf71b4be2184e21e32d75b17014c502b/packages/graphql/lib/schema-builder/factories/args.factory.ts#L83-L83) because `LivingBeingClass.id` does not have a `type` even though its parent class does.

The metadata should ignore this field for this intermediate class since it doesn't do anything with it - it just inherits.

## What is the new behavior?

Error is avoided. Fields are still merged/inherited as expected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I also added a check to avoid merging metadata for common parents.
i.e. `TypeMetadataStorage.addClassFieldMetadata` would previous be called for `Entity.id` for every concrete type extending `Entity`. Which is redundant work after the first time.