### PR TITLE
feat(packages/graphql): resolve field output type by name

### DIFF
--- a/packages/graphql/lib/interfaces/return-type-func.interface.ts
+++ b/packages/graphql/lib/interfaces/return-type-func.interface.ts
@@ -6,7 +6,8 @@ export type GqlTypeReference<T = any> =
   | GraphQLScalarType
   | Function
   | object
-  | symbol;
+  | symbol
+  | string;
 export type ReturnTypeFuncValue = GqlTypeReference | [GqlTypeReference];
 export type ReturnTypeFunc<T extends ReturnTypeFuncValue = any> = (
   returns?: void,

--- a/packages/graphql/lib/schema-builder/storages/type-definitions.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-definitions.storage.ts
@@ -15,7 +15,7 @@ import { UnionDefinition } from '../factories/union-definition.factory';
 export type GqlInputTypeKey = Function | object;
 export type GqlInputType = InputTypeDefinition | EnumDefinition;
 
-export type GqlOutputTypeKey = Function | object | symbol;
+export type GqlOutputTypeKey = Function | object | symbol | string;
 export type GqlOutputType =
   | InterfaceTypeDefinition
   | ObjectTypeDefinition
@@ -38,13 +38,15 @@ export class TypeDefinitionsStorage {
     Function,
     InputTypeDefinition
   >();
+  private readonly outputTypesByName = new Map<string, GqlOutputType>();
   private inputTypeDefinitionsLinks?: Map<GqlInputTypeKey, GqlInputType>;
   private outputTypeDefinitionsLinks?: Map<GqlOutputTypeKey, GqlOutputType>;
 
   addEnums(enumDefs: EnumDefinition[]) {
-    enumDefs.forEach((item) =>
-      this.enumTypeDefinitions.set(item.enumRef, item),
-    );
+    enumDefs.forEach((item) => {
+      this.enumTypeDefinitions.set(item.enumRef, item);
+      this.outputTypesByName.set(item.type.name, item);
+    });
   }
 
   getEnumByObject(obj: object): EnumDefinition {
@@ -56,7 +58,10 @@ export class TypeDefinitionsStorage {
   }
 
   addUnions(unionDefs: UnionDefinition[]) {
-    unionDefs.forEach((item) => this.unionTypeDefinitions.set(item.id, item));
+    unionDefs.forEach((item) => {
+      this.unionTypeDefinitions.set(item.id, item);
+      this.outputTypesByName.set(item.type.name, item);
+    });
   }
 
   getUnionBySymbol(key: symbol): UnionDefinition {
@@ -68,9 +73,10 @@ export class TypeDefinitionsStorage {
   }
 
   addInterfaces(interfaceDefs: InterfaceTypeDefinition[]) {
-    interfaceDefs.forEach((item) =>
-      this.interfaceTypeDefinitions.set(item.target, item),
-    );
+    interfaceDefs.forEach((item) => {
+      this.interfaceTypeDefinitions.set(item.target, item);
+      this.outputTypesByName.set(item.type.name, item);
+    });
   }
 
   getInterfaceByTarget(type: Function): InterfaceTypeDefinition {
@@ -96,9 +102,10 @@ export class TypeDefinitionsStorage {
   }
 
   addObjectTypes(objectDefs: ObjectTypeDefinition[]) {
-    objectDefs.forEach((item) =>
-      this.objectTypeDefinitions.set(item.target, item),
-    );
+    objectDefs.forEach((item) => {
+      this.objectTypeDefinitions.set(item.target, item);
+      this.outputTypesByName.set(item.type.name, item);
+    });
   }
 
   getObjectTypeByTarget(type: Function): ObjectTypeDefinition {
@@ -142,6 +149,7 @@ export class TypeDefinitionsStorage {
         ...this.interfaceTypeDefinitions.entries(),
         ...this.enumTypeDefinitions.entries(),
         ...this.unionTypeDefinitions.entries(),
+        ...this.outputTypesByName.entries(),
       ]);
     }
     const definition = this.outputTypeDefinitionsLinks.get(key);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In a code-first schema definition, we need to import the type of any object field.
This behavior can lead NodeJS module circular import issue because GraphQL philosophy allows (and even encourage in complex schemas) cyclic relations.

Here is tiny project illustrating the problem with a very simple 3 types schema, using a  classical GraphQL pattern: https://github.com/NicolasGn/nestjs-graphql-circluar-dependency

## What is the new behavior?

To break the circular import, we need to be able to reference a schema type by its name and not exclusively by a type reference.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
