### PR TITLE
refactor(graphql/lib): definitions generator `defaultTypeMapping` type reinforcement

### DIFF
--- a/packages/graphql/lib/graphql-ast.explorer.ts
+++ b/packages/graphql/lib/graphql-ast.explorer.ts
@@ -68,7 +68,8 @@ export interface DefinitionsGeneratorOptions {
    * @default undefined
    */
   defaultTypeMapping?: Partial<
-    Record<'ID' | 'Boolean' | 'Float' | 'String' | 'Int', string>
+    Record<'ID' | 'Float' | 'Int', 'string' | 'number'> &
+    Record<'Boolean' | 'String', 'boolean' | 'string' | 'number'>
   >;
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3210

## What is the new behavior?

Reinforce the `DefinitionsGeneratorOptions.defaultTypeMapping` interface for better visual over the allowed types.

> Better suggestions over the supported types
>
> ![Screenshot 2024-10-24 at 11 39 58 PM](https://github.com/user-attachments/assets/09ff069f-f86c-4fad-b9b5-fedb016bd996)
>
> ![Screenshot 2024-10-24 at 11 41 07 PM](https://github.com/user-attachments/assets/98a22025-520d-4c62-87c7-bec99751abdb)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

> will close #3210
