### PR TITLE
feat(@nestjs/graphql): accept array of SDL strings in @Directive

### DIFF
--- a/packages/graphql/lib/decorators/directive.decorator.ts
+++ b/packages/graphql/lib/decorators/directive.decorator.ts
@@ -4,29 +4,34 @@ import { LazyMetadataStorage } from '../schema-builder/storages/lazy-metadata.st
 import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.storage';
 
 /**
- * Adds a directive to specified field, type, or handler.
+ * Adds one or more directives to a field, type, or handler. Passing an array
+ * attaches every directive in a single decorator call, equivalent to stacking
+ * multiple `@Directive(...)` decorators.
  *
  * @publicApi
  */
 export function Directive(
-  sdl: string,
+  sdl: string | string[],
 ): MethodDecorator & PropertyDecorator & ClassDecorator {
-  return (target: Function | object, key?: string | symbol) => {
-    validateDirective(sdl);
+  const sdls = Array.isArray(sdl) ? sdl : [sdl];
+  sdls.forEach(validateDirective);
 
+  return (target: Function | object, key?: string | symbol) => {
     LazyMetadataStorage.store(() => {
-      if (key) {
-        TypeMetadataStorage.addDirectivePropertyMetadata({
-          target: target.constructor,
-          fieldName: key as string,
-          sdl,
-        });
-      } else {
-        TypeMetadataStorage.addDirectiveMetadata({
-          target: target as Function,
-          sdl,
-        });
-      }
+      sdls.forEach((singleSdl) => {
+        if (key) {
+          TypeMetadataStorage.addDirectivePropertyMetadata({
+            target: target.constructor,
+            fieldName: key as string,
+            sdl: singleSdl,
+          });
+        } else {
+          TypeMetadataStorage.addDirectiveMetadata({
+            target: target as Function,
+            sdl: singleSdl,
+          });
+        }
+      });
     });
   };
 }

--- a/packages/graphql/tests/schema-builder/factories/directive-multi-sdl.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/directive-multi-sdl.spec.ts
@@ -1,0 +1,81 @@
+import { Test } from '@nestjs/testing';
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import {
+  Directive,
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../../lib';
+
+@ObjectType()
+@Directive(['@tag(name: "internal")', '@tag(name: "restricted")'])
+class User {
+  @Field(() => ID)
+  @Directive(['@tag(name: "pii")', '@tag(name: "audit")'])
+  id: string;
+
+  @Field()
+  @Directive('@tag(name: "friendly")')
+  name: string;
+}
+
+@Resolver(() => User)
+class UserResolver {
+  @Query(() => User)
+  me(): User {
+    return null;
+  }
+}
+
+const tagArg = (
+  directive: { arguments?: ReadonlyArray<{ value: unknown }> } | undefined,
+): string | undefined =>
+  (directive?.arguments?.[0]?.value as { value?: string } | undefined)?.value;
+
+describe('@Directive with multiple SDL strings', () => {
+  let schema: GraphQLSchema;
+  let userType: GraphQLObjectType;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    const schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+    schema = await schemaFactory.create([UserResolver]);
+    userType = schema.getType('User') as GraphQLObjectType;
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should attach every class-level directive passed as an array', () => {
+    const directives = userType.astNode?.directives ?? [];
+    expect(directives.length).toBe(2);
+    expect(directives.map((d) => tagArg(d))).toEqual(
+      expect.arrayContaining(['internal', 'restricted']),
+    );
+  });
+
+  it('should attach every property-level directive passed as an array', () => {
+    const idField = userType.getFields().id;
+    const directives = idField.astNode?.directives ?? [];
+    expect(directives.length).toBe(2);
+    expect(directives.map((d) => tagArg(d))).toEqual(
+      expect.arrayContaining(['pii', 'audit']),
+    );
+  });
+
+  it('should still accept a single SDL string', () => {
+    const nameField = userType.getFields().name;
+    const directives = nameField.astNode?.directives ?? [];
+    expect(directives.length).toBe(1);
+    expect(tagArg(directives[0])).toBe('friendly');
+  });
+});


### PR DESCRIPTION
## Summary
- `@Directive` now also accepts a `string[]`, attaching every directive in a single decorator call.
- Each SDL string is validated individually and stored as its own metadata entry, so existing dedup and AST generation semantics are unchanged.

## Motivation
Stacking several federation/Contract directives requires repeating `@Directive(...)` for each SDL:

```ts
@Directive('@tag(name: "internal")')
@Directive('@tag(name: "restricted")')
@Directive('@inaccessible')
@ObjectType()
class User { ... }
```

This PR lets authors batch them together:

```ts
@Directive(['@tag(name: "internal")', '@tag(name: "restricted")', '@inaccessible'])
@ObjectType()
class User { ... }
```

The single-string form is fully preserved.

## Test plan
- [x] New spec `directive-multi-sdl.spec.ts` — class-level array, property-level array, and single-string forms all produce the expected AST directives.
- [x] `tests/schema-builder/**` continues to pass.