### PR TITLE
feat(graphiql): add inputValueDeprecation option

### DIFF
--- a/packages/apollo/lib/graphiql/graphiql-html.factory.ts
+++ b/packages/apollo/lib/graphiql/graphiql-html.factory.ts
@@ -4,6 +4,7 @@ export class GraphiQLHTMLFactory {
   create(options: GraphiQLOptions): string {
     const shouldPersistHeaders = options.shouldPersistHeaders ?? true;
     const isHeadersEditorEnabled = options.isHeadersEditorEnabled ?? true;
+    const inputValueDeprecation = options.inputValueDeprecation ?? false;
     const headers = options.headers ?? {};
     const url = options.url ?? '/graphql';
     const html = `
@@ -53,6 +54,7 @@ export class GraphiQLHTMLFactory {
           defaultEditorToolsVisibility: true,
           shouldPersistHeaders: ${shouldPersistHeaders ? 'true' : 'false'},
           isHeadersEditorEnabled: ${isHeadersEditorEnabled ? 'true' : 'false'},
+          inputValueDeprecation: ${inputValueDeprecation ? 'true' : 'false'},
         }),
         document.getElementById('graphiql'),
       );

--- a/packages/apollo/lib/graphiql/interfaces/graphiql-options.interface.ts
+++ b/packages/apollo/lib/graphiql/interfaces/graphiql-options.interface.ts
@@ -22,4 +22,11 @@ export interface GraphiQLOptions {
    * @default true
    */
   isHeadersEditorEnabled?: boolean;
+  /**
+   * If `true`, the schema documentation will include deprecated input field
+   * and argument values. When introspecting the schema, deprecated values
+   * will be included.
+   * @default false
+   */
+  inputValueDeprecation?: boolean;
 }

--- a/packages/apollo/tests/e2e/graphiql-playground.spec.ts
+++ b/packages/apollo/tests/e2e/graphiql-playground.spec.ts
@@ -71,6 +71,7 @@ describe('GraphiQL Playground', () => {
           defaultEditorToolsVisibility: true,
           shouldPersistHeaders: true,
           isHeadersEditorEnabled: true,
+          inputValueDeprecation: false,
         }),
         document.getElementById('graphiql'),
       );
@@ -160,6 +161,7 @@ describe('GraphiQL Playground', () => {
           defaultEditorToolsVisibility: true,
           shouldPersistHeaders: false,
           isHeadersEditorEnabled: false,
+          inputValueDeprecation: false,
         }),
         document.getElementById('graphiql'),
       );
@@ -167,6 +169,38 @@ describe('GraphiQL Playground', () => {
   </body>
 </html>
 `);
+          done();
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+
+  describe('when "graphiql" has inputValueDeprecation enabled', () => {
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [
+          GraphiQLPlaygroundModule.withEnabledAndCustomized({
+            inputValueDeprecation: true,
+          }),
+        ],
+      }).compile();
+
+      app = module.createNestApplication();
+      await app.init();
+    });
+
+    it(`should render GraphiQL Playground with inputValueDeprecation enabled`, (done) => {
+      request(app.getHttpServer())
+        .get('/graphql')
+        .set('Accept', 'text/html')
+        .expect(200, (err, res) => {
+          if (err) {
+            throw err;
+          }
+          expect(res.text).toContain('inputValueDeprecation: true');
           done();
         });
     });


### PR DESCRIPTION
## Summary

This PR adds an `inputValueDeprecation` option to the GraphiQL configuration that controls whether deprecated input field and argument values are shown in the schema documentation.

## Problem

When using `deprecationReason` on InputType fields, GraphiQL hides these fields by default in the schema documentation panel.

## Solution

Add a new `inputValueDeprecation` option to `GraphiQLOptions` interface that:
- When set to `true`, passes `inputValueDeprecation: true` to the GraphiQL component
- This makes GraphiQL include deprecated values when introspecting the schema
- Defaults to `false` to maintain backward compatibility

## Usage

```typescript
GraphQLModule.forRoot<ApolloDriverConfig>({
  driver: ApolloDriver,
  graphiql: {
    inputValueDeprecation: true,
  },
})
```

## Changes

- `packages/apollo/lib/graphiql/interfaces/graphiql-options.interface.ts` - Added `inputValueDeprecation?: boolean` option with JSDoc
- `packages/apollo/lib/graphiql/graphiql-html.factory.ts` - Pass option to GraphiQL component
- `packages/apollo/tests/e2e/graphiql-playground.spec.ts` - Updated existing tests and added new test case