### PR TITLE
fix(@nestjs/graphql): emit clearer error when nested object type is used in mapped input

### DIFF
--- a/packages/graphql/lib/schema-builder/errors/cannot-determine-input-type.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/cannot-determine-input-type.error.ts
@@ -1,9 +1,24 @@
 import { GqlTypeReference } from '../../interfaces';
 
 export class CannotDetermineInputTypeError extends Error {
-  constructor(hostType: string, typeRef?: GqlTypeReference) {
+  constructor(
+    hostType: string,
+    typeRef?: GqlTypeReference,
+    isRegisteredAsObjectType?: boolean,
+  ) {
     const inputObjectName: string | false =
       typeof typeRef === 'function' && typeRef.name;
+
+    if (isRegisteredAsObjectType && inputObjectName) {
+      super(
+        `Cannot use "${inputObjectName}" as a GraphQL input type for the "${hostType}" field because it is decorated with @ObjectType(). ` +
+          `Input types cannot reference object types. ` +
+          `Create a separate class decorated with @InputType() for "${inputObjectName}", ` +
+          `or pass \`InputType\` as the second argument to the mapped-type helper (e.g. PartialType(${inputObjectName}, InputType)) so that it is registered as an input type.`,
+      );
+      return;
+    }
+
     super(
       `Cannot determine a GraphQL input type ${
         inputObjectName ? `("${inputObjectName}")` : null

--- a/packages/graphql/lib/schema-builder/factories/input-type.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type.factory.ts
@@ -31,7 +31,16 @@ export class InputTypeFactory {
         typeRef as any,
       );
       if (!inputType) {
-        throw new CannotDetermineInputTypeError(hostType, typeRef);
+        const isRegisteredAsObjectType =
+          typeof typeRef === 'function' &&
+          !!this.typeDefinitionsStorage.getObjectTypeByTarget(
+            typeRef as Function,
+          );
+        throw new CannotDetermineInputTypeError(
+          hostType,
+          typeRef,
+          isRegisteredAsObjectType,
+        );
       }
     }
     return this.typeMapperService.mapToGqlType(

--- a/packages/graphql/tests/schema-builder/errors/cannot-determine-input-type.error.spec.ts
+++ b/packages/graphql/tests/schema-builder/errors/cannot-determine-input-type.error.spec.ts
@@ -1,0 +1,33 @@
+import { CannotDetermineInputTypeError } from '../../../lib/schema-builder/errors/cannot-determine-input-type.error';
+
+describe('CannotDetermineInputTypeError', () => {
+  class SomeNestedType {}
+
+  it('should produce the generic message when the type is not registered as an object type', () => {
+    const error = new CannotDetermineInputTypeError('field', SomeNestedType);
+
+    expect(error.message).toContain('Cannot determine a GraphQL input type');
+    expect(error.message).toContain('"SomeNestedType"');
+    expect(error.message).toContain('"field"');
+  });
+
+  it('should produce a clearer, actionable message when the type is registered as an ObjectType', () => {
+    const error = new CannotDetermineInputTypeError(
+      'nestedField',
+      SomeNestedType,
+      true,
+    );
+
+    expect(error.message).toContain(
+      'Cannot use "SomeNestedType" as a GraphQL input type for the "nestedField" field',
+    );
+    expect(error.message).toContain('@ObjectType()');
+    expect(error.message).toContain('@InputType()');
+    expect(error.message).toContain('PartialType(SomeNestedType, InputType)');
+  });
+
+  it('should fall back to the generic message when no type reference is provided', () => {
+    const error = new CannotDetermineInputTypeError('field', undefined, true);
+    expect(error.message).toContain('Cannot determine a GraphQL input type');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (not applicable — error-message change only)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue

Closes #2841

## What is the current behavior?

When a class decorated with `@ObjectType()` is referenced (directly or transitively) by a field of an `@InputType()`, schema construction fails with:

> Cannot determine a GraphQL input type ("ClassB") for the "propName". Make sure your class is decorated with an appropriate decorator.

This is what happens for the scenario described in #2841: `PartialType(ClassA, InputType)` re-decorates `ClassA` as an input type, but any nested `@ObjectType()` field of `ClassA` is still an object type, and the schema builder rejects it with a generic error that does not explain what actually went wrong.

## What is the new behavior?

The `InputTypeFactory` now detects the specific case where the referenced class is already registered as an `@ObjectType()` and throws a clearer, actionable error:

> Cannot use "ClassB" as a GraphQL input type for the "propName" field because it is decorated with @ObjectType(). Input types cannot reference object types. Create a separate class decorated with @InputType() for "ClassB", or pass `InputType` as the second argument to the mapped-type helper (e.g. PartialType(ClassB, InputType)) so that it is registered as an input type.

This names the offending class, explains the root cause, and points users to both of the valid fixes (a dedicated `@InputType()` class, or using the mapped-type helper's decorator override on the nested type). The original generic message is preserved for all other cases (unregistered types, scalars the builder cannot resolve, etc.).

A focused unit test for `CannotDetermineInputTypeError` covers the new and preserved branches.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The public error type (`CannotDetermineInputTypeError`) gains an optional third constructor argument; existing call sites and error handling are unaffected.

## Other information

The more invasive alternative — cascading the second-argument decorator override in `PartialType` / `PickType` / `OmitType` / `IntersectionType` to nested types — would silently change the decoration of classes declared elsewhere and affect the schema globally. This PR deliberately limits the scope to an error-message improvement so users are immediately told what to do.