### PR TITLE
fix(graphql): resolve scalar type mapping failures with Jest globalSetup

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/nestjs/graphql.git"
   },
   "scripts": {
-    "test:e2e": "jest --config ./tests/jest-e2e.ts --runInBand",
+    "test:e2e": "jest --config ./tests/jest-e2e.ts --runInBand && jest --config ./tests/global-setup-issue/jest-global-setup.ts --runInBand",
     "test:e2e:dev": "jest --config ./tests/jest-e2e.ts --runInBand --watch"
   },
   "bugs": {

--- a/packages/apollo/tests/global-setup-issue/app.module.ts
+++ b/packages/apollo/tests/global-setup-issue/app.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '../../lib';
+import { PostsResolver } from './posts.resolver';
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      autoSchemaFile: true,
+    }),
+  ],
+  providers: [PostsResolver],
+})
+export class GlobalSetupIssueModule {}

--- a/packages/apollo/tests/global-setup-issue/global-setup-issue.e2e-spec.ts
+++ b/packages/apollo/tests/global-setup-issue/global-setup-issue.e2e-spec.ts
@@ -1,0 +1,90 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApolloServer } from '@apollo/server';
+import { gql } from 'graphql-tag';
+import { ApolloDriver } from '../../lib';
+import { GlobalSetupIssueModule } from './app.module';
+import { expectSingleResult } from '../utils/assertion-utils';
+
+/**
+ * This test reproduces the issue described in:
+ * https://github.com/nestjs/graphql/issues/3356
+ *
+ * When Jest's globalSetup initializes the NestJS GraphQL app,
+ * the @Field() decorators store type references (String, Number, Boolean)
+ * from the globalSetup's VM context. Later, when the test file runs
+ * in a different VM context and initializes the app again, the
+ * TypeMapperService fails to map the nested type's scalar fields
+ * because its Map uses strict equality (===) for key lookup.
+ *
+ * Expected behavior: The app should initialize successfully
+ * Actual behavior: Error "Cannot determine a GraphQL output type for the 'text'"
+ */
+describe('GlobalSetup Issue - Nested Types (Issue #3356)', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServer;
+
+  beforeEach(async () => {
+    console.log('\n=== Test: Initializing app second time ===');
+    console.log('test String reference:', String);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [GlobalSetupIssueModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    // This will fail with:
+    // "Cannot determine a GraphQL output type for the 'text'. Make sure your class is decorated with an appropriate decorator."
+    await app.init();
+
+    const graphqlModule = app.get<GraphQLModule<ApolloDriver>>(GraphQLModule);
+    apolloClient = graphqlModule.graphQlAdapter?.instance;
+    console.log('=== Test: App initialized successfully ===\n');
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('should query posts with nested content', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          posts {
+            id
+            title
+            content {
+              text
+              description
+            }
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      posts: [
+        {
+          id: '1',
+          title: 'First Post',
+          content: {
+            text: 'Hello World',
+            description: 'A sample post',
+          },
+        },
+        {
+          id: '2',
+          title: 'Second Post',
+          content: {
+            text: 'Another content',
+            description: null,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/apollo/tests/global-setup-issue/global-setup.ts
+++ b/packages/apollo/tests/global-setup-issue/global-setup.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'path';
+import { register } from 'tsconfig-paths';
+
+// Register tsconfig paths for globalSetup context
+// Jest's moduleNameMapper doesn't apply to globalSetup, so we need this
+const tsConfig = require('../../tsconfig.spec.json');
+register({
+  baseUrl: resolve(__dirname, '../..'),
+  paths: tsConfig.compilerOptions.paths,
+});
+
+/**
+ * Jest globalSetup function that initializes the app first.
+ * This runs in a separate VM context from the test files.
+ *
+ * The issue: When this globalSetup initializes the app,
+ * the @Field() decorators capture the String/Number/Boolean
+ * references from this VM context. Later, when test files
+ * run in a different VM context, the TypeMapperService
+ * creates a Map with their own String/Number/Boolean references.
+ * Since Map uses strict equality (===) for key lookup, the
+ * lookup fails because globalSetup's String !== test's String.
+ */
+export default async function globalSetup() {
+  console.log('\n=== Global Setup: Initializing app first time ===');
+  console.log('globalSetup String reference:', String);
+
+  // Dynamic imports after tsconfig-paths is registered
+  const { Test } = await import('@nestjs/testing');
+  const { GlobalSetupIssueModule } = await import('./app.module');
+
+  const moduleFixture = await Test.createTestingModule({
+    imports: [GlobalSetupIssueModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  await app.init();
+  await app.close();
+
+  console.log('=== Global Setup: App closed ===\n');
+}

--- a/packages/apollo/tests/global-setup-issue/jest-global-setup.ts
+++ b/packages/apollo/tests/global-setup-issue/jest-global-setup.ts
@@ -1,0 +1,22 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '../../.',
+  testRegex: 'global-setup-issue\\.e2e-spec\\.ts$',
+  moduleNameMapper: {
+    '^@nestjs/graphql$': '<rootDir>/../graphql/lib',
+    '^@nestjs/graphql/(.*)$': '<rootDir>/../graphql/lib/$1',
+  },
+  transform: {
+    '^.+\\.(t|j)s$': [
+      'ts-jest',
+      { tsconfig: '<rootDir>/tsconfig.spec.json', isolatedModules: true },
+    ],
+  },
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+  globalSetup: '<rootDir>/tests/global-setup-issue/global-setup.ts',
+};
+
+export default config;

--- a/packages/apollo/tests/global-setup-issue/models/nested-content.model.ts
+++ b/packages/apollo/tests/global-setup-issue/models/nested-content.model.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Nested ObjectType that will cause the issue when
+ * the app is initialized twice (globalSetup + test)
+ */
+@ObjectType()
+export class NestedContent {
+  @Field()
+  text: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  constructor(data?: Partial<NestedContent>) {
+    if (data) {
+      Object.assign(this, data);
+    }
+  }
+}

--- a/packages/apollo/tests/global-setup-issue/models/post.model.ts
+++ b/packages/apollo/tests/global-setup-issue/models/post.model.ts
@@ -1,0 +1,23 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { NestedContent } from './nested-content.model';
+
+/**
+ * Post ObjectType with a nested NestedContent field
+ */
+@ObjectType()
+export class Post {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  title: string;
+
+  @Field(() => NestedContent)
+  content: NestedContent;
+
+  constructor(data?: Partial<Post>) {
+    if (data) {
+      Object.assign(this, data);
+    }
+  }
+}

--- a/packages/apollo/tests/global-setup-issue/posts.resolver.ts
+++ b/packages/apollo/tests/global-setup-issue/posts.resolver.ts
@@ -1,0 +1,27 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import { Post } from './models/post.model';
+import { NestedContent } from './models/nested-content.model';
+
+@Resolver(() => Post)
+export class PostsResolver {
+  @Query(() => [Post])
+  posts(): Post[] {
+    return [
+      new Post({
+        id: '1',
+        title: 'First Post',
+        content: new NestedContent({
+          text: 'Hello World',
+          description: 'A sample post',
+        }),
+      }),
+      new Post({
+        id: '2',
+        title: 'Second Post',
+        content: new NestedContent({
+          text: 'Another content',
+        }),
+      }),
+    ];
+  }
+}

--- a/packages/graphql/lib/schema-builder/collections/target-metadata.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/target-metadata.collection.ts
@@ -66,7 +66,16 @@ export class TargetMetadataCollection {
 
   set objectType(val: ObjectTypeMetadata) {
     this._objectType = val;
-    this.all.objectType.push(val);
+    // Check if a type with the same name already exists (can happen with
+    // different VM contexts in Jest globalSetup scenarios). If so, replace it.
+    const existingIndex = this.all.objectType.findIndex(
+      (existing) => existing.name === val.name,
+    );
+    if (existingIndex >= 0) {
+      this.all.objectType[existingIndex] = val;
+    } else {
+      this.all.objectType.push(val);
+    }
   }
 
   get objectType() {


### PR DESCRIPTION
Jest globalSetup runs in a separate VM context. Built-in constructor references (String, Number, Boolean) differ between contexts, which breaks Map-based lookups using strict equality.

Use name-based lookup in TypeMapperService.mapToScalarType() and prevent duplicate ObjectType registration by name in TargetMetadataCollection.

Closes #3356

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using Jest's globalSetup to pre-initialize a NestJS GraphQL application, ObjectTypes with scalar fields (String, Number, Boolean, Date) fail with the error:

```
Cannot determine a GraphQL output type for the 'fieldName'. Make sure your class is decorated with an appropriate decorator.
```

This occurs because Jest's globalSetup runs in a separate VM context from test files(https://jestjs.io/docs/configuration#globalsetup-string, https://github.com/jestjs/jest/issues/6007).
Built-in constructor references captured by @Field() decorators in globalSetup differ from those in the test context, causing TypeMapperService.mapToScalarType() Map-based lookups with strict equality (===) to fail.

Issue Number: #3356

## What is the new behavior?

- Scalar types are correctly mapped regardless of which VM context the type reference originated from
- globalSetup can be used safely with NestJS GraphQL applications
- Duplicate ObjectType registrations from different contexts are handled by replacing existing entries with the same name

Changes:
- TypeMapperService.mapToScalarType(): Use name-based lookup (typeRef.name) instead of Map-based reference equality
- TargetMetadataCollection.objectType setter: Prevent duplicate registrations by checking type name before adding

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The change from reference equality to name-based lookup introduces a minor behavioral difference. If a user defines a custom class with the same name as a built-in type (e.g., class String {}), it will now be incorrectly mapped to the corresponding GraphQL scalar.

This is considered low risk because:
- Naming custom classes the same as built-in types is generally bad practice
- TypeScript/ESLint typically warns against shadowing built-in types
- Such usage is extremely rare in practice

## Other information

Calling TypeMetadataStorage.clear() at the end of globalSetup also resolves the issue without library code changes, but requires users to know about and implement this workaround. 
The name-based approach provides a seamless experience.
I'm not sure which is the best, so I'll leave the judgment to you all.
