### PR TITLE
fix(@nestjs/graphql): treat single-key string enums as enums in plugin type detection

### DIFF
--- a/packages/graphql/lib/plugin/utils/ast-utils.ts
+++ b/packages/graphql/lib/plugin/utils/ast-utils.ts
@@ -53,7 +53,11 @@ export function isString(type: Type) {
 }
 
 export function isStringLiteral(type: Type) {
-  return hasFlag(type, TypeFlags.StringLiteral) && !type.isUnion();
+  return (
+    hasFlag(type, TypeFlags.StringLiteral) &&
+    !hasFlag(type, TypeFlags.EnumLiteral) &&
+    !type.isUnion()
+  );
 }
 
 export function isBigInt(type: Type) {
@@ -344,13 +348,10 @@ export function safelyMergeObjects(
   // if both of objects are ObjectLiterals, so merge property by property in compile time
   // if one or both of expressions not an object literal, produce rest spread and merge in runtime
   if (ts.isObjectLiteralExpression(a) && ts.isObjectLiteralExpression(b)) {
-    const aMap = a.properties.reduce(
-      (acc, prop) => {
-        acc[(prop.name as ts.Identifier).text] = prop;
-        return acc;
-      },
-      {} as { [propName: string]: ts.ObjectLiteralElementLike },
-    );
+    const aMap = a.properties.reduce((acc, prop) => {
+      acc[(prop.name as ts.Identifier).text] = prop;
+      return acc;
+    }, {} as { [propName: string]: ts.ObjectLiteralElementLike });
 
     b.properties.forEach((prop) => {
       aMap[(prop.name as ts.Identifier).text] = prop;

--- a/packages/graphql/tests/plugin/model-class-visitor.spec.ts
+++ b/packages/graphql/tests/plugin/model-class-visitor.spec.ts
@@ -424,4 +424,27 @@ class Model {
       "
     `);
   });
+
+  it('should treat a single-key string enum as an enum, not a string', () => {
+    const source = `
+enum MultipleEnum {
+    One = 'One',
+    Two = 'Two',
+}
+
+enum SingleEnum {
+    Single = 'Single',
+}
+
+@ObjectType()
+export class ClassA {
+    multipleEnum: MultipleEnum;
+    singleEnum: SingleEnum;
+}
+`;
+
+    const actual = transpile(source, {});
+    expect(actual).toContain('multipleEnum: { type: () => MultipleEnum }');
+    expect(actual).toContain('singleEnum: { type: () => SingleEnum }');
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Bugfix.

## What is the current behavior?

Issue Number: #3025

When a property is typed as a single-member string enum, the plugin's CLI metadata generator emits the property as `String` instead of the enum. The `isStringLiteral` helper in `packages/graphql/lib/plugin/utils/ast-utils.ts` matches any type whose flags include `StringLiteral`, but a one-key string enum carries both the `StringLiteral` and `EnumLiteral` flags, so the enum branch is never reached and `type: () => Enum` metadata is lost.

## What is the new behavior?

`isStringLiteral` now also excludes the `EnumLiteral` flag, so single-key enum members fall through to the existing enum branch and are emitted with the correct `type: () => Enum` metadata. Multi-key string enums were already handled because they surface as unions, which the existing check excluded. A regression test was added under `packages/graphql/tests/plugin/model-class-visitor.spec.ts` that asserts a single-key string enum property is detected as an enum rather than a string literal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified locally with `yarn test:e2e:graphql` (87 passed, 1 skipped). Two snapshot tests fail only on Windows due to a pre-existing CRLF/LF fixture issue that is unrelated to this change.