### PR TITLE
fix(graphql): change info to nullable

### DIFF
--- a/packages/graphql/lib/interfaces/field-middleware.interface.ts
+++ b/packages/graphql/lib/interfaces/field-middleware.interface.ts
@@ -8,7 +8,7 @@ export interface MiddlewareContext<
   source: TSource;
   args: TArgs;
   context: TContext;
-  info: GraphQLResolveInfo;
+  info?: GraphQLResolveInfo | null;
 }
 
 export type NextFn<T = any> = () => Promise<T>;

--- a/packages/graphql/tests/middleware/middleware-type-check.spec.ts
+++ b/packages/graphql/tests/middleware/middleware-type-check.spec.ts
@@ -1,0 +1,58 @@
+import { GraphQLResolveInfo } from 'graphql';
+import { MiddlewareContext, NextFn } from '../../lib/interfaces';
+
+export const testMiddleware = async (ctx: MiddlewareContext, next: NextFn) => {
+  let logData: MiddlewareContext = {
+    source: ctx.source,
+    args: ctx.args,
+    context: ctx.context,
+  };
+
+  if (ctx.info) {
+    logData = {
+      ...logData,
+      info: ctx.info,
+    };
+  }
+
+  return next();
+};
+
+describe('testMiddleware', () => {
+  let mockContext: MiddlewareContext;
+  let mockNext: NextFn;
+
+  beforeEach(() => {
+    mockContext = {
+      source: {},
+      args: {},
+      context: {},
+      info: {
+        path: { typename: 'TestType', key: 'testField' },
+      } as GraphQLResolveInfo,
+    };
+
+    mockNext = jest.fn().mockResolvedValue('next result');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call next when info is provided', () => {
+    testMiddleware(mockContext, mockNext);
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should handle case when info is undefined', () => {
+    mockContext.info = undefined;
+    testMiddleware(mockContext, mockNext);
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should handle case when info is null', () => {
+    mockContext.info = null;
+    testMiddleware(mockContext, mockNext);
+    expect(mockNext).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2824 


## What is the new behavior?
<img width="1084" alt="스크린샷 2024-09-22 오후 10 22 30" src="https://github.com/user-attachments/assets/bdacbaca-0480-4f49-bb03-2027355a5926">
The info property in the MiddlewareContext interface is now optional.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
