### PR TITLE
fix(@nestjs/graphql): keep resolvers required when skipping args

### DIFF
--- a/packages/graphql/lib/graphql-ast.explorer.ts
+++ b/packages/graphql/lib/graphql-ast.explorer.ts
@@ -336,8 +336,7 @@ export class GraphQLAstExplorer {
     return {
       name: propertyName,
       type: this.addSymbolIfRoot(type),
-      hasQuestionToken:
-        !required || (item as FieldDefinitionNode).arguments?.length > 0,
+      hasQuestionToken: !required,
     };
   }
 

--- a/packages/graphql/tests/graphql-ast.explorer.spec.ts
+++ b/packages/graphql/tests/graphql-ast.explorer.spec.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-tag';
 
 describe('GraphQLAstExplorer', () => {
   describe('explore', () => {
-    it('should generate fields as optional when they contain arguments', () => {
+    it('should mark non-nullable fields with arguments as required', async () => {
       const astExplorer = new GraphQLAstExplorer();
 
       const document = gql`
@@ -18,16 +18,56 @@ describe('GraphQLAstExplorer', () => {
         }
       `;
 
-      astExplorer
-        .explore(document, '/dev/null', 'interface', {})
-        .then((sourceFile) => {
-          expect(
-            sourceFile
-              .getStructure()
-              .statements[0].properties.find((prop) => prop.name === 'weight')!
-              .hasQuestionToken,
-          ).toBe(true);
-        });
+      const sourceFile = await astExplorer.explore(
+        document,
+        '/dev/null',
+        'interface',
+        {},
+      );
+
+      const catType = (sourceFile.getStructure().statements as any[]).find(
+        (statement) => statement.name === 'Cat',
+      );
+      const weightField = catType.properties.find(
+        (prop: any) => prop.name === 'weight',
+      );
+      expect(weightField.hasQuestionToken).toBe(false);
+    });
+
+    it('should keep root resolver fields required when skipResolverArgs is true', async () => {
+      const astExplorer = new GraphQLAstExplorer();
+
+      const document = gql`
+        type User {
+          id: ID!
+          email: String!
+        }
+
+        type Mutation {
+          signIn(login: String!, password: String!): User!
+          signUp: User!
+        }
+      `;
+
+      const sourceFile = await astExplorer.explore(
+        document,
+        '/dev/null',
+        'interface',
+        { skipResolverArgs: true },
+      );
+
+      const mutationType = (sourceFile.getStructure().statements as any[]).find(
+        (statement) => statement.name === 'IMutation',
+      );
+      const signIn = mutationType.properties.find(
+        (prop: any) => prop.name === 'signIn',
+      );
+      const signUp = mutationType.properties.find(
+        (prop: any) => prop.name === 'signUp',
+      );
+
+      expect(signIn.hasQuestionToken).toBe(false);
+      expect(signUp.hasQuestionToken).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Fix is scoped: a single line in `graphql-ast.explorer.ts`.
- [x] Added a regression test in `packages/graphql/tests/graphql-ast.explorer.spec.ts`.
- [x] Updated the existing test that incorrectly asserted optional behaviour based on arguments.
- [x] `yarn build` passes.

## Issue
Closes #3065

## Before
With `definitions.skipResolverArgs: true` in `GraphQLModule`, the generated `.d.ts` emitted every root resolver field as optional, e.g.:

```ts
export interface IMutation {
  signIn?: User;
  signUp?: User;
}
```

This was wrong because `skipResolverArgs` only means "omit the argument list from the generated type", not "the resolver itself is optional". The required/optional status of a field should follow the schema's non-null semantics.

## After
`hasQuestionToken` is now driven solely by schema nullability (`!required`). The presence of a non-empty `arguments` array is no longer treated as evidence that the field is optional, so with `skipResolverArgs: true` the output matches the `skipResolverArgs: false` shape in terms of optionality:

```ts
export interface IMutation {
  signIn: User;
  signUp: User;
}
```

Non-null object fields without arguments, and nullable fields, continue to emit the correct optionality as before.

## Test plan
- [x] `yarn vitest run tests/graphql-ast.explorer.spec.ts` passes locally, including the new regression test asserting root resolver fields are required when `skipResolverArgs: true`.
- [x] No other tests in `packages/graphql` regressed due to this change (two unrelated pre-existing CRLF/LF diff failures in `tests/plugin/*` reproduce on `upstream/master` without this change).