### PR TITLE
feat(@nestjs/graphql): default federation to v2.12 directives

### DIFF
--- a/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
+++ b/packages/graphql/lib/federation/type-defs-federation2.decorator.ts
@@ -9,19 +9,27 @@ export class TypeDefsFederation2Decorator {
   decorate(typeDefs: string, config: Federation2Config = { version: 2 }) {
     const {
       directives = [
+        '@authenticated',
+        '@cacheTag',
         '@composeDirective',
+        '@context',
+        '@cost',
         '@extends',
         '@external',
+        '@fromContext',
         '@inaccessible',
         '@interfaceObject',
         '@key',
+        '@listSize',
         '@override',
+        '@policy',
         '@provides',
         '@requires',
+        '@requiresScopes',
         '@shareable',
         '@tag',
       ],
-      importUrl = 'https://specs.apollo.dev/federation/v2.3',
+      importUrl = 'https://specs.apollo.dev/federation/v2.12',
     } = config;
     const mappedDirectives = directives
       .map((directive) => {

--- a/packages/graphql/lib/interfaces/schema-file-config.interface.ts
+++ b/packages/graphql/lib/interfaces/schema-file-config.interface.ts
@@ -10,12 +10,12 @@ export interface Federation2Config {
   version: 2;
   /**
    * The imported directives
-   * @default ['@composeDirective', '@extends', '@external', '@inaccessible', '@interfaceObject', '@key', '@override', '@provides', '@requires', '@shareable', '@tag']
+   * @default ['@authenticated', '@cacheTag', '@composeDirective', '@context', '@cost', '@extends', '@external', '@fromContext', '@inaccessible', '@interfaceObject', '@key', '@listSize', '@override', '@policy', '@provides', '@requires', '@requiresScopes', '@shareable', '@tag']
    */
   directives?: (string | AliasDirectiveImport)[];
   /**
    * The import link
-   * @default 'https://specs.apollo.dev/federation/v2.3'
+   * @default 'https://specs.apollo.dev/federation/v2.12'
    */
   importUrl?: string;
 }

--- a/packages/graphql/tests/type-defs-federation2.decorator.spec.ts
+++ b/packages/graphql/tests/type-defs-federation2.decorator.spec.ts
@@ -1,0 +1,84 @@
+import { TypeDefsFederation2Decorator } from '../lib/federation/type-defs-federation2.decorator';
+
+describe('TypeDefsFederation2Decorator', () => {
+  let decorator: TypeDefsFederation2Decorator;
+
+  beforeEach(() => {
+    decorator = new TypeDefsFederation2Decorator();
+  });
+
+  describe('decorate', () => {
+    it('should default to federation v2.12 import url', () => {
+      const result = decorator.decorate('type Query { hello: String }');
+      expect(result).toContain(
+        'url: "https://specs.apollo.dev/federation/v2.12"',
+      );
+    });
+
+    it('should include the v2.12 default directives', () => {
+      const result = decorator.decorate('type Query { hello: String }');
+      const expectedDirectives = [
+        '@authenticated',
+        '@cacheTag',
+        '@composeDirective',
+        '@context',
+        '@cost',
+        '@extends',
+        '@external',
+        '@fromContext',
+        '@inaccessible',
+        '@interfaceObject',
+        '@key',
+        '@listSize',
+        '@override',
+        '@policy',
+        '@provides',
+        '@requires',
+        '@requiresScopes',
+        '@shareable',
+        '@tag',
+      ];
+      for (const directive of expectedDirectives) {
+        expect(result).toContain(`"${directive}"`);
+      }
+    });
+
+    it('should append the original typeDefs after the @link extension', () => {
+      const typeDefs = 'type Query { hello: String }';
+      const result = decorator.decorate(typeDefs);
+      expect(result).toContain(typeDefs);
+      const linkIndex = result.indexOf('@link');
+      const typeDefsIndex = result.indexOf(typeDefs);
+      expect(linkIndex).toBeLessThan(typeDefsIndex);
+    });
+
+    it('should respect a user-provided importUrl override', () => {
+      const result = decorator.decorate('type Query { hello: String }', {
+        version: 2,
+        importUrl: 'https://specs.apollo.dev/federation/v2.3',
+      });
+      expect(result).toContain(
+        'url: "https://specs.apollo.dev/federation/v2.3"',
+      );
+    });
+
+    it('should respect a user-provided directives override', () => {
+      const result = decorator.decorate('type Query { hello: String }', {
+        version: 2,
+        directives: ['@key', '@shareable'],
+      });
+      expect(result).toContain('"@key"');
+      expect(result).toContain('"@shareable"');
+      expect(result).not.toContain('"@policy"');
+      expect(result).not.toContain('"@cacheTag"');
+    });
+
+    it('should prepend @ to directives missing the prefix', () => {
+      const result = decorator.decorate('type Query { hello: String }', {
+        version: 2,
+        directives: ['key'],
+      });
+      expect(result).toContain('"@key"');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Bumps the default Apollo Federation import URL in `TypeDefsFederation2Decorator` from `v2.3` to `v2.12` and expands the default imported directive list to cover every directive introduced in core federation between v2.3 and v2.12.

Consumers who pass an explicit `directives` array or `importUrl` in `Federation2Config` are unaffected; this change only touches the defaults applied when neither is provided.

## Issue

Closes #3837

## What is the new behavior?

The default `@link(url: ...)` now points at `https://specs.apollo.dev/federation/v2.12` and the default `import:` list is:

- `@authenticated` (v2.5)
- `@cacheTag` (v2.12)
- `@composeDirective` (v2.1)
- `@context` (v2.8)
- `@cost` (v2.9)
- `@extends`
- `@external`
- `@fromContext` (v2.8)
- `@inaccessible`
- `@interfaceObject` (v2.3)
- `@key`
- `@listSize` (v2.9)
- `@override`
- `@policy` (v2.6)
- `@provides`
- `@requires`
- `@requiresScopes` (v2.5)
- `@shareable`
- `@tag`

`@connect` / `@source` from v2.10 are intentionally omitted because Apollo Connectors are imported from a separate spec URL (`https://specs.apollo.dev/connect/v0.1`) and are not part of the core federation link.

The `Federation2Config.directives` and `Federation2Config.importUrl` JSDoc `@default` annotations were updated to match.

## Tests

A new unit spec `packages/graphql/tests/type-defs-federation2.decorator.spec.ts` covers:

- default import URL is v2.12
- default directive list includes all v2.12 imports
- user-provided `importUrl` / `directives` overrides still win
- directive strings without a leading `@` are normalized