### PR TITLE
fix(@nestjs/graphql): stop double-registering PickType inputs

### DIFF
--- a/packages/graphql/lib/type-helpers/pick-type.helper.ts
+++ b/packages/graphql/lib/type-helpers/pick-type.helper.ts
@@ -26,7 +26,6 @@ export function PickType<T, K extends keyof T>(
       inheritPropertyInitializers(this, classRef, isInheritedPredicate);
     }
   }
-  decoratorFactory({ isAbstract: true })(PickObjectType);
   if (decorator) {
     decorator({ isAbstract: true })(PickObjectType);
   } else {

--- a/packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts
+++ b/packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts
@@ -1,0 +1,36 @@
+import {
+  Field,
+  InputType,
+  TypeMetadataStorage,
+} from '../../lib';
+import { PickType } from '../../lib/type-helpers';
+import { LazyMetadataStorage } from '../../lib/schema-builder/storages/lazy-metadata.storage';
+
+@InputType()
+class PickSourceInput {
+  @Field()
+  a: string;
+
+  @Field()
+  b: string;
+}
+
+class PickedInput extends PickType(PickSourceInput, ['a'] as const) {}
+
+describe('PickType duplicate registration regression', () => {
+  beforeAll(() => {
+    LazyMetadataStorage.load([PickSourceInput, PickedInput]);
+    TypeMetadataStorage.compile();
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should register the picked input type exactly once', () => {
+    const inputs = TypeMetadataStorage.getInputTypesMetadata();
+    const pickAbstract = Object.getPrototypeOf(PickedInput) as Function;
+    const matches = inputs.filter((item) => item.target === pickAbstract);
+    expect(matches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Drop the redundant `decoratorFactory({ isAbstract: true })(PickObjectType)` call at the top of `PickType`. The same factory was already invoked inside the `else` branch a few lines below when no custom class decorator was provided, so every `PickType(...)` registered the generated abstract class twice.

## Bug
`TargetMetadataCollection`'s `inputType`/`objectType` setters always `push` onto the canonical `all.inputType` / `all.objectType` arrays. Calling the decorator factory twice therefore added two entries for the same target, and `getInputTypesMetadata()` returned duplicates which the schema generator then processed twice (and `addInputTypes` `Map.set`s once, hiding the issue but doubling work and complicating debugging).

`OmitType`, `PartialType` and `IntersectionType` already use the single-call pattern that this PR aligns `PickType` with.

## Test plan
- [x] New regression test `tests/type-helpers/pick-type-double-register.spec.ts` (fails on master; passes after the fix).
- [x] `tests/plugin/type-helpers/**` suite still passes.