### PR TITLE
feat(apollo): map unprocessable entity code to bad user input

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -18,6 +18,7 @@ import { createAsyncIterator } from '../utils/async-iterator.util';
 
 const apolloPredefinedExceptions: Partial<Record<HttpStatus, string>> = {
   [HttpStatus.BAD_REQUEST]: ApolloServerErrorCode.BAD_REQUEST,
+  [HttpStatus.UNPROCESSABLE_ENTITY]: ApolloServerErrorCode.BAD_USER_INPUT,
   [HttpStatus.UNAUTHORIZED]: 'UNAUTHENTICATED',
   [HttpStatus.FORBIDDEN]: 'FORBIDDEN',
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The code in error extensions is INTERNAL_SERVER_ERROR if we set HttpStatus.UNPROCESSABLE_ENTITY for ValidationPipe. 

```json
{
  "errors": [
    {
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
      }
    }
  ]
}
```

## What is the new behavior?

The code in error extensions is BAD_USER_INPUT.

```json
{
  "errors": [
    {
      "extensions": {
        "code": "BAD_USER_INPUT",
      }
    }
  ]
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Can we have it merged please or there is some reason why this mapping was not added before?
