### PR TITLE
fix(@nestjs/graphql): inherit class directives from abstract parents

### DIFF
--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -282,9 +282,7 @@ export class TypeMetadataStorageHost {
         item.properties = this.getClassFieldsByPredicate(item);
       }
       if (!item.directives) {
-        item.directives = this.metadataByTargetCollection
-          .get(item.target)
-          .classDirectives.getAll();
+        item.directives = this.getInheritedClassDirectives(item.target);
       }
       if (!item.extensions) {
         item.extensions = this.metadataByTargetCollection
@@ -295,6 +293,31 @@ export class TypeMetadataStorageHost {
           );
       }
     });
+  }
+
+  private getInheritedClassDirectives(
+    target: Function,
+  ): ClassDirectiveMetadata[] {
+    const directives: ClassDirectiveMetadata[] = [];
+    const seenSdls = new Set<string>();
+
+    let current: Function | null = target;
+    while (current && current !== Function.prototype) {
+      const targetDirectives = this.metadataByTargetCollection
+        .get(current)
+        .classDirectives.getAll();
+
+      targetDirectives.forEach((directive) => {
+        if (!seenSdls.has(directive.sdl)) {
+          seenSdls.add(directive.sdl);
+          directives.push(directive);
+        }
+      });
+
+      current = Object.getPrototypeOf(current);
+    }
+
+    return directives;
   }
 
   clear() {

--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -298,26 +298,35 @@ export class TypeMetadataStorageHost {
   private getInheritedClassDirectives(
     target: Function,
   ): ClassDirectiveMetadata[] {
-    const directives: ClassDirectiveMetadata[] = [];
-    const seenSdls = new Set<string>();
+    const ownDirectives = this.metadataByTargetCollection
+      .get(target)
+      .classDirectives.getAll();
 
-    let current: Function | null = target;
+    const inherited: ClassDirectiveMetadata[] = [];
+    const seenSdls = new Set<string>(ownDirectives.map((d) => d.sdl));
+
+    let current: Function | null = Object.getPrototypeOf(target);
     while (current && current !== Function.prototype) {
-      const targetDirectives = this.metadataByTargetCollection
+      this.metadataByTargetCollection
         .get(current)
-        .classDirectives.getAll();
-
-      targetDirectives.forEach((directive) => {
-        if (!seenSdls.has(directive.sdl)) {
-          seenSdls.add(directive.sdl);
-          directives.push(directive);
-        }
-      });
-
+        .classDirectives.getAll()
+        .forEach((directive) => {
+          if (!seenSdls.has(directive.sdl)) {
+            seenSdls.add(directive.sdl);
+            inherited.push(directive);
+          }
+        });
       current = Object.getPrototypeOf(current);
     }
 
-    return directives;
+    // Preserve the shared-reference semantic when nothing is inherited: the
+    // compile() pass mutates the per-target `classDirectives` array in place
+    // (reverse() is called on it), and `item.directives` is expected to stay
+    // in sync with that mutation. Only produce a fresh array when we actually
+    // have to combine directives from an abstract parent.
+    return inherited.length === 0
+      ? ownDirectives
+      : [...ownDirectives, ...inherited];
   }
 
   clear() {

--- a/packages/graphql/tests/schema-builder/factories/directive-inheritance.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/directive-inheritance.spec.ts
@@ -1,0 +1,63 @@
+import { Test } from '@nestjs/testing';
+import { GraphQLObjectType } from 'graphql';
+import {
+  Directive,
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../../lib';
+
+@ObjectType({ isAbstract: true })
+@Directive('@key(fields: "id")')
+class AbstractBase {
+  @Field(() => ID)
+  id: number;
+}
+
+@ObjectType()
+class DerivedUser extends AbstractBase {
+  @Field()
+  name: string;
+}
+
+@Resolver(() => DerivedUser)
+class DerivedUserResolver {
+  @Query(() => DerivedUser)
+  user(): DerivedUser {
+    return null;
+  }
+}
+
+describe('Directive inheritance from abstract @ObjectType', () => {
+  let schemaFactory: GraphQLSchemaFactory;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should propagate class-level directives from an abstract parent to the derived type', async () => {
+    const schema = await schemaFactory.create([DerivedUserResolver], {
+      skipCheck: true,
+    });
+
+    const derivedType = schema.getType('DerivedUser') as GraphQLObjectType;
+    expect(derivedType).toBeDefined();
+
+    const directives = derivedType.astNode?.directives ?? [];
+    const directiveNames = directives.map((d) => d.name.value);
+    expect(directiveNames).toContain('key');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Only `Bugfix` applies: [x] Bugfix.

## What is the current behavior?

Issue Number: #2960

When a `@Directive(...)` decorator is placed on an abstract `@ObjectType()` parent class (e.g. `@Directive('@key(fields: "id")')`), classes that extend that parent do not inherit the directive metadata. Field metadata inherits correctly, but class-level directives silently disappear on every derived concrete type. The bug surfaces in federation setups where shared keys/directives live on a base class.

## What is the new behavior?

`TypeMetadataStorageHost.compileClassMetadata()` now sources class-level directive metadata via a new private helper, `getInheritedClassDirectives(target)`, which walks the prototype chain via `Object.getPrototypeOf` and collects `classDirectives` from every ancestor, de-duplicating by SDL string. Child-first ordering means own directives win the de-dup pass, preserving prior single-class behavior.

A regression spec at `packages/graphql/tests/schema-builder/factories/directive-inheritance.spec.ts` declares an abstract `@ObjectType({ isAbstract: true })` parent decorated with `@Directive('@key(fields: "id")')`, a derived concrete `@ObjectType()`, builds the schema via `GraphQLSchemaFactory`, and asserts the resulting type's `astNode.directives` includes `key`. (graphql-js `printSchema` does not emit type-level directives in SDL — that's why the assertion targets `astNode.directives`, which is what federation tooling reads.)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The change strictly adds inherited directives to the compiled metadata; classes that previously had no inherited directives still have none if no ancestor declared any. Existing classes that declared their own directives continue to see only those directives (de-dup keeps the child copy first).

## Other information

Verified with `yarn test:e2e:graphql` (87 passed plus the unrelated pre-existing Windows CRLF snapshot failures in `tests/plugin/model-class-visitor.spec.ts` `es5-eager-imports` and `tests/plugin/readonly-visitor.spec.ts` `should generate a serialized metadata`, both reproducible on clean master). `npx oxlint` and `npx prettier` clean on touched files only.