### PR TITLE
feat(@nestjs/graphql): Allow InputType Deprecation (code first)

### DIFF
--- a/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
@@ -80,6 +80,7 @@ export class InputTypeDefinitionFactory {
           description: property.description,
           type,
           defaultValue: property.options.defaultValue,
+          deprecationReason: property.deprecationReason,
           /**
            * AST node has to be manually created in order to define directives
            * (more on this topic here: https://github.com/graphql/graphql-js/issues/1343)

--- a/packages/graphql/tests/schema-builder/factories/input-type-definition.factory.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/input-type-definition.factory.spec.ts
@@ -1,0 +1,56 @@
+import { Test } from '@nestjs/testing';
+import {
+  Field,
+  InputType,
+  GraphQLSchemaBuilderModule,
+  TypeMetadataStorage,
+} from '../../../lib';
+import { TypeDefinitionsGenerator } from '../../../lib/schema-builder/type-definitions.generator';
+import { TypeDefinitionsStorage } from '../../../lib/schema-builder/storages/type-definitions.storage';
+import { LazyMetadataStorage } from '../../../lib/schema-builder/storages/lazy-metadata.storage';
+
+@InputType('DeprecationInput')
+class DeprecationInput {
+  @Field(() => String, { description: 'regular' })
+  regular!: string;
+
+  @Field(() => String, {
+    description: 'deprecated',
+    deprecationReason: 'use something else',
+  })
+  oldField!: string;
+}
+
+describe('InputTypeDefinitionFactory (deprecation)', () => {
+  let generator: TypeDefinitionsGenerator;
+  let storage: TypeDefinitionsStorage;
+
+  beforeAll(async () => {
+    // Register metadata for the input type
+    LazyMetadataStorage.load([DeprecationInput]);
+    TypeMetadataStorage.compile();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    generator = moduleRef.get(TypeDefinitionsGenerator);
+    storage = moduleRef.get(TypeDefinitionsStorage);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should mark input fields as deprecated if value is set', () => {
+    // Generate type definitions (inputs included)
+    generator.generate({} as any);
+
+    const inputType: any = storage.getInputTypeAndExtract(DeprecationInput);
+    expect(inputType).toBeDefined();
+
+    const fields = inputType.getFields();
+    expect(fields.regular.deprecationReason).toBeUndefined();
+    expect(fields.oldField.deprecationReason).toBe('use something else');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As called out in these 2 previous issues below, InputType Fields currently do not pass their deprecationReason to the generated schema.
- https://github.com/nestjs/graphql/issues/2354
- https://github.com/nestjs/nest/issues/13060

Issue Number: N/A

## What is the new behavior?
Properly passes the deprecationReason defined on any InputType Fields along to the generated schema. This was officially supported June 3, 2022 as seen with this PR - https://github.com/graphql/graphql-spec/pull/805

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Running the test suite locally for me required a downgrade to jest 29.x dependencies from jest 30.x. Just a callout
