### PR TITLE
feat(graphql): support one of input objects

### DIFF
--- a/packages/graphql/lib/decorators/input-type.decorator.ts
+++ b/packages/graphql/lib/decorators/input-type.decorator.ts
@@ -25,6 +25,11 @@ export interface InputTypeOptions {
    * If `true`, type will not be registered in the schema.
    */
   isAbstract?: boolean;
+  /**
+   * If 'true', the input type will be '@oneOf' type.
+   * More info about '@oneOf' types in the [GraphQL spec](https://spec.graphql.org/September2025/#sec-OneOf-Input-Objects).
+   */
+  isOneOf?: boolean;
 }
 
 /**
@@ -67,6 +72,7 @@ export function InputType(
       name: name || target.name,
       description: options.description,
       isAbstract: options.isAbstract,
+      isOneOf: options.isOneOf,
     };
     LazyMetadataStorage.store(() =>
       TypeMetadataStorage.addInputTypeMetadata(metadata),

--- a/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
@@ -34,6 +34,7 @@ export class InputTypeDefinitionFactory {
       type: new GraphQLInputObjectType({
         name: metadata.name,
         description: metadata.description,
+        isOneOf: metadata.isOneOf,
         fields: this.generateFields(metadata, options),
         /**
          * AST node has to be manually created in order to define directives

--- a/packages/graphql/lib/schema-builder/metadata/class.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/class.metadata.ts
@@ -10,4 +10,5 @@ export interface ClassMetadata {
   extensions?: Record<string, unknown>;
   properties?: PropertyMetadata[];
   inheritDescription?: boolean;
+  isOneOf?: boolean; // For '@oneOf' input types
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3687

## What is the new behavior?

### Code First

#### Code
```ts
// New `isOneOf` property
@InputType({ isOneOf: true })
export class UserByInput {
  @Field(type => ID)
  id: string;

  @Field(type => String)
  email: string;

  @Field(type => String)
  username: string;
}

@Resolver(of => User)
export class UserResolver {
  @Query(type => User)
  user(@Args("by") by: UserByInput) {
    // ...
  }
}
```

#### Result (Auto Generated GraphQL Schema)
```graphql
input UserByInput @oneOf {
  id: ID
  email: String
  username: String
}

type Query {
  user(by: UserByInput!): User
}
```

### Schema First

#### GraphQL Schema
```graphql
input UserByInput @oneOf {
  id: ID
  email: String
  username: String
}

type Query {
  user(by: UserByInput!): User
}
```

#### Code (Auto Generated Type)
```ts
export class UserByInput {
  id: string;
  email: string;
  username: string;
}

// ...

export abstract class IQuery {
    abstract user(by: UserByInput): Nullable<User> | Promise<Nullable<User>>;
}

type Nullable<T> = T | null;
```

#### Resolver
```ts
@Resolver("User")
export class UserResolver {
  @Query()
  user(@Args("by") by: UserByInput) {
    // ...
  }
}
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
