### PR TITLE
feat(@nestjs/graphql): add conditional exports for browser shim

### DIFF
--- a/packages/graphql/lib/extra/graphql-model-shim.ts
+++ b/packages/graphql/lib/extra/graphql-model-shim.ts
@@ -1,6 +1,9 @@
 // this "shim" can be used on the frontend to prevent from errors on undefined
 // decorators in the models, when you are sharing same models across backend and frontend.
-// to use this shim simply configure your webpack configuration to use this file instead of @nestjs/graphql module.
+// The package exposes it automatically via the "browser" and "react-native"
+// conditional exports in package.json, so bundlers such as webpack, Metro or
+// Vite will pick this file up when bundling for those environments without
+// any additional configuration.
 /* eslint @typescript-eslint/no-empty-function: 0 */
 import {
   FieldOptions,
@@ -11,7 +14,8 @@ import {
 } from '..';
 import * as typeFactories from '../type-factories';
 
-// for webpack this is resolved this way:
+// If the conditional export cannot be leveraged (older bundler, custom setup),
+// the shim can still be aliased manually, for example with webpack:
 // resolve: { // see: https://webpack.js.org/configuration/resolve/
 //     alias: {
 //         @nestjs/graphql: path.resolve(__dirname, "../node_modules/@nestjs/graphql/dist/extra/graphql-model-shim")

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -6,6 +6,31 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "browser": "./dist/extra/graphql-model-shim.js",
+  "react-native": "./dist/extra/graphql-model-shim.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "browser": "./dist/extra/graphql-model-shim.js",
+      "react-native": "./dist/extra/graphql-model-shim.js",
+      "node": {
+        "types": "./dist/index.d.ts",
+        "require": "./dist/index.js",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "require": "./dist/index.js",
+      "import": "./dist/index.js",
+      "default": "./dist/extra/graphql-model-shim.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin/index.d.ts",
+      "require": "./plugin.js",
+      "default": "./plugin.js"
+    },
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "files": [
     "dist",
     "plugin.js"


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (n/a for package.json change; exports verified manually via `require.resolve` + conditions)
- [x] Docs have been added / updated (n/a for package.json metadata)

## Issue

Closes #3468

## What is the new behavior?

Adds a proper `"exports"` map (plus matching top-level `"browser"` / `"react-native"` fields for legacy tooling) to `@nestjs/graphql`'s `package.json` so the browser shim is picked up automatically, without consumers having to configure webpack/Metro/Vite aliases or resolver overrides.

Conditional resolution for the main entry (`@nestjs/graphql`):

- `types` -> `./dist/index.d.ts`
- `browser` -> `./dist/extra/graphql-model-shim.js`
- `react-native` -> `./dist/extra/graphql-model-shim.js`
- `node` (nested) -> `./dist/index.js` (types/require/import/default)
- `require` / `import` -> `./dist/index.js`
- `default` -> `./dist/extra/graphql-model-shim.js` (safe fallback for non-Node environments)

Additional subpaths are preserved for back-compat:

- `@nestjs/graphql/plugin` -> `./plugin.js` (with proper types pointing at `./dist/plugin/index.d.ts`)
- `@nestjs/graphql/package.json` -> explicit passthrough
- `@nestjs/graphql/*` -> wildcard passthrough so existing deep imports such as `@nestjs/graphql/dist/extra/graphql-model-shim.js` continue to work

The existing `main` / `types` fields are kept to preserve compatibility with older tooling that does not understand `exports`. The shim's documentation comment is also updated to describe the new automatic behavior while keeping the legacy webpack-alias recipe for anyone on older setups.

Resolution verified locally via `node --conditions=browser -e "require.resolve('@nestjs/graphql')"` (resolves to the shim) and default `node -e "require.resolve('@nestjs/graphql')"` (resolves to `dist/index.js`). `yarn build` passes across all packages (`graphql`, `apollo`, `mercurius`).