### PR TITLE
fix(apollo): preserve HTTP 200 for execution-level GraphQL errors

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -103,6 +103,13 @@ export abstract class ApolloBaseDriver<
 
     this.wrapContextResolver(options);
     this.wrapFormatErrorFn(options);
+
+    if (options.autoTransformHttpErrors !== false) {
+      (options as ApolloDriverConfig).plugins = [
+        ...((options as ApolloDriverConfig).plugins || []),
+        this.createPreserveHttpStatusPlugin(),
+      ];
+    }
     return options;
   }
 
@@ -215,6 +222,34 @@ export abstract class ApolloBaseDriver<
     });
 
     this.apolloServer = server;
+  }
+
+  private createPreserveHttpStatusPlugin() {
+    // When a resolver throws an error whose `extensions.http.status` is set
+    // (either directly via GraphQLError or transitively via NestJS HTTP
+    // exceptions in user code), Apollo Server uses that value as the HTTP
+    // response status. Some GraphQL clients/UIs then refuse to parse the
+    // response as a normal `{ data, errors }` payload and instead wrap it as
+    // a transport-level error. Reset the HTTP status to 200 once execution
+    // has run so the response shape stays stable. Request-level failures
+    // (parse, validate) are unaffected because their body has no `data` key.
+    // @see https://github.com/nestjs/graphql/issues/2940
+    return {
+      async requestDidStart() {
+        return {
+          async willSendResponse(requestContext: any) {
+            const body = requestContext.response?.body;
+            if (
+              body?.kind === 'single' &&
+              'data' in (body.singleResult ?? {}) &&
+              requestContext.response?.http
+            ) {
+              requestContext.response.http.status = 200;
+            }
+          },
+        };
+      },
+    };
   }
 
   private wrapFormatErrorFn(options: T) {

--- a/packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts
+++ b/packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts
@@ -1,0 +1,128 @@
+import { BadRequestException, INestApplication, Module } from '@nestjs/common';
+import { GraphQLModule, Query, Resolver } from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { GraphQLError } from 'graphql';
+import request from 'supertest';
+import { ApolloDriver, ApolloDriverConfig } from '../../lib';
+
+@Resolver()
+class IssueResolver {
+  @Query(() => String)
+  throwHttpException(): string {
+    throw new BadRequestException('foo');
+  }
+
+  @Query(() => String)
+  throwGraphqlErrorWithHttpStatus(): string {
+    throw new GraphQLError('boom', {
+      extensions: {
+        code: 'BAD_REQUEST',
+        http: { status: 400 },
+      },
+    });
+  }
+}
+
+function buildModule(autoTransformHttpErrors?: boolean) {
+  @Module({
+    imports: [
+      GraphQLModule.forRoot<ApolloDriverConfig>({
+        driver: ApolloDriver,
+        autoSchemaFile: true,
+        includeStacktraceInErrorResponses: false,
+        autoTransformHttpErrors,
+      }),
+    ],
+    providers: [IssueResolver],
+  })
+  class Issue2940Module {}
+  return Issue2940Module;
+}
+
+async function bootstrap(autoTransformHttpErrors?: boolean) {
+  const moduleRef = await Test.createTestingModule({
+    imports: [buildModule(autoTransformHttpErrors)],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  return app;
+}
+
+describe('Issue #2940 - GraphQL error formatting with HTTP status', () => {
+  describe('default (autoTransformHttpErrors enabled)', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+      app = await bootstrap();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should return the standard {data, errors} response shape (HTTP 200) when a NestJS HttpException is thrown from a resolver', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwHttpException }' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data', null);
+      expect(res.body).toHaveProperty('errors');
+      expect(res.body).not.toHaveProperty('error');
+      expect(res.body.errors[0].extensions).toMatchObject({
+        code: 'BAD_REQUEST',
+        originalError: {
+          statusCode: 400,
+          message: 'foo',
+        },
+      });
+      expect(res.body.errors[0].extensions).not.toHaveProperty('http');
+    });
+
+    it('should keep the response at HTTP 200 when a resolver throws a GraphQLError carrying extensions.http.status', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwGraphqlErrorWithHttpStatus }' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data', null);
+      expect(res.body).toHaveProperty('errors');
+      expect(res.body).not.toHaveProperty('error');
+      expect(res.body.errors[0].extensions.code).toBe('BAD_REQUEST');
+      expect(res.body.errors[0].extensions).not.toHaveProperty('http');
+    });
+
+    it('should still return a non-200 status for request-level errors (e.g. parse failures)', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwHttpException ' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).not.toHaveProperty('data');
+      expect(res.body).toHaveProperty('errors');
+    });
+  });
+
+  describe('with autoTransformHttpErrors disabled', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+      app = await bootstrap(false);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should preserve Apollo Server`s extensions.http.status response status when the user opts out', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwGraphqlErrorWithHttpStatus }' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('data', null);
+      expect(res.body).toHaveProperty('errors');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

(Selected: **Bugfix**.)

## What is the current behavior?

Issue Number: #2940

When a resolver throws a raw `GraphQLError` whose `extensions.http.status` is set (or a NestJS HTTP exception that maps onto Apollo's HTTP-status semantics), the GraphQL endpoint returns the resolver-derived HTTP 4xx/5xx status. Some GraphQL clients and UIs (Apollo Studio, Sandbox) then refuse to parse the response as `{data, errors}` and wrap it as a transport-level `{ error: ... }` envelope, which is what the issue's reporter sees. The bug is Apollo-specific because Mercurius does not honour `extensions.http.status`.

## What is the new behavior?

Adds a tiny Apollo Server plugin (`createPreserveHttpStatusPlugin`) registered in `ApolloBaseDriver.mergeDefaultOptions`. The plugin runs in `willSendResponse` after Apollo has finished merging error-derived HTTP status onto the response and resets the status to **200** when the request reached execution (detected by the presence of a `data` key on `singleResult`). Request-level failures (parse, validate) are untouched because their body has no `data` key. The plugin is gated on the existing `autoTransformHttpErrors` flag — users who want Apollo's default behaviour can opt out with `autoTransformHttpErrors: false`. Regression spec at `packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts` covers four cases: NestJS exception → 200, raw GraphQLError with `http.status: 400` → 200, parse failure → 400 preserved, opt-out → 400 preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Users currently throwing raw `GraphQLError` with `extensions.http.status` set deliberately and *expecting* the HTTP status to leak into the response will now see HTTP 200 unless they set `autoTransformHttpErrors: false`. The flag already exists in the public driver config and is exactly the knob for this behaviour.

## Other information

The plugin reuses the existing public flag `autoTransformHttpErrors`. Users who explicitly relied on `extensions.http.status` mapping to a non-2xx response can opt back in by setting `autoTransformHttpErrors: false`. Verified with the full apollo suite (`yarn test:e2e:apollo`: 133 passed / 3 skipped) including existing `pipes.spec.ts` and `guards-filters.spec.ts` error-handling tests, plus `yarn test:e2e:graphql` (only the unrelated pre-existing Windows CRLF snapshot failures in `tests/plugin/model-class-visitor.spec.ts` `es5-eager-imports` and `tests/plugin/readonly-visitor.spec.ts` appear; both reproducible on clean master). Prettier (v3 binary) and oxlint clean on touched files.