### PR TITLE
chore(deps): Use `crypto.randomUUID()` instead of `uuid` module

### DIFF
--- a/packages/graphql/lib/utils/generate-token.util.ts
+++ b/packages/graphql/lib/utils/generate-token.util.ts
@@ -1,3 +1,1 @@
-import { v4 } from 'uuid';
-
-export const generateString = () => v4();
+export const generateString = () => crypto.randomUUID();

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,7 +30,6 @@
     "normalize-path": "3.0.0",
     "subscriptions-transport-ws": "0.11.0",
     "tslib": "2.8.1",
-    "uuid": "11.0.3",
     "ws": "8.18.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10797,11 +10797,6 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
-  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
-
 uuid@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz"


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No if Node.js ^18 is required (which is the oldest supported version)

The `crypto` global is available in all supported Node.js versions as well as [in all major browsers](https://caniuse.com/mdn-api_crypto_randomuuid). The uuid module is rendered unnecessary for uuidv4.

`@nestjs/graphql` is currently downloaded about 580000 times per week, so about 30740000 times per year. `uuid@11` is about 3.7 kB in size (gzipped+minified). Removing this dependency saves about 113GB traffic per year.