### PR TITLE
fix(apollo): respect useGlobalPrefix on custom subscription path

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -101,9 +101,26 @@ export abstract class ApolloBaseDriver<
       defaults.plugins || [],
     );
 
+    this.normalizeSubscriptionsPath(options);
     this.wrapContextResolver(options);
     this.wrapFormatErrorFn(options);
     return options;
+  }
+
+  private normalizeSubscriptionsPath(options: T) {
+    const subscriptions = (options as ApolloDriverConfig).subscriptions;
+    if (!subscriptions) {
+      return;
+    }
+    for (const protocol of [
+      'graphql-ws',
+      'subscriptions-transport-ws',
+    ] as const) {
+      const config = subscriptions[protocol];
+      if (config && typeof config === 'object' && config.path) {
+        config.path = this.applyGlobalPrefix(config.path, options);
+      }
+    }
   }
 
   public subscriptionWithFilter(

--- a/packages/apollo/tests/e2e/subscription-global-prefix.spec.ts
+++ b/packages/apollo/tests/e2e/subscription-global-prefix.spec.ts
@@ -1,0 +1,90 @@
+import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
+import { GraphQLFactory } from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { ApolloDriver } from '../../lib/drivers';
+import { ApolloDriverConfig } from '../../lib/interfaces';
+
+describe('Subscription path with global prefix', () => {
+  async function createDriver(prefix: string) {
+    const applicationConfig = new ApplicationConfig();
+    applicationConfig.setGlobalPrefix(prefix);
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ApolloDriver,
+        { provide: ApplicationConfig, useValue: applicationConfig },
+        { provide: HttpAdapterHost, useValue: {} },
+        { provide: GraphQLFactory, useValue: {} },
+      ],
+    }).compile();
+
+    return moduleRef.get(ApolloDriver);
+  }
+
+  it('prefixes the http endpoint when useGlobalPrefix is true', async () => {
+    const driver = await createDriver('api');
+    const merged = await driver.mergeDefaultOptions({
+      useGlobalPrefix: true,
+    } as ApolloDriverConfig);
+
+    expect(merged.path).toBe('/api/graphql');
+  });
+
+  it('prefixes a custom subscription path when useGlobalPrefix is true', async () => {
+    const driver = await createDriver('api');
+    const merged = await driver.mergeDefaultOptions({
+      useGlobalPrefix: true,
+      subscriptions: {
+        'graphql-ws': { path: '/graphql' },
+        'subscriptions-transport-ws': { path: '/graphql' },
+      },
+    } as ApolloDriverConfig);
+
+    expect(merged.subscriptions?.['graphql-ws']).toMatchObject({
+      path: '/api/graphql',
+    });
+    expect(merged.subscriptions?.['subscriptions-transport-ws']).toMatchObject({
+      path: '/api/graphql',
+    });
+  });
+
+  it('prefixes a non-default subscription path when useGlobalPrefix is true', async () => {
+    const driver = await createDriver('api');
+    const merged = await driver.mergeDefaultOptions({
+      useGlobalPrefix: true,
+      subscriptions: {
+        'graphql-ws': { path: '/subscriptions' },
+      },
+    } as ApolloDriverConfig);
+
+    expect(merged.subscriptions?.['graphql-ws']).toMatchObject({
+      path: '/api/subscriptions',
+    });
+  });
+
+  it('leaves subscription path untouched when useGlobalPrefix is false', async () => {
+    const driver = await createDriver('api');
+    const merged = await driver.mergeDefaultOptions({
+      useGlobalPrefix: false,
+      subscriptions: {
+        'graphql-ws': { path: '/graphql' },
+      },
+    } as ApolloDriverConfig);
+
+    expect(merged.subscriptions?.['graphql-ws']).toMatchObject({
+      path: '/graphql',
+    });
+  });
+
+  it('does not touch boolean subscription protocol shorthand', async () => {
+    const driver = await createDriver('api');
+    const merged = await driver.mergeDefaultOptions({
+      useGlobalPrefix: true,
+      subscriptions: {
+        'graphql-ws': true,
+      },
+    } as ApolloDriverConfig);
+
+    expect(merged.subscriptions?.['graphql-ws']).toBe(true);
+  });
+});

--- a/packages/graphql/lib/drivers/abstract-graphql.driver.ts
+++ b/packages/graphql/lib/drivers/abstract-graphql.driver.ts
@@ -57,11 +57,15 @@ export abstract class AbstractGraphQLDriver<
   }
 
   protected getNormalizedPath(options: TOptions): string {
+    return this.applyGlobalPrefix(options.path, options);
+  }
+
+  protected applyGlobalPrefix(path: string, options: TOptions): string {
     const prefix = this.applicationConfig?.getGlobalPrefix() ?? '';
     const useGlobalPrefix = prefix && options.useGlobalPrefix;
-    const gqlOptionsPath = normalizeRoutePath(options.path);
+    const normalizedPath = normalizeRoutePath(path);
     return useGlobalPrefix
-      ? normalizeRoutePath(prefix) + gqlOptionsPath
-      : gqlOptionsPath;
+      ? normalizeRoutePath(prefix) + normalizedPath
+      : normalizedPath;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2477

When `app.setGlobalPrefix('api')` is set together with `GraphQLModule.forRoot({ useGlobalPrefix: true, subscriptions: { 'graphql-ws': { path: '/graphql' } } })`, the HTTP endpoint correctly resolves to `/api/graphql` but the websocket subscription endpoint binds to `/graphql`. Clients connecting to `/api/graphql` get their upgrade rejected because the WSS handler is mounted on the un-prefixed path. The boolean shorthand `subscriptions: { 'graphql-ws': true }` already works correctly because the apollo driver later defaults the subscription path to the (already prefixed) `options.path`.

## What is the new behavior?

Extracted the prefix-application logic in `AbstractGraphQLDriver.getNormalizedPath` into a reusable protected helper `applyGlobalPrefix(path, options)` (no behavior change for existing callers). In `ApolloBaseDriver.mergeDefaultOptions`, added `normalizeSubscriptionsPath(options)` which iterates over `subscriptions['graphql-ws']` and `subscriptions['subscriptions-transport-ws']`, applying `applyGlobalPrefix` to any user-supplied `path`. Boolean shorthand is left untouched. Mercurius needs no change because its transport reuses the already-prefixed mercurius route. A regression spec covering five cases (HTTP-prefix baseline, custom subscription path with prefix, non-default custom path with prefix, prefix-disabled passthrough, boolean shorthand passthrough) lives at `packages/apollo/tests/e2e/subscription-global-prefix.spec.ts`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The change matches what users with `useGlobalPrefix: true` already expect: their HTTP endpoint and subscription endpoint live under the same prefix. The previous behavior was the bug. See **Other information** for a note on clients that may have been relying on the un-prefixed subscription path.

## Other information

Behavior change visible to users currently relying on the un-prefixed subscription path with `useGlobalPrefix: true`: they must connect to the prefixed URL after this fix. This matches the documented intent of `useGlobalPrefix`. Verified with `yarn test:e2e:graphql`, `yarn test:e2e:apollo`, and `yarn test:e2e:mercurius` — only the unrelated pre-existing Windows CRLF snapshot failures (`tests/plugin/model-class-visitor.spec.ts` `es5-eager-imports`, `tests/plugin/readonly-visitor.spec.ts`) appear, and they reproduce on clean master.