### PR TITLE
feat(@nestjs/graphql): support directives on enums and unions

### DIFF
--- a/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
+++ b/packages/apollo/tests/e2e/__snapshots__/serialized-graph.spec.ts.snap
@@ -1642,6 +1642,22 @@ exports[`Serialized graph > should generate a post-initialization graph and matc
       },
       "id": "1118498651"
     },
+    "1159932337": {
+      "source": "576628947",
+      "target": "-1155703408",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "GraphQLSchemaBuilderModule",
+        "sourceClassName": "EnumDefinitionFactory",
+        "targetClassName": "AstDefinitionNodeFactory",
+        "sourceClassToken": "EnumDefinitionFactory",
+        "targetClassToken": "AstDefinitionNodeFactory",
+        "targetModuleName": "GraphQLSchemaBuilderModule",
+        "keyOrIndex": 0,
+        "injectionType": "constructor"
+      },
+      "id": "1159932337"
+    },
     "1194720497": {
       "source": "543894580",
       "target": "-407945788",
@@ -2160,6 +2176,22 @@ exports[`Serialized graph > should generate a post-initialization graph and matc
         "injectionType": "constructor"
       },
       "id": "-1647339849"
+    },
+    "-954715350": {
+      "source": "-1492607355",
+      "target": "-1155703408",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "GraphQLSchemaBuilderModule",
+        "sourceClassName": "UnionDefinitionFactory",
+        "targetClassName": "AstDefinitionNodeFactory",
+        "sourceClassToken": "UnionDefinitionFactory",
+        "targetClassToken": "AstDefinitionNodeFactory",
+        "targetModuleName": "GraphQLSchemaBuilderModule",
+        "keyOrIndex": 2,
+        "injectionType": "constructor"
+      },
+      "id": "-954715350"
     },
     "-1795848503": {
       "source": "206199259",

--- a/packages/apollo/tests/e2e/enum-union-directives.spec.ts
+++ b/packages/apollo/tests/e2e/enum-union-directives.spec.ts
@@ -1,0 +1,124 @@
+import { ApolloServer } from '@apollo/server';
+import { ApolloServerPluginInlineTraceDisabled } from '@apollo/server/plugin/disabled';
+import { INestApplication, Module } from '@nestjs/common';
+import {
+  Directive,
+  Field,
+  GraphQLModule,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  createUnionType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import assert from 'assert';
+import { gql } from 'graphql-tag';
+import { ApolloFederationDriver, ApolloFederationDriverConfig } from '../../lib';
+
+enum Visibility {
+  PUBLIC = 'PUBLIC',
+  PRIVATE = 'PRIVATE',
+}
+
+registerEnumType(Visibility, {
+  name: 'Visibility',
+  description: 'Visibility of a resource',
+  directives: ['@tag(name: "visibility")'],
+  valuesMap: {
+    PUBLIC: { directives: ['@tag(name: "public")'] },
+  },
+});
+
+@ObjectType()
+@Directive('@key(fields: "id")')
+class Article {
+  @Field(() => ID)
+  id: string;
+}
+
+@ObjectType()
+@Directive('@key(fields: "id")')
+class Video {
+  @Field(() => ID)
+  id: string;
+}
+
+const Media = createUnionType({
+  name: 'Media',
+  types: () => [Article, Video] as const,
+  directives: ['@tag(name: "media")'],
+});
+
+@Resolver()
+class DirectivesResolver {
+  @Query(() => Visibility)
+  visibility(): Visibility {
+    return Visibility.PUBLIC;
+  }
+
+  @Query(() => Media)
+  latest(): typeof Media {
+    return { id: '1' } as unknown as typeof Media;
+  }
+}
+
+@Module({
+  imports: [
+    GraphQLModule.forRoot<ApolloFederationDriverConfig>({
+      driver: ApolloFederationDriver,
+      autoSchemaFile: true,
+      buildSchemaOptions: {
+        orphanedTypes: [Article, Video],
+      },
+      plugins: [ApolloServerPluginInlineTraceDisabled()],
+    }),
+  ],
+  providers: [DirectivesResolver],
+})
+class DirectivesAppModule {}
+
+describe('Code-first - directives on enums and unions (e2e)', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServer;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [DirectivesAppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const graphqlModule =
+      app.get<GraphQLModule<ApolloFederationDriver>>(GraphQLModule);
+    apolloClient = graphqlModule.graphQlAdapter?.instance;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should emit enum, enum-value and union directives in the subgraph SDL', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          _service {
+            sdl
+          }
+        }
+      `,
+    });
+    assert(response.body.kind === 'single');
+    expect(response.body.singleResult.errors).toBeUndefined();
+    const sdl = (
+      response.body.singleResult.data as { _service: { sdl: string } }
+    )._service.sdl;
+
+    expect(sdl).toMatch(/enum Visibility[^{]*@tag\(name: "visibility"\)/);
+    expect(sdl).toMatch(/PUBLIC @tag\(name: "public"\)/);
+    expect(sdl).not.toMatch(/PRIVATE[^\n]*@tag/);
+    expect(sdl).toMatch(/union Media[^=]*@tag\(name: "media"\)/);
+  });
+});

--- a/packages/graphql/lib/schema-builder/factories/ast-definition-node.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/ast-definition-node.factory.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { isEmpty } from '@nestjs/common/utils/shared.utils';
 import {
   ConstDirectiveNode,
+  EnumTypeDefinitionNode,
+  EnumValueDefinitionNode,
   FieldDefinitionNode,
   GraphQLInputType,
   GraphQLOutputType,
@@ -10,6 +12,7 @@ import {
   InterfaceTypeDefinitionNode,
   Kind,
   ObjectTypeDefinitionNode,
+  UnionTypeDefinitionNode,
   parse,
 } from 'graphql';
 import { head } from 'lodash';
@@ -156,8 +159,59 @@ export class AstDefinitionNodeFactory {
     };
   }
 
+  createEnumTypeNode(
+    name: string,
+    directives?: string[],
+  ): EnumTypeDefinitionNode | undefined {
+    if (isEmpty(directives)) {
+      return;
+    }
+    return {
+      kind: Kind.ENUM_TYPE_DEFINITION,
+      name: {
+        kind: Kind.NAME,
+        value: name,
+      },
+      directives: directives.map((sdl) => this.createDirectiveNode({ sdl })),
+    };
+  }
+
+  createEnumValueNode(
+    name: string,
+    directives?: string[],
+  ): EnumValueDefinitionNode | undefined {
+    if (isEmpty(directives)) {
+      return;
+    }
+    return {
+      kind: Kind.ENUM_VALUE_DEFINITION,
+      name: {
+        kind: Kind.NAME,
+        value: name,
+      },
+      directives: directives.map((sdl) => this.createDirectiveNode({ sdl })),
+    };
+  }
+
+  createUnionTypeNode(
+    name: string,
+    directives?: string[],
+  ): UnionTypeDefinitionNode | undefined {
+    if (isEmpty(directives)) {
+      return;
+    }
+    return {
+      kind: Kind.UNION_TYPE_DEFINITION,
+      name: {
+        kind: Kind.NAME,
+        value: name,
+      },
+      directives: directives.map((sdl) => this.createDirectiveNode({ sdl })),
+    };
+  }
+
   private createDirectiveNode(
-    directive: DirectiveMetadata,
+    directive: Pick<DirectiveMetadata, 'sdl'>,
   ): ConstDirectiveNode {
     const parsed = parse(`type String ${directive.sdl}`);
     const definitions = parsed.definitions as ObjectTypeDefinitionNode[];

--- a/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/enum-definition.factory.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { GraphQLEnumType } from 'graphql';
 import { EnumMetadata } from '../metadata';
+import { AstDefinitionNodeFactory } from './ast-definition-node.factory';
 
 export interface EnumDefinition {
   enumRef: object;
@@ -9,6 +10,10 @@ export interface EnumDefinition {
 
 @Injectable()
 export class EnumDefinitionFactory {
+  constructor(
+    private readonly astDefinitionNodeFactory: AstDefinitionNodeFactory,
+  ) {}
+
   public create(metadata: EnumMetadata): EnumDefinition {
     const enumValues = this.getEnumValues(metadata.ref);
 
@@ -23,9 +28,25 @@ export class EnumDefinitionFactory {
             value: enumValues[key],
             description: valueMap?.description,
             deprecationReason: valueMap?.deprecationReason,
+            /**
+             * AST node has to be manually created in order to define directives
+             * (more on this topic here: https://github.com/graphql/graphql-js/issues/1343)
+             */
+            astNode: this.astDefinitionNodeFactory.createEnumValueNode(
+              key,
+              valueMap?.directives,
+            ),
           };
           return prevValue;
         }, {}),
+        /**
+         * AST node has to be manually created in order to define directives
+         * (more on this topic here: https://github.com/graphql/graphql-js/issues/1343)
+         */
+        astNode: this.astDefinitionNodeFactory.createEnumTypeNode(
+          metadata.name,
+          metadata.directives,
+        ),
       }),
     };
   }

--- a/packages/graphql/lib/schema-builder/factories/union-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/union-definition.factory.ts
@@ -3,6 +3,7 @@ import { GraphQLUnionType } from 'graphql';
 import { ReturnTypeCannotBeResolvedError } from '../errors/return-type-cannot-be-resolved.error';
 import { UnionMetadata } from '../metadata';
 import { TypeDefinitionsStorage } from '../storages/type-definitions.storage';
+import { AstDefinitionNodeFactory } from './ast-definition-node.factory';
 import { ResolveTypeFactory } from './resolve-type.factory';
 
 export interface UnionDefinition {
@@ -15,6 +16,7 @@ export class UnionDefinitionFactory {
   constructor(
     private readonly resolveTypeFactory: ResolveTypeFactory,
     private readonly typeDefinitionsStorage: TypeDefinitionsStorage,
+    private readonly astDefinitionNodeFactory: AstDefinitionNodeFactory,
   ) {}
 
   public create(metadata: UnionMetadata): UnionDefinition {
@@ -29,6 +31,14 @@ export class UnionDefinitionFactory {
         description: metadata.description,
         types,
         resolveType: this.createResolveTypeFn(metadata),
+        /**
+         * AST node has to be manually created in order to define directives
+         * (more on this topic here: https://github.com/graphql/graphql-js/issues/1343)
+         */
+        astNode: this.astDefinitionNodeFactory.createUnionTypeNode(
+          metadata.name,
+          metadata.directives,
+        ),
       }),
     };
   }

--- a/packages/graphql/lib/schema-builder/metadata/enum.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/enum.metadata.ts
@@ -1,6 +1,7 @@
 export interface EnumMetadataValuesMapOptions {
   deprecationReason?: string;
   description?: string;
+  directives?: string[];
 }
 
 export type EnumMetadataValuesMap<T extends object> = Partial<
@@ -12,4 +13,5 @@ export interface EnumMetadata<T extends object = any> {
   name: string;
   description?: string;
   valuesMap?: EnumMetadataValuesMap<T>;
+  directives?: string[];
 }

--- a/packages/graphql/lib/schema-builder/metadata/union.metadata.ts
+++ b/packages/graphql/lib/schema-builder/metadata/union.metadata.ts
@@ -9,4 +9,5 @@ export interface UnionMetadata<
   id?: symbol;
   description?: string;
   resolveType?: ResolveTypeFn;
+  directives?: string[];
 }

--- a/packages/graphql/lib/type-factories/create-union-type.factory.ts
+++ b/packages/graphql/lib/type-factories/create-union-type.factory.ts
@@ -32,6 +32,11 @@ export interface UnionOptions<
    * Types that the union consist of.
    */
   types: () => T;
+  /**
+   * An array of directive SDL strings (e.g. `['@tag(name: "internal")']`) to be
+   * applied on the generated union type.
+   */
+  directives?: string[];
 }
 
 export type ArrayElement<ArrayType extends readonly unknown[]> =
@@ -45,7 +50,7 @@ export type Union<T extends readonly any[]> = InstanceType<ArrayElement<T>>;
 export function createUnionType<
   T extends readonly Type<unknown>[] = Type<unknown>[],
 >(options: UnionOptions<T>): Union<T> {
-  const { name, description, types, resolveType } = options;
+  const { name, description, types, resolveType, directives } = options;
   const id = Symbol(name);
 
   LazyMetadataStorage.store(() =>
@@ -55,6 +60,7 @@ export function createUnionType<
       description,
       typesFn: types,
       resolveType,
+      directives,
     }),
   );
   return id as any;

--- a/packages/graphql/lib/type-factories/register-enum-type.factory.ts
+++ b/packages/graphql/lib/type-factories/register-enum-type.factory.ts
@@ -25,6 +25,11 @@ export interface EnumOptions<T extends object = any> {
    * A map of options for the values of the enum.
    */
   valuesMap?: EnumMetadataValuesMap<T>;
+  /**
+   * An array of directive SDL strings (e.g. `['@tag(name: "internal")']`) to be
+   * applied on the generated enum type.
+   */
+  directives?: string[];
 }
 
 /**
@@ -41,6 +46,7 @@ export function registerEnumType<T extends object = any>(
       name: options.name,
       description: options.description,
       valuesMap: options.valuesMap || {},
+      directives: options.directives,
     }),
   );
 }

--- a/packages/graphql/tests/schema-builder/factories/enum-union-directives.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/enum-union-directives.spec.ts
@@ -1,0 +1,113 @@
+import { Test } from '@nestjs/testing';
+import { GraphQLEnumType, GraphQLObjectType, GraphQLUnionType } from 'graphql';
+import {
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+  createUnionType,
+  registerEnumType,
+} from '../../../lib';
+
+enum MovieGenre {
+  ACTION = 'ACTION',
+  COMEDY = 'COMEDY',
+}
+
+registerEnumType(MovieGenre, {
+  name: 'MovieGenre',
+  directives: ['@tag(name: "public")'],
+  valuesMap: {
+    ACTION: {
+      directives: ['@tag(name: "featured")'],
+    },
+  },
+});
+
+@ObjectType()
+class Book {
+  @Field(() => ID)
+  id: string;
+}
+
+@ObjectType()
+class Movie {
+  @Field(() => ID)
+  id: string;
+}
+
+const MediaUnion = createUnionType({
+  name: 'Media',
+  types: () => [Book, Movie] as const,
+  directives: ['@tag(name: "public")'],
+});
+
+@Resolver()
+class MediaResolver {
+  @Query(() => MovieGenre)
+  genre(): MovieGenre {
+    return MovieGenre.ACTION;
+  }
+
+  @Query(() => MediaUnion)
+  media(): typeof MediaUnion {
+    return null;
+  }
+}
+
+describe('Directives on enums and unions (issue #2920)', () => {
+  let schemaFactory: GraphQLSchemaFactory;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should attach directives to the generated enum type', async () => {
+    const schema = await schemaFactory.create([MediaResolver]);
+
+    const enumType = schema.getType('MovieGenre') as GraphQLEnumType;
+    expect(enumType).toBeDefined();
+
+    const directiveNames =
+      enumType.astNode?.directives?.map((d) => d.name.value) ?? [];
+    expect(directiveNames).toContain('tag');
+  });
+
+  it('should attach directives to individual enum values', async () => {
+    const schema = await schemaFactory.create([MediaResolver]);
+
+    const enumType = schema.getType('MovieGenre') as GraphQLEnumType;
+    const actionValue = enumType.getValue('ACTION');
+    expect(actionValue).toBeDefined();
+
+    const directiveNames =
+      actionValue!.astNode?.directives?.map((d) => d.name.value) ?? [];
+    expect(directiveNames).toContain('tag');
+
+    const comedyValue = enumType.getValue('COMEDY');
+    expect(comedyValue!.astNode).toBeUndefined();
+  });
+
+  it('should attach directives to the generated union type', async () => {
+    const schema = await schemaFactory.create([MediaResolver]);
+
+    const unionType = schema.getType('Media') as GraphQLUnionType;
+    expect(unionType).toBeDefined();
+
+    const directiveNames =
+      unionType.astNode?.directives?.map((d) => d.name.value) ?? [];
+    expect(directiveNames).toContain('tag');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `directives` option to `registerEnumType`, `createUnionType`, and enum `valuesMap` entries to attach custom directives (e.g. `@tag`, `@inaccessible`) via SDL strings.
- Factories now build the corresponding AST nodes so the directives round-trip through `printSchemaWithDirectives` and tools such as Apollo Contracts.
- Closes #2920.

## Motivation
The GraphQL spec allows directives on enum types, enum values, and union types. Today there is no supported way to attach them with the code-first API, which blocks use cases like Apollo Contracts (`@tag` on enums/unions to hide them from partner schemas).

## Example
```ts
enum MovieGenre { ACTION = 'ACTION', COMEDY = 'COMEDY' }
registerEnumType(MovieGenre, {
  name: 'MovieGenre',
  directives: ['@tag(name: "public")'],
  valuesMap: { ACTION: { directives: ['@tag(name: "featured")'] } },
});

const Media = createUnionType({
  name: 'Media',
  types: () => [Book, Movie] as const,
  directives: ['@tag(name: "public")'],
});
```

## Test plan
- [x] New spec `enum-union-directives.spec.ts` verifies directives on the enum type, union type, and a single enum value.
- [x] Existing `tests/schema-builder/**` suites still pass.