### PR TITLE
fix(@nestjs/graphql): allow CustomScalar methods to return null

### DIFF
--- a/packages/graphql/lib/interfaces/custom-scalar.interface.ts
+++ b/packages/graphql/lib/interfaces/custom-scalar.interface.ts
@@ -1,12 +1,11 @@
-import {
-  GraphQLScalarLiteralParser,
-  GraphQLScalarSerializer,
-  GraphQLScalarValueParser,
-} from 'graphql';
+import { ValueNode } from 'graphql';
 
 export interface CustomScalar<T, K> {
   description?: string;
-  parseValue: GraphQLScalarValueParser<K>;
-  serialize: GraphQLScalarSerializer<T>;
-  parseLiteral: GraphQLScalarLiteralParser<K>;
+  parseValue: (value: unknown) => K | null | undefined;
+  serialize: (value: unknown) => T | null | undefined;
+  parseLiteral: (
+    valueNode: ValueNode,
+    variables?: { [key: string]: any } | null,
+  ) => K | null | undefined;
 }

--- a/packages/graphql/tests/interfaces/custom-scalar.interface.spec.ts
+++ b/packages/graphql/tests/interfaces/custom-scalar.interface.spec.ts
@@ -1,0 +1,51 @@
+import { Kind, ValueNode } from 'graphql';
+import { expectTypeOf } from 'vitest';
+import { CustomScalar } from '../../lib/interfaces';
+
+describe('CustomScalar', () => {
+  it('should allow parseLiteral, parseValue and serialize to return null or undefined', () => {
+    class DateScalar implements CustomScalar<number, Date> {
+      description = 'Date custom scalar type';
+
+      parseValue(value: unknown): Date | null {
+        return typeof value === 'number' ? new Date(value) : null;
+      }
+
+      serialize(value: unknown): number | null {
+        return value instanceof Date ? value.getTime() : null;
+      }
+
+      parseLiteral(ast: ValueNode): Date | null {
+        if (ast.kind === Kind.INT) {
+          return new Date(parseInt(ast.value, 10));
+        }
+        return null;
+      }
+    }
+
+    const scalar = new DateScalar();
+
+    expect(
+      scalar.parseLiteral({ kind: Kind.STRING, value: 'noop' }),
+    ).toBeNull();
+    expect(scalar.parseLiteral({ kind: Kind.INT, value: '0' })).toBeInstanceOf(
+      Date,
+    );
+    expect(scalar.parseValue('not-a-number')).toBeNull();
+    expect(scalar.serialize('not-a-date')).toBeNull();
+  });
+
+  it('should expose method signatures whose return types include null and undefined', () => {
+    type Methods = CustomScalar<number, Date>;
+
+    expectTypeOf<ReturnType<Methods['parseLiteral']>>().toEqualTypeOf<
+      Date | null | undefined
+    >();
+    expectTypeOf<ReturnType<Methods['parseValue']>>().toEqualTypeOf<
+      Date | null | undefined
+    >();
+    expectTypeOf<ReturnType<Methods['serialize']>>().toEqualTypeOf<
+      number | null | undefined
+    >();
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/graphql/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Bugfix

## What is the current behavior?

Issue Number: #3176

The `CustomScalar<T, K>` interface types `parseValue`, `serialize`, and `parseLiteral` via the upstream `graphql` package's `GraphQLScalarValueParser<K>`, `GraphQLScalarSerializer<T>`, and `GraphQLScalarLiteralParser<K>` aliases. Since `graphql` v16, those aliases no longer wrap their return type in `Maybe`, so consumers compiling with `strictNullChecks` cannot return `null` or `undefined` from those methods — even though every NestJS-shipped scalar (`GraphQLISODateTime`, `GraphQLTimestamp`) and the documented custom-scalar sample do exactly that. Issue #222 (PR #749) originally fixed this with `Maybe`-wrapped types but the v16 upstream change silently regressed it.

## What is the new behavior?

The three methods are now declared inline on the interface with explicit `K | null | undefined` / `T | null | undefined` return types, matching what the reporter proposed and the maintainer signed off on. No runtime behavior change — the schema-builder code never relied on the old aliases. A regression spec at `packages/graphql/tests/interfaces/custom-scalar.interface.spec.ts` covers both runtime nulls and a compile-time `expectTypeOf` assertion on the return types.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Type signature is widened, which is backward-compatible: existing scalars that never return `null` still satisfy the new signature. The only consumer-visible change is that strict-mode projects can now legitimately return `null`/`undefined` without a TypeScript error.

## Other information

Verified with `yarn test:e2e:graphql` (88 passed; 2 pre-existing Windows CRLF snapshot failures in `model-class-visitor.spec.ts` and `readonly-visitor.spec.ts` are reproducible on clean master and unrelated). `yarn lint` clean repo-wide.