### PR TITLE
fix(plugin): emit .js metadata imports for NodeNext readonly output

### DIFF
--- a/packages/graphql/lib/plugin/visitors/model-class.visitor.ts
+++ b/packages/graphql/lib/plugin/visitors/model-class.visitor.ts
@@ -54,7 +54,8 @@ export class ModelClassVisitor {
     const metadataWithImports = [];
     Object.keys(this._collectedMetadata).forEach((filePath) => {
       const metadata = this._collectedMetadata[filePath];
-      const path = filePath.replace(/\.[jt]s$/, '');
+      // Emit explicit .js specifiers so generated metadata.ts stays NodeNext-compatible.
+      const path = filePath.replace(/\.[jt]s$/, '.js');
       const importExpr = ts.factory.createCallExpression(
         ts.factory.createToken(ts.SyntaxKind.ImportKeyword) as ts.Expression,
         undefined,

--- a/packages/graphql/tests/plugin/fixtures/serialized-meta.fixture.ts
+++ b/packages/graphql/tests/plugin/fixtures/serialized-meta.fixture.ts
@@ -9,7 +9,7 @@ export default async () => {
     '@nestjs/graphql': {
       models: [
         [
-          import('./recipes/dto/new-recipe.input'),
+          import('./recipes/dto/new-recipe.input.js'),
           {
             NewRecipeInput: {
               title: {
@@ -22,7 +22,7 @@ export default async () => {
           }
         ],
         [
-          import('./recipes/dto/recipes.args'),
+          import('./recipes/dto/recipes.args.js'),
           {
             RecipesArgs: {
               skip: { type: () => Number },
@@ -31,7 +31,7 @@ export default async () => {
           }
         ],
         [
-          import('./recipes/models/ingredient.model'),
+          import('./recipes/models/ingredient.model.js'),
           {
             Ingredient: {
               id: { type: () => String },
@@ -40,7 +40,7 @@ export default async () => {
           }
         ],
         [
-          import('./recipes/models/recipe.model'),
+          import('./recipes/models/recipe.model.js'),
           {
             Recipe: {
               id: { type: () => String },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Readonly GraphQL plugin metadata emits extensionless dynamic import specifiers (for example `import('./recipes/dto/new-recipe.input')`). In projects using TypeScript `moduleResolution: "nodenext"`, generated metadata files fail type-check/build with `TS2307` because NodeNext requires explicit file extensions for relative imports.

Issue Number: Fixes #3870


## What is the new behavior?
When collecting readonly metadata imports, the plugin now rewrites `*.ts`/`*.js` source paths to explicit `.js` specifiers (for example `import('./recipes/dto/new-recipe.input.js')`). This keeps generated metadata compatible with NodeNext resolution.

Also updated the readonly metadata fixture to reflect `.js` import specifiers.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
Validation run:
- `yarn test:e2e:graphql`
