### PR TITLE
fix(graphql,apollo): ensures extensions are added to resolved fields

### DIFF
--- a/packages/apollo/tests/code-first-extensions/app.module.ts
+++ b/packages/apollo/tests/code-first-extensions/app.module.ts
@@ -1,0 +1,19 @@
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '../../lib';
+import { UserModule } from './user/user.module';
+import { Module } from '@nestjs/common';
+
+/**
+ * Main application module for the code-first extensions example.
+ */
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+      playground: false,
+    }),
+    UserModule,
+  ],
+})
+export class AppModule {}

--- a/packages/apollo/tests/code-first-extensions/user/create-user.input.ts
+++ b/packages/apollo/tests/code-first-extensions/user/create-user.input.ts
@@ -1,0 +1,9 @@
+import { Extensions, Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+@Extensions({ exampleExtension: 'exampleValue' })
+export class CreateUserInput {
+  @Extensions({ fieldLevelExtension: 123 })
+  @Field()
+  name!: string;
+}

--- a/packages/apollo/tests/code-first-extensions/user/user-status.dto.ts
+++ b/packages/apollo/tests/code-first-extensions/user/user-status.dto.ts
@@ -1,0 +1,11 @@
+import { ID, Field, ObjectType, Extensions } from '@nestjs/graphql';
+
+@ObjectType()
+export class Status {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  @Extensions({ isPublic: true })
+  code!: string;
+}

--- a/packages/apollo/tests/code-first-extensions/user/user.dto.ts
+++ b/packages/apollo/tests/code-first-extensions/user/user.dto.ts
@@ -1,0 +1,15 @@
+import { Extensions, Field, ID, ObjectType } from '@nestjs/graphql';
+import { Status } from './user-status.dto';
+
+@ObjectType()
+export class User {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  name!: string;
+
+  @Extensions({ isPublic: true })
+  @Field(() => Status, { nullable: true, description: 'DTO Description' })
+  status?: Status;
+}

--- a/packages/apollo/tests/code-first-extensions/user/user.module.ts
+++ b/packages/apollo/tests/code-first-extensions/user/user.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from './user.resolver';
+import { UserService } from './user.service';
+
+@Module({
+  providers: [UserResolver, UserService],
+})
+export class UserModule {}

--- a/packages/apollo/tests/code-first-extensions/user/user.resolver.ts
+++ b/packages/apollo/tests/code-first-extensions/user/user.resolver.ts
@@ -1,0 +1,38 @@
+import {
+  Args,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
+import { User } from './user.dto';
+import { UserService } from './user.service';
+import { CreateUserInput } from './create-user.input';
+import { Status } from './user-status.dto';
+
+@Resolver(() => User)
+export class UserResolver {
+  constructor(private readonly userService: UserService) {}
+
+  @Query(() => [User], { name: 'users' })
+  findAll(): User[] {
+    return this.userService.findAll();
+  }
+
+  @Mutation(() => User)
+  createUser(@Args('createUserInput') createUserInput: CreateUserInput): User {
+    return this.userService.create(createUserInput);
+  }
+
+  @ResolveField('status', undefined, {
+    nullable: true,
+    description: 'Resolve Field Description',
+  })
+  getStatus(@Parent() user: User): Status {
+    return {
+      id: 'status-id',
+      code: 'ACTIVE',
+    };
+  }
+}

--- a/packages/apollo/tests/code-first-extensions/user/user.service.ts
+++ b/packages/apollo/tests/code-first-extensions/user/user.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { User } from './user.dto';
+import { CreateUserInput } from './create-user.input';
+
+@Injectable()
+export class UserService {
+  private users: User[] = [];
+  private idCounter = 1;
+
+  findAll(): User[] {
+    return this.users;
+  }
+
+  findOne(id: string): User | undefined {
+    return this.users.find((user) => user.id === id);
+  }
+
+  create(createUserInput: CreateUserInput): User {
+    const user: User = {
+      id: String(this.idCounter++),
+      name: createUserInput.name,
+    };
+    this.users.push(user);
+    return user;
+  }
+}

--- a/packages/apollo/tests/e2e/code-first-extensions.spec.ts
+++ b/packages/apollo/tests/e2e/code-first-extensions.spec.ts
@@ -1,0 +1,35 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import * as assert from 'assert';
+import { GraphQLObjectType } from 'graphql';
+import { AppModule } from '../code-first-extensions/app.module';
+
+describe('Code-first extensions', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Adds extensions to resolved field', async () => {
+    const { schema } = app.get(GraphQLSchemaHost);
+    const userObject = schema.getType('User') as GraphQLObjectType;
+    assert(userObject, 'User type not found in schema');
+    const statusField = userObject.getFields().status;
+    assert(statusField, 'status field not found in User type');
+
+    const extensions = statusField.extensions;
+
+    expect(extensions.isPublic).toBe(true);
+  });
+});

--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -421,7 +421,7 @@ export class TypeMetadataStorageHost {
     }
     let objectOrInterfaceTypeField =
       objectOrInterfaceTypeMetadata.properties.find(
-        (fieldDef) => fieldDef.name === item.methodName,
+        (fieldDef) => fieldDef.schemaName === item.schemaName,
       );
     for (
       let _objectTypeRef = objectTypeRef;
@@ -430,7 +430,7 @@ export class TypeMetadataStorageHost {
     ) {
       const possibleTypeMetadata = getTypeMetadata(_objectTypeRef);
       objectOrInterfaceTypeField = possibleTypeMetadata?.properties.find(
-        (fieldDef) => fieldDef.name === item.methodName,
+        (fieldDef) => fieldDef.schemaName === item.schemaName,
       );
       if (objectOrInterfaceTypeField) {
         objectTypeRef = _objectTypeRef;

--- a/packages/graphql/tests/graphql.factory.spec.ts
+++ b/packages/graphql/tests/graphql.factory.spec.ts
@@ -4,7 +4,6 @@ import { GraphQLAstExplorer, GraphQLFactory } from '../lib';
 import { GraphQLSchemaBuilder } from '../lib/graphql-schema.builder';
 import { ResolversExplorerService } from '../lib/services/resolvers-explorer.service';
 import { ScalarsExplorerService } from '../lib/services/scalars-explorer.service';
-import gql from 'graphql-tag';
 import { GraphQLSchema } from 'graphql';
 
 describe('GraphQLFactory', () => {


### PR DESCRIPTION
Closes #3778

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3778


## What is the new behavior?

Extensions are correctly applied to resolved fields with renamed method names.


## Does this PR introduce a breaking change?
- [x] Yes (I think)
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

⚠️ Requires Attention - Possibly a breaking change

This bug only occurs when we use a **custom method name** for a resolve field. If we rename the method mentioned above to `status`, it works as expected.

However, it's worth noting that the underlying reason for this bug is how the `TypeMetadataStorage` class identifies a GQL field's metadata - when we rename a resolver's method name, it handles it as a **new** field . The fix I'll propose for this will probably fix #3524 too - but there's a catch here - this might impact how existing applications using the code-first approach build their schemas.

Currently, if we define an Object's field's metadata in **both** the DTO **and** in the @ResolveField() decorator, the `@ResolveField()` will take precedence (but that's a bug, as I mentioned, because of how the metadata storage thinks the method decorated with @ResolveField is actually a new field when renamed). Let's recap the example:

```ts
@ObjectType()
export class User {
  @Field(() => ID)
  id!: string;

  @Field()
  name!: string;

  @Extensions({ isPublic: true })
  @Field(() => Status, { nullable: true, description: 'DTO Description' })
  status?: Status;
}
```

Notice the `status` field description: `DTO Description`.

Now, let's look at the @ResolveField definition:

```ts
@ResolveField('status', undefined, {
    nullable: true,
    description: 'Resolve Field Description',
  })
  getStatus(@Parent() user: User): Status {
    return {
      id: 'status-id',
      code: 'ACTIVE',
    };
  }
```

Right now, when our application schema is generated, the final description will be `Resolve Field Description`. But if we fix the existing bug, the field description will be updated to `DTO Description`.

I wanted to mention this because there might be several applications right now that will have their schema definitions changed if there are any discrepancies between the DTO and the @ResolveField, so, Kamil, you probably need to decide whether to apply this patch to a new major version or a hotfix. 
