### PR TITLE
chore: add function to get all union defs

### DIFF
--- a/packages/graphql/lib/schema-builder/storages/type-definitions.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-definitions.storage.ts
@@ -63,6 +63,10 @@ export class TypeDefinitionsStorage {
     return this.unionTypeDefinitions.get(key);
   }
 
+  getAllUnionDefinitions(): UnionDefinition[] {
+    return Array.from(this.unionTypeDefinitions.values());
+  }
+
   addInterfaces(interfaceDefs: InterfaceTypeDefinition[]) {
     interfaceDefs.forEach((item) =>
       this.interfaceTypeDefinitions.set(item.target, item),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Summary
This PR adds a function to get all union types from the type definitions storage. So far, this function has been missing. We need this for a generation use case involving the type definitions storage. In this case, we want to get _all_ definitions, not just object, interface, input.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
