### PR TITLE
fix(@nestjs/graphql): keep class directive when a field has the same SDL

### DIFF
--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -142,7 +142,10 @@ export class TypeMetadataStorageHost {
 
   addDirectiveMetadata(metadata: ClassDirectiveMetadata) {
     const classMetadata = this.metadataByTargetCollection.get(metadata.target);
-    if (!classMetadata.fieldDirectives.sdls.has(metadata.sdl)) {
+    const isDuplicate = classMetadata.classDirectives
+      .getAll()
+      .some((directive) => directive.sdl === metadata.sdl);
+    if (!isDuplicate) {
       classMetadata.classDirectives.push(metadata);
     }
   }

--- a/packages/graphql/tests/schema-builder/factories/class-directive-not-shadowed.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/class-directive-not-shadowed.spec.ts
@@ -1,0 +1,73 @@
+import { Test } from '@nestjs/testing';
+import { GraphQLObjectType } from 'graphql';
+import {
+  Directive,
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../../lib';
+
+@ObjectType()
+@Directive('@tag(name: "public")')
+class Account {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  @Directive('@tag(name: "public")')
+  email: string;
+}
+
+@Resolver(() => Account)
+class AccountResolver {
+  @Query(() => Account)
+  me(): Account {
+    return null;
+  }
+}
+
+describe('Class-level directive not shadowed by identical field-level directive', () => {
+  let accountType: GraphQLObjectType;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    const schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+    const schema = await schemaFactory.create([AccountResolver]);
+    accountType = schema.getType('Account') as GraphQLObjectType;
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should keep the class-level directive even when a field declares the same SDL', () => {
+    const classDirectives = accountType.astNode?.directives ?? [];
+    const classTagNames = classDirectives
+      .filter((d) => d.name.value === 'tag')
+      .map(
+        (d) =>
+          (d.arguments?.[0]?.value as { value?: string } | undefined)?.value,
+      );
+    expect(classTagNames).toContain('public');
+  });
+
+  it('should still keep the field-level directive', () => {
+    const emailField = accountType.getFields().email;
+    const fieldDirectives = emailField.astNode?.directives ?? [];
+    const fieldTagNames = fieldDirectives
+      .filter((d) => d.name.value === 'tag')
+      .map(
+        (d) =>
+          (d.arguments?.[0]?.value as { value?: string } | undefined)?.value,
+      );
+    expect(fieldTagNames).toContain('public');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `addDirectiveMetadata` silently dropping a class-level `@Directive(sdl)` whenever any field on the same class already has a property `@Directive(sdl)` with the same SDL.
- Dedupe against the class's own directive list instead, preserving the original "no exact duplicates" intent but without the cross-contamination between the class and its fields.

## Bug
```ts
@ObjectType()
@Directive('@tag(name: "public")')
class Account {
  @Field(() => ID) id: string;

  @Field()
  @Directive('@tag(name: "public")')
  email: string;
}
```
Because decorators run field-before-class, `fieldDirectives.sdls` already contained `@tag(name: "public")` by the time the class decorator fired, and the class directive was skipped. The emitted SDL therefore lacked the class-level `@tag`, which breaks Apollo Contracts / federation tagging patterns that tag both the entity and one of its fields.

## Fix
Check `classMetadata.classDirectives` for an existing SDL match instead of the field-directive set. This still prevents stacking the exact same class directive twice on the same target, but decouples the check from field-directive state.

## Test plan
- [x] New spec `class-directive-not-shadowed.spec.ts` fails on `master`; passes after the fix.
- [x] `tests/schema-builder/**` continues to pass (including the directive inheritance coverage from #3938).