### PR TITLE
fix(@nestjs/graphql): emit enum key for Args defaultValue in generated SDL

### DIFF
--- a/packages/graphql/lib/schema-builder/factories/args.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/args.factory.ts
@@ -4,6 +4,7 @@ import { GraphQLFieldConfigArgumentMap } from 'graphql';
 import { BuildSchemaOptions } from '../../interfaces';
 import { CannotDetermineArgTypeError } from '../errors/cannot-determine-arg-type.error';
 import { getDefaultValue } from '../helpers/get-default-value.helper';
+import { normalizeEnumDefaultValue } from '../helpers/normalize-enum-default-value.helper';
 import { ClassMetadata, MethodArgsMetadata } from '../metadata';
 import { TypeMetadataStorage } from '../storages/type-metadata.storage';
 import { InputTypeFactory } from './input-type.factory';
@@ -23,16 +24,21 @@ export class ArgsFactory {
     const fieldConfigMap: GraphQLFieldConfigArgumentMap = {};
     args.forEach((param) => {
       if (param.kind === 'arg') {
+        const typeRef = param.typeFn();
         fieldConfigMap[param.name] = {
           description: param.description,
           deprecationReason: param.deprecationReason,
           type: this.inputTypeFactory.create(
             param.name,
-            param.typeFn(),
+            typeRef,
             options,
             param.options,
           ),
-          defaultValue: param.options.defaultValue,
+          defaultValue: normalizeEnumDefaultValue(
+            param.options.defaultValue,
+            typeRef,
+            TypeMetadataStorage.getEnumsMetadata(),
+          ),
         };
       } else if (param.kind === 'args') {
         const argumentTypes = TypeMetadataStorage.getArgumentsMetadata();
@@ -78,9 +84,10 @@ export class ArgsFactory {
       );
 
       const { schemaName } = field;
+      const typeRef = field.typeFn();
       const type = this.inputTypeFactory.create(
         field.name,
-        field.typeFn(),
+        typeRef,
         options,
         field.options,
       );
@@ -88,7 +95,11 @@ export class ArgsFactory {
         description: field.description,
         deprecationReason: field.deprecationReason,
         type,
-        defaultValue: field.options.defaultValue,
+        defaultValue: normalizeEnumDefaultValue(
+          field.options.defaultValue,
+          typeRef,
+          TypeMetadataStorage.getEnumsMetadata(),
+        ),
         /**
          * AST node has to be manually created in order to define directives
          * (more on this topic here: https://github.com/graphql/graphql-js/issues/1343)

--- a/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/input-type-definition.factory.ts
@@ -3,9 +3,11 @@ import { isUndefined } from '@nestjs/common/utils/shared.utils';
 import { GraphQLInputFieldConfigMap, GraphQLInputObjectType } from 'graphql';
 import { BuildSchemaOptions } from '../../interfaces';
 import { getDefaultValue } from '../helpers/get-default-value.helper';
+import { normalizeEnumDefaultValue } from '../helpers/normalize-enum-default-value.helper';
 import { ClassMetadata } from '../metadata';
 import { TypeFieldsAccessor } from '../services/type-fields.accessor';
 import { TypeDefinitionsStorage } from '../storages/type-definitions.storage';
+import { TypeMetadataStorage } from '../storages/type-metadata.storage';
 import { AstDefinitionNodeFactory } from './ast-definition-node.factory';
 import { InputTypeFactory } from './input-type.factory';
 
@@ -71,16 +73,21 @@ export class InputTypeDefinitionFactory {
           metadata.name,
         );
 
+        const typeRef = property.typeFn();
         const type = this.inputTypeFactory.create(
           property.name,
-          property.typeFn(),
+          typeRef,
           options,
           property.options,
         );
         fields[property.schemaName] = {
           description: property.description,
           type,
-          defaultValue: property.options.defaultValue,
+          defaultValue: normalizeEnumDefaultValue(
+            property.options.defaultValue,
+            typeRef,
+            TypeMetadataStorage.getEnumsMetadata(),
+          ),
           deprecationReason: property.deprecationReason,
           /**
            * AST node has to be manually created in order to define directives

--- a/packages/graphql/lib/schema-builder/helpers/normalize-enum-default-value.helper.ts
+++ b/packages/graphql/lib/schema-builder/helpers/normalize-enum-default-value.helper.ts
@@ -1,0 +1,70 @@
+import { isUndefined } from '@nestjs/common/utils/shared.utils';
+import { GqlTypeReference } from '../../interfaces';
+import { EnumMetadata } from '../metadata';
+
+/**
+ * Normalizes a `defaultValue` declared on an argument / input field whose
+ * type references a `registerEnumType`-registered enum.
+ *
+ * GraphQL serializes enum default values through the enum's internal value
+ * lookup (see `GraphQLEnumType#serialize`), so the library must pass the
+ * enum's internal VALUE (not its KEY) as `defaultValue`. When a user writes
+ * `defaultValue: 'BOOKS'` for `enum Category { BOOKS = 'books' }`, the
+ * produced SDL fails validation with
+ * `Enum "Category" cannot represent value: "BOOKS"`.
+ *
+ * This helper keeps the value untouched whenever it already matches a
+ * registered enum value, otherwise it checks whether the supplied string
+ * matches an enum KEY and translates it to the matching enum value so
+ * `astFromValue` can emit the correct SDL literal.
+ *
+ * See: https://github.com/nestjs/graphql/issues/3618
+ */
+export function normalizeEnumDefaultValue<T = unknown>(
+  defaultValue: T,
+  typeRef: GqlTypeReference | undefined,
+  enumsMetadata: EnumMetadata[],
+): T {
+  if (isUndefined(defaultValue) || defaultValue === null) {
+    return defaultValue;
+  }
+  if (!typeRef || !enumsMetadata?.length) {
+    return defaultValue;
+  }
+
+  const enumMetadata = enumsMetadata.find((item) => item.ref === typeRef);
+  if (!enumMetadata) {
+    return defaultValue;
+  }
+
+  const enumRef = enumMetadata.ref as Record<string, unknown>;
+
+  if (Array.isArray(defaultValue)) {
+    return defaultValue.map((item) =>
+      translateEnumValue(item, enumRef),
+    ) as unknown as T;
+  }
+  return translateEnumValue(defaultValue, enumRef) as unknown as T;
+}
+
+function translateEnumValue(value: unknown, enumRef: Record<string, unknown>) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  const registeredValues = getEnumMemberValues(enumRef);
+  if (registeredValues.includes(value)) {
+    return value;
+  }
+  if (Object.prototype.hasOwnProperty.call(enumRef, value)) {
+    const translated = enumRef[value];
+    if (registeredValues.includes(translated)) {
+      return translated;
+    }
+  }
+  return value;
+}
+
+function getEnumMemberValues(enumRef: Record<string, unknown>): unknown[] {
+  const keys = Object.keys(enumRef).filter((key) => isNaN(parseInt(key, 10)));
+  return keys.map((key) => enumRef[key]);
+}

--- a/packages/graphql/tests/schema-builder/factories/enum-default-value.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/enum-default-value.spec.ts
@@ -1,0 +1,103 @@
+import { Test } from '@nestjs/testing';
+import { GraphQLEnumType, GraphQLSchema, printSchema } from 'graphql';
+import {
+  Args,
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  InputType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+  registerEnumType,
+} from '../../../lib';
+
+enum Category {
+  BOOKS = 'books',
+  MOVIES = 'movies',
+}
+
+registerEnumType(Category, { name: 'Category' });
+
+@InputType()
+class CategoryFilterInput {
+  @Field(() => Category, { defaultValue: 'BOOKS' })
+  category!: Category;
+}
+
+@Resolver()
+class CategoryResolver {
+  @Query(() => String)
+  getCategory(
+    @Args('category', { type: () => Category, defaultValue: 'BOOKS' })
+    category: Category,
+  ): string {
+    return category;
+  }
+
+  @Query(() => String)
+  getCategoryAlreadyValue(
+    @Args('category', { type: () => Category, defaultValue: Category.MOVIES })
+    category: Category,
+  ): string {
+    return category;
+  }
+
+  @Query(() => String)
+  filterCategories(
+    @Args('filter', { type: () => CategoryFilterInput })
+    filter: CategoryFilterInput,
+  ): string {
+    return filter.category;
+  }
+}
+
+describe('Enum default value translation (issue #3618)', () => {
+  let schema: GraphQLSchema;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+    const schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+    schema = await schemaFactory.create([CategoryResolver]);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should emit the enum key when defaultValue is passed as the enum key string', () => {
+    const printed = printSchema(schema);
+    expect(printed).toContain(
+      'getCategory(category: Category! = BOOKS): String!',
+    );
+  });
+
+  it('should emit the enum key when defaultValue is passed as the actual enum value', () => {
+    const printed = printSchema(schema);
+    expect(printed).toContain(
+      'getCategoryAlreadyValue(category: Category! = MOVIES): String!',
+    );
+  });
+
+  it('should translate enum key default values on input object fields', () => {
+    const printed = printSchema(schema);
+    expect(printed).toContain('category: Category! = BOOKS');
+  });
+
+  it('should store the resolved enum value on the generated GraphQLEnumType', () => {
+    const queryType = schema.getQueryType();
+    const fields = queryType!.getFields();
+    const categoryArg = fields.getCategory.args.find(
+      (a) => a.name === 'category',
+    );
+    expect(categoryArg).toBeDefined();
+    expect(categoryArg!.defaultValue).toBe(Category.BOOKS);
+    const innerType =
+      'ofType' in categoryArg!.type
+        ? (categoryArg!.type as unknown as { ofType: GraphQLEnumType }).ofType
+        : (categoryArg!.type as GraphQLEnumType);
+    expect(innerType.toString()).toBe('Category');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the guidelines: https://github.com/nestjs/graphql/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Issue

Closes #3618

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Current behavior

When a user declares a default value for an `@Args` / `@Field` whose type is a registered enum, the string is forwarded as-is to `GraphQLFieldConfig#defaultValue`. Passing the enum KEY (for example `{ defaultValue: 'BOOKS' }` with `enum Category { BOOKS = 'books' }`) makes `astFromValue` call `GraphQLEnumType#serialize('BOOKS')`, which looks up by enum VALUE and throws:

```
GraphQLError: Enum "Category" cannot represent value: "BOOKS"
```

Downstream tooling such as `mergeSchemas` surfaces the same validation error when it re-parses the generated SDL.

## New behavior

Default values for enum-typed arguments and input-object fields are now normalized before being handed to `graphql-js`:

- When the supplied string already matches a registered enum value, it is passed through untouched (existing behaviour).
- When the supplied string matches a registered enum KEY, it is translated to the corresponding value so `astFromValue` serializes it back to the correct SDL literal.
- Non-enum defaults, array defaults, `null`, and `undefined` are unchanged.

A regression test (`packages/graphql/tests/schema-builder/factories/enum-default-value.spec.ts`) mirrors the reproduction from the issue and verifies that both KEY- and VALUE-shaped defaults produce the expected SDL for `@Args` and `@Field`.

## Does this PR introduce a breaking change?

- [x] No