### PR TITLE
fix(@nestjs/graphql): exclude graphql path from global prefix by default

### DIFF
--- a/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
+++ b/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
@@ -2547,6 +2547,23 @@ exports[`Serialized graph > should generate a post-initialization graph and matc
       },
       "id": "-1187631397"
     },
+    "-2131886386": {
+      "source": "-1497318880",
+      "target": "2022351939",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "GraphQLModule",
+        "sourceClassName": "GraphQLModule",
+        "targetClassName": "ApplicationConfig",
+        "sourceClassToken": "GraphQLModule",
+        "targetClassToken": "ApplicationConfig",
+        "targetModuleName": "GraphQLModule",
+        "keyOrIndex": 5,
+        "injectionType": "constructor",
+        "internal": true
+      },
+      "id": "-2131886386"
+    },
     "-1983130485": {
       "source": "-1251270035",
       "target": "-1119992209",

--- a/packages/graphql/lib/graphql.module.ts
+++ b/packages/graphql/lib/graphql.module.ts
@@ -6,10 +6,12 @@ import {
   OnModuleInit,
   Provider,
 } from '@nestjs/common/interfaces';
-import { HttpAdapterHost } from '@nestjs/core';
+import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import { ROUTE_MAPPED_MESSAGE } from '@nestjs/core/helpers/messages';
 import { InitializeOnPreviewAllowlist } from '@nestjs/core/inspector';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
+import { ExcludeRouteMetadata } from '@nestjs/core/router/interfaces/exclude-route-metadata.interface';
+import { pathToRegexp } from 'path-to-regexp';
 import { AbstractGraphQLDriver } from './drivers/abstract-graphql.driver';
 import { GraphQLFederationFactory } from './federation/graphql-federation.factory';
 import { TypeDefsDecoratorFactory } from './federation/type-defs-decorator.factory';
@@ -27,7 +29,7 @@ import {
 import { MetadataLoader } from './plugin/metadata-loader';
 import { GraphQLSchemaBuilderModule } from './schema-builder/schema-builder.module';
 import { ResolversExplorerService, ScalarsExplorerService } from './services';
-import { extend, generateString } from './utils';
+import { extend, generateString, normalizeRoutePath } from './utils';
 
 /**
  * @publicApi
@@ -54,9 +56,8 @@ import { extend, generateString } from './utils';
   ],
 })
 export class GraphQLModule<
-    TAdapter extends AbstractGraphQLDriver = AbstractGraphQLDriver,
-  >
-  implements OnModuleInit, OnModuleDestroy, OnApplicationShutdown
+  TAdapter extends AbstractGraphQLDriver = AbstractGraphQLDriver,
+> implements OnModuleInit, OnModuleDestroy, OnApplicationShutdown
 {
   public completeOptions: GqlModuleOptions | undefined;
   private static readonly logger = new Logger(GraphQLModule.name, {
@@ -74,7 +75,37 @@ export class GraphQLModule<
     private readonly _graphQlAdapter: AbstractGraphQLDriver,
     private readonly graphQlTypesLoader: GraphQLTypesLoader,
     private readonly gqlSchemaHost: GraphQLSchemaHost,
-  ) {}
+    private readonly applicationConfig: ApplicationConfig,
+  ) {
+    if (!this.options.useGlobalPrefix) {
+      this.excludeFromGlobalPrefix();
+    }
+  }
+
+  /**
+   * Auto-excludes the GraphQL endpoint path from the application's global
+   * prefix so that user middleware registered via
+   * `consumer.apply(...).forRoutes('graphql')` resolves to the same path the
+   * GraphQL endpoint is mounted on. Without this, the middleware would be
+   * registered at `<prefix>/graphql` while the endpoint stays at `/graphql`.
+   * @see https://github.com/nestjs/graphql/issues/3180
+   */
+  private excludeFromGlobalPrefix() {
+    const prefixOptions = this.applicationConfig.getGlobalPrefixOptions();
+    const path = normalizeRoutePath(this.options.path ?? '/graphql');
+    const excludeRoute: ExcludeRouteMetadata = {
+      path,
+      requestMethod: RequestMethod.ALL,
+      pathRegex: pathToRegexp(path).regexp,
+    };
+    const exclude = prefixOptions.exclude
+      ? [...prefixOptions.exclude, excludeRoute]
+      : [excludeRoute];
+    this.applicationConfig.setGlobalPrefixOptions({
+      ...prefixOptions,
+      exclude,
+    });
+  }
 
   async onModuleDestroy() {
     if (!this.options.stopOnApplicationShutdown) {

--- a/packages/graphql/tests/global-prefix-middleware.spec.ts
+++ b/packages/graphql/tests/global-prefix-middleware.spec.ts
@@ -1,0 +1,76 @@
+import { ApplicationConfig } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { AbstractGraphQLDriver, GraphQLModule } from '../lib';
+
+class StubGraphQLDriver extends AbstractGraphQLDriver {
+  public async start(): Promise<void> {}
+  public async stop(): Promise<void> {}
+}
+
+describe('GraphQLModule (global prefix middleware)', () => {
+  it('should auto-exclude the GraphQL path from the global prefix when "useGlobalPrefix" is not enabled (issue #3180)', async () => {
+    const applicationConfig = new ApplicationConfig();
+    applicationConfig.setGlobalPrefix('prefix');
+
+    const module = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot({
+          driver: StubGraphQLDriver,
+        }),
+      ],
+    })
+      .overrideProvider(ApplicationConfig)
+      .useValue(applicationConfig)
+      .compile();
+
+    await module.init();
+
+    const exclude = applicationConfig.getGlobalPrefixOptions().exclude ?? [];
+    const excludedPaths = exclude.map((route) => route.path);
+    expect(excludedPaths).toContain('/graphql');
+  });
+
+  it('should not auto-exclude the GraphQL path when "useGlobalPrefix" is enabled', async () => {
+    const applicationConfig = new ApplicationConfig();
+    applicationConfig.setGlobalPrefix('prefix');
+
+    const module = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot({
+          driver: StubGraphQLDriver,
+          useGlobalPrefix: true,
+        }),
+      ],
+    })
+      .overrideProvider(ApplicationConfig)
+      .useValue(applicationConfig)
+      .compile();
+
+    await module.init();
+
+    const exclude = applicationConfig.getGlobalPrefixOptions().exclude ?? [];
+    const excludedPaths = exclude.map((route) => route.path);
+    expect(excludedPaths).not.toContain('/graphql');
+  });
+
+  it('should auto-exclude the GraphQL path even before "setGlobalPrefix" is called, so it persists once the prefix is later set', async () => {
+    const applicationConfig = new ApplicationConfig();
+
+    const module = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot({
+          driver: StubGraphQLDriver,
+        }),
+      ],
+    })
+      .overrideProvider(ApplicationConfig)
+      .useValue(applicationConfig)
+      .compile();
+
+    await module.init();
+
+    const exclude = applicationConfig.getGlobalPrefixOptions().exclude ?? [];
+    const excludedPaths = exclude.map((route) => route.path);
+    expect(excludedPaths).toContain('/graphql');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/graphql/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) — N/A (behavior fix; no public API change)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Note: only `Bugfix` is ticked above.

- [x] Bugfix

## What is the current behavior?

Issue Number: #3180

Middleware registered with `consumer.apply(SomeMiddleware).forRoutes('graphql')` does not fire for GraphQL requests when `app.setGlobalPrefix(...)` is set without `useGlobalPrefix: true` on the GraphQL module. NestJS auto-prepends the global prefix to user middleware paths, but the GraphQL endpoint stays at `/graphql`, so the two paths diverge (middleware ends up bound at `/prefix/graphql` while the endpoint serves `/graphql`).

## What is the new behavior?

`GraphQLModule` now auto-excludes its endpoint path from the application's global prefix on construction (only when `useGlobalPrefix` is not enabled). User middleware registered via `forRoutes('graphql')` now resolves to `/graphql` and matches the endpoint.

Implementation lives in `packages/graphql/lib/graphql.module.ts` (`excludeFromGlobalPrefix`); regression tests added under `packages/graphql/tests/global-prefix-middleware.spec.ts`. The DI snapshot in `packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap` was regenerated to reflect the new `ApplicationConfig` constructor edge.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a default behavior change: prior to this PR, projects with `app.setGlobalPrefix('prefix')` (no `useGlobalPrefix` on the GraphQL module) had their middleware bound at `/prefix/graphql`, which never matched the GraphQL endpoint at `/graphql`. After this PR, the middleware binds at `/graphql` and fires correctly. Projects relying on the previous (broken) behavior should opt back in by setting `useGlobalPrefix: true` on `GraphQLModule.forRoot(...)`. Verified with `yarn test:e2e:graphql` and `yarn test:e2e:apollo` — all pre-existing global-prefix specs continue to pass.