### PR TITLE
fix(@nestjs/graphql): count args for parenless arrow functions

### DIFF
--- a/packages/graphql/lib/utils/get-number-of-arguments.util.ts
+++ b/packages/graphql/lib/utils/get-number-of-arguments.util.ts
@@ -33,6 +33,14 @@ export function getNumberOfArguments(fn: Function): number | undefined {
     return argumentsArray.length;
   }
 
+  // Arrow functions with a single parameter can omit the parentheses
+  // (e.g. `x => x + 2` or `async x => x + 2`). Match a bare identifier
+  // immediately followed by `=>`, allowing an optional `async` prefix.
+  const parenlessArrowRegex = /^\s*(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>/;
+  if (parenlessArrowRegex.test(functionAsStringWithoutNewLines)) {
+    return 1;
+  }
+
   return 0;
 }
 

--- a/packages/graphql/tests/utils/get-number-of-arguments.util.spec.ts
+++ b/packages/graphql/tests/utils/get-number-of-arguments.util.spec.ts
@@ -194,12 +194,18 @@ describe('getNumberOfArguments', () => {
       expect(getNumberOfArguments(functionWithArray)).toBe(2);
     });
 
-    // This test is skipped because we don't support it yet.
-    it.skip('should count correctly for arrow functions without parenthesis', () => {
+    it('should count correctly for arrow functions without parenthesis', () => {
       // prettier-ignore
       const leanArrowFunction = x => x + 2;
 
       expect(getNumberOfArguments(leanArrowFunction)).toBe(1);
+    });
+
+    it('should count correctly for async arrow functions without parenthesis', () => {
+      // prettier-ignore
+      const asyncLeanArrowFunction = async x => x + 2;
+
+      expect(getNumberOfArguments(asyncLeanArrowFunction)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Handle single-parameter arrow functions without parentheses (e.g. `x => x + 2`, `async x => x + 2`) in `getNumberOfArguments`, which used to return 0 because the regex only inspected content between parentheses.
- Unskip the existing regression test and add an async variant.

## Details
`getNumberOfArguments` serializes the function and searches for the first `(...)` block. For a parenless arrow (`x => x + 2`) that match fails, so the utility incorrectly returned `0`. When no parenthesized param list is found, we now look for a bare identifier immediately followed by `=>` (optionally preceded by `async`) and return `1`.

## Test plan
- [x] `packages/graphql/tests/utils/get-number-of-arguments.util.spec.ts` — previously-`it.skip` case now runs and passes; new async-arrow case covered.
- [x] Remaining cases in that file (function declarations, parenthesized arrows, default initializers, arrays/objects as defaults) still pass.