### PR TITLE
fix(graphql): fix input field extension metadata

### DIFF
--- a/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
@@ -90,7 +90,7 @@ export class InputTypeDefinitionFactory {
             type,
             property.directives,
           ),
-          extensions: metadata.extensions,
+          extensions: property.extensions,
         };
       });
 

--- a/packages/graphql/tests/schema-builder/factories/input-type-definition.factory.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/input-type-definition.factory.spec.ts
@@ -4,6 +4,7 @@ import {
   InputType,
   GraphQLSchemaBuilderModule,
   TypeMetadataStorage,
+  Extensions
 } from '../../../lib';
 import { TypeDefinitionsGenerator } from '../../../lib/schema-builder/type-definitions.generator';
 import { TypeDefinitionsStorage } from '../../../lib/schema-builder/storages/type-definitions.storage';
@@ -19,6 +20,10 @@ class DeprecationInput {
     deprecationReason: 'use something else',
   })
   oldField!: string;
+
+  @Field(() => String)
+  @Extensions({ metadata: 'field' })
+  extendedField!: string;
 }
 
 describe('InputTypeDefinitionFactory (deprecation)', () => {
@@ -52,5 +57,17 @@ describe('InputTypeDefinitionFactory (deprecation)', () => {
     const fields = inputType.getFields();
     expect(fields.regular.deprecationReason).toBeUndefined();
     expect(fields.oldField.deprecationReason).toBe('use something else');
+  });
+
+   it('should add extensions to the field', () => {
+    // Generate type definitions (inputs included)
+    generator.generate({} as any);
+
+    const inputType: any = storage.getInputTypeAndExtract(DeprecationInput);
+    expect(inputType).toBeDefined();
+
+    const fields = inputType.getFields();
+    expect(fields.extendedField.extensions).toBeDefined()
+    expect(fields.extendedField.extensions.metadata).toBe('field')
   });
 });


### PR DESCRIPTION
closes #3764

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3764 


## What is the new behavior?

The `Extensions()` decorator correctly adds metadata to an Input's field.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
