### PR TITLE
feat(@nestjs/graphql): add stopOnApplicationShutdown option for graceful shutdown

### DIFF
--- a/packages/graphql/lib/graphql.module.ts
+++ b/packages/graphql/lib/graphql.module.ts
@@ -1,6 +1,7 @@
 import { Inject, Logger, Module, RequestMethod } from '@nestjs/common';
 import {
   DynamicModule,
+  OnApplicationShutdown,
   OnModuleDestroy,
   OnModuleInit,
   Provider,
@@ -55,7 +56,7 @@ import { extend, generateString } from './utils';
 export class GraphQLModule<
     TAdapter extends AbstractGraphQLDriver = AbstractGraphQLDriver,
   >
-  implements OnModuleInit, OnModuleDestroy
+  implements OnModuleInit, OnModuleDestroy, OnApplicationShutdown
 {
   public completeOptions: GqlModuleOptions | undefined;
   private static readonly logger = new Logger(GraphQLModule.name, {
@@ -76,7 +77,15 @@ export class GraphQLModule<
   ) {}
 
   async onModuleDestroy() {
-    await this._graphQlAdapter.stop();
+    if (!this.options.stopOnApplicationShutdown) {
+      await this._graphQlAdapter.stop();
+    }
+  }
+
+  async onApplicationShutdown() {
+    if (this.options.stopOnApplicationShutdown) {
+      await this._graphQlAdapter.stop();
+    }
   }
 
   static forRoot<TOptions extends Record<string, any> = GqlModuleOptions>(

--- a/packages/graphql/lib/interfaces/gql-module-options.interface.ts
+++ b/packages/graphql/lib/interfaces/gql-module-options.interface.ts
@@ -148,6 +148,14 @@ export interface GqlModuleOptions<TDriver extends GraphQLDriver = any> {
    * @default true
    */
   introspection?: boolean;
+
+  /**
+   * If `true`, the GraphQL server will stop during `onApplicationShutdown`
+   * instead of `onModuleDestroy`. This allows the server to keep accepting
+   * requests during `beforeApplicationShutdown`, enabling graceful shutdown.
+   * @default false
+   */
+  stopOnApplicationShutdown?: boolean;
 }
 
 export interface GqlOptionsFactory<


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

GraphQL server stops in `onModuleDestroy` lifecycle hook, which is called before `beforeApplicationShutdown`. This prevents users from implementing graceful shutdown logic because the server is already closed when `beforeApplicationShutdown` is triggered.

Issue Number: #3597

## What is the new behavior?

Added `stopOnApplicationShutdown` option to `GqlModuleOptions`. When set to `true`, the GraphQL server stops in `onApplicationShutdown` instead of `onModuleDestroy`, allowing the server to keep accepting requests during `beforeApplicationShutdown` for graceful shutdown handling.

Default is `false` to preserve existing behavior.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

As suggested by @kamilmysliwiec in #3597, this adds a configuration attribute to control the shutdown behavior without introducing a breaking change.