### PR TITLE
fix(@nestjs/apollo): lazy-load the Express dependency to allow the Fastify usage

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -4,7 +4,6 @@ import {
   ApolloServerErrorCode,
   unwrapResolverError,
 } from '@apollo/server/errors';
-import { expressMiddleware } from '@as-integrations/express5';
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
 import { HttpStatus } from '@nestjs/common';
@@ -126,6 +125,12 @@ export abstract class ApolloBaseDriver<
     options: T,
     { preStartHook }: { preStartHook?: () => void } = {},
   ) {
+    const { expressMiddleware } = loadPackage(
+      '@as-integrations/express5',
+      'GraphQLModule',
+      () => require('@as-integrations/express5'),
+    );
+
     const { path, typeDefs, resolvers, schema } = options;
 
     const httpAdapter = this.httpAdapterHost.httpAdapter;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After upgrading to Apollo Server v5 `@nestjs/apollo` requires you to install `@as-integrations/express5`, otherwise is throws an error. The `@as-integrations/express5` is not needed when the package is used together with Fastify.

Issue Number: #3693


## What is the new behavior?
`@nestjs/apollo` allows for the consumer to use Fastify instead of Express

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
