### PR TITLE
fix(@nestjs/graphql): handle definitions factory typename option

### DIFF
--- a/packages/graphql/lib/graphql-definitions.factory.ts
+++ b/packages/graphql/lib/graphql-definitions.factory.ts
@@ -39,6 +39,7 @@ export class GraphQLDefinitionsFactory {
       additionalHeader: options.additionalHeader,
       defaultTypeMapping: options.defaultTypeMapping,
       enumsAsTypes: options.enumsAsTypes,
+      typeName: options.typeName,
     };
 
     if (options.watch) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The `GraphQLDefinitionsFactory#generate` method ignores the `typeName` option.

Issue Number: N/A


## What is the new behavior?

The `GraphQLDefinitionsFactory#generate` method correctly forwards the `typeName` option to the AST explorer.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
