### PR TITLE
fix: separate raw and compiled resolver metadata from each other

### DIFF
--- a/packages/apollo/tests/e2e/code-first-inheritance.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-inheritance.spec.ts
@@ -1,0 +1,89 @@
+import { ApolloServer } from '@apollo/server';
+import { INestApplication, Module } from '@nestjs/common';
+import {
+  Args,
+  Field,
+  GraphQLModule,
+  InputType,
+  Int,
+  Mutation,
+  Query,
+  Resolver,
+} from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { gql } from 'graphql-tag';
+import { ApolloDriver, ApolloDriverConfig } from '../../lib';
+import { expectSingleResult } from '../utils/assertion-utils';
+
+@InputType()
+class MyArgs {
+  @Field()
+  public myInput: number;
+}
+
+@Resolver({ isAbstract: true })
+abstract class MyBaseResolver {
+  @Query(() => Int)
+  public myQuery(): number {
+    return 10;
+  }
+
+  @Mutation(() => Int)
+  public myMutation(
+    @Args({ type: () => MyArgs, name: 'input' }) args: MyArgs,
+  ): number {
+    return args.myInput;
+  }
+}
+
+@Resolver()
+class MyResolver extends MyBaseResolver {}
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
+  ],
+  providers: [MyResolver],
+})
+class MyModule {}
+
+describe('code-first with a resolver that uses inheritance', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServer;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [MyModule],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+    const graphqlModule = app.get<GraphQLModule<ApolloDriver>>(GraphQLModule);
+    apolloClient = graphqlModule.graphQlAdapter?.instance;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function createTest() {
+    it("resolver inherits schema from its' parent class", async () => {
+      const mutation = gql`
+        mutation MyTest {
+          myMutation(input: { myInput: 5 })
+        }
+      `;
+      const response = await apolloClient.executeOperation({
+        query: mutation,
+      });
+      expectSingleResult(response).toEqual({
+        myMutation: 5,
+      });
+    });
+  }
+
+  createTest();
+  createTest();
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] ~~Docs have been added / updated (for bug fixes / features)~~ not needed

## PR Type

- [x] Bugfix

## What is the current behavior?

GraphQL Schema can be compiled only once. If it happens twice, if the schema relies on abstract absolvers, they will lack important metadata, e.g. query/mutation arguments.

See https://github.com/nestjs/graphql/issues/2657 for more information.

## What is the new behavior?

When compiling the schema, raw metadata (coming from decorators) is separated out from the compiled metadata (that is later used to build the final schema).

## Does this PR introduce a breaking change?
- [x] No

## Other information

Fixes https://github.com/nestjs/graphql/issues/2657 .