### PR TITLE
feat(@nestjs/graphql): forward specifiedByURL and extensions on custom scalars

### DIFF
--- a/packages/graphql/lib/interfaces/custom-scalar.interface.ts
+++ b/packages/graphql/lib/interfaces/custom-scalar.interface.ts
@@ -2,6 +2,16 @@ import { ValueNode } from 'graphql';
 
 export interface CustomScalar<T, K> {
   description?: string;
+  /**
+   * URL pointing to the specification for this scalar (emitted as the
+   * `@specifiedBy(url: ...)` directive in the generated SDL).
+   */
+  specifiedByURL?: string;
+  /**
+   * Arbitrary metadata attached to the scalar, accessible through the
+   * generated `GraphQLScalarType`'s `extensions` field.
+   */
+  extensions?: Record<string, unknown>;
   parseValue: (value: unknown) => K | null | undefined;
   serialize: (value: unknown) => T | null | undefined;
   parseLiteral: (

--- a/packages/graphql/lib/utils/scalar-types.utils.ts
+++ b/packages/graphql/lib/utils/scalar-types.utils.ts
@@ -16,6 +16,8 @@ export function createScalarType(
   return new GraphQLScalarType({
     name,
     description: instance.description,
+    specifiedByURL: instance.specifiedByURL,
+    extensions: instance.extensions,
     parseValue: bindInstanceContext(instance, 'parseValue'),
     serialize: bindInstanceContext(instance, 'serialize'),
     parseLiteral: bindInstanceContext(instance, 'parseLiteral'),

--- a/packages/graphql/tests/utils/scalar-types.util.spec.ts
+++ b/packages/graphql/tests/utils/scalar-types.util.spec.ts
@@ -1,0 +1,59 @@
+import { Kind, ValueNode } from 'graphql';
+import { CustomScalar } from '../../lib/interfaces';
+import { createScalarType } from '../../lib/utils/scalar-types.utils';
+
+describe('createScalarType', () => {
+  class BaseScalar implements CustomScalar<number, Date> {
+    description = 'Date custom scalar type';
+
+    parseValue(value: unknown): Date | null {
+      return typeof value === 'number' ? new Date(value) : null;
+    }
+
+    serialize(value: unknown): number | null {
+      return value instanceof Date ? value.getTime() : null;
+    }
+
+    parseLiteral(ast: ValueNode): Date | null {
+      if (ast.kind === Kind.INT) {
+        return new Date(parseInt(ast.value, 10));
+      }
+      return null;
+    }
+  }
+
+  it('should propagate description, parseValue, serialize and parseLiteral', () => {
+    const scalar = createScalarType('Date', new BaseScalar());
+    expect(scalar.name).toBe('Date');
+    expect(scalar.description).toBe('Date custom scalar type');
+    expect(scalar.parseValue(0)).toEqual(new Date(0));
+    expect(scalar.serialize(new Date(0))).toBe(0);
+    expect(scalar.parseLiteral({ kind: Kind.INT, value: '0' }, {})).toEqual(
+      new Date(0),
+    );
+  });
+
+  it('should propagate specifiedByURL when provided by the instance', () => {
+    class DateTimeScalar extends BaseScalar {
+      specifiedByURL = 'https://scalars.graphql.org/andimarek/date-time.html';
+    }
+    const scalar = createScalarType('DateTime', new DateTimeScalar());
+    expect(scalar.specifiedByURL).toBe(
+      'https://scalars.graphql.org/andimarek/date-time.html',
+    );
+  });
+
+  it('should propagate extensions when provided by the instance', () => {
+    class TaggedScalar extends BaseScalar {
+      extensions = { tag: 'public' };
+    }
+    const scalar = createScalarType('Tagged', new TaggedScalar());
+    expect(scalar.extensions).toEqual({ tag: 'public' });
+  });
+
+  it('should leave specifiedByURL and extensions at GraphQL defaults when not set', () => {
+    const scalar = createScalarType('Plain', new BaseScalar());
+    expect(scalar.specifiedByURL).toBeUndefined();
+    expect(scalar.extensions).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- Add `specifiedByURL` and `extensions` to the `CustomScalar` interface.
- `createScalarType` now forwards them to the constructed `GraphQLScalarType`, so a custom scalar class can participate in the `@specifiedBy(url: ...)` directive emitted by `printSchema` and attach arbitrary metadata via `extensions`.

## Motivation
`GraphQLScalarType` already supports `specifiedByURL` (for the GraphQL-spec `@specifiedBy` directive) and `extensions`, but `CustomScalar`-based scalars silently dropped both fields because `createScalarType` never read them from the instance. Users building scalars like `DateTime`, `URL`, or `UUID` had no supported way to surface the spec URL.

## Example
```ts
@Scalar('DateTime')
export class DateTimeScalar implements CustomScalar<string, Date> {
  description = 'ISO-8601 encoded UTC datetime';
  specifiedByURL = 'https://scalars.graphql.org/andimarek/date-time.html';
  extensions = { tag: 'public' };

  parseValue(value: unknown) { /* ... */ }
  serialize(value: unknown)  { /* ... */ }
  parseLiteral(ast: ValueNode) { /* ... */ }
}
```
The emitted SDL now includes `scalar DateTime @specifiedBy(url: "https://...")`.

## Test plan
- [x] New spec `tests/utils/scalar-types.util.spec.ts` covers: description/parse/serialize pass-through, `specifiedByURL` pass-through, `extensions` pass-through, and default behavior when neither is set.