### PR TITLE
fix(@nestjs/graphql): de-duplicate per-target metadata in TargetMetadataCollection

### DIFF
--- a/packages/graphql/lib/schema-builder/collections/target-metadata.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/target-metadata.collection.ts
@@ -38,8 +38,8 @@ export class TargetMetadataCollection {
   private _resolver: ResolverClassMetadata;
 
   set argumentType(val: ClassMetadata) {
+    this.replaceOrPush(this.all.argumentType, this._argumentType, val);
     this._argumentType = val;
-    this.all.argumentType.push(val);
   }
 
   get argumentType() {
@@ -56,8 +56,8 @@ export class TargetMetadataCollection {
   }
 
   set inputType(val: ClassMetadata) {
+    this.replaceOrPush(this.all.inputType, this._inputType, val);
     this._inputType = val;
-    this.all.inputType.push(val);
   }
 
   get inputType() {
@@ -65,8 +65,8 @@ export class TargetMetadataCollection {
   }
 
   set objectType(val: ObjectTypeMetadata) {
+    this.replaceOrPush(this.all.objectType, this._objectType, val);
     this._objectType = val;
-    this.all.objectType.push(val);
   }
 
   get objectType() {
@@ -74,11 +74,24 @@ export class TargetMetadataCollection {
   }
 
   set resolver(val: ResolverClassMetadata) {
+    this.replaceOrPush(this.all.resolver, this._resolver, val);
     this._resolver = val;
-    this.all.resolver.push(val);
   }
 
   get resolver() {
     return this._resolver;
+  }
+
+  private replaceOrPush<T>(list: T[], previous: T | undefined, next: T) {
+    if (previous === undefined) {
+      list.push(next);
+      return;
+    }
+    const index = list.indexOf(previous);
+    if (index === -1) {
+      list.push(next);
+    } else {
+      list[index] = next;
+    }
   }
 }

--- a/packages/graphql/tests/schema-builder/storages/target-metadata-set.spec.ts
+++ b/packages/graphql/tests/schema-builder/storages/target-metadata-set.spec.ts
@@ -1,0 +1,47 @@
+import {
+  ArgsType,
+  Field,
+  ID,
+  ObjectType,
+  TypeMetadataStorage,
+} from '../../../lib';
+import { LazyMetadataStorage } from '../../../lib/schema-builder/storages/lazy-metadata.storage';
+
+@ObjectType()
+class TargetSetObjectCheck {
+  @Field(() => ID)
+  id: string;
+}
+
+@ArgsType()
+class TargetSetArgsCheck {
+  @Field()
+  q: string;
+}
+
+describe('TargetMetadataCollection idempotent set', () => {
+  beforeAll(() => {
+    LazyMetadataStorage.load([TargetSetObjectCheck, TargetSetArgsCheck]);
+    TypeMetadataStorage.compile();
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should list each @ObjectType once, even though the decorator runs eagerly and as a lazy callback', () => {
+    const objectTypes = TypeMetadataStorage.getObjectTypesMetadata();
+    const matches = objectTypes.filter(
+      (item) => item.target === TargetSetObjectCheck,
+    );
+    expect(matches).toHaveLength(1);
+  });
+
+  it('should list each @ArgsType once', () => {
+    const argTypes = TypeMetadataStorage.getArgumentsMetadata();
+    const matches = argTypes.filter(
+      (item) => item.target === TargetSetArgsCheck,
+    );
+    expect(matches).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Make `TargetMetadataCollection`'s `objectType`, `argumentType`, `inputType` and `resolver` setters idempotent: when the same target's metadata is re-assigned, replace the entry in the canonical `all.<kind>` array in place instead of pushing a second one.

## Bug
`@ObjectType()` registers metadata both eagerly (so `getObjectTypeMetadataByTarget(...)` works synchronously inside `@Resolver(() => Cat)`) and again through `LazyMetadataStorage.store(...)`. Each registration goes through:

```ts
set objectType(val: ObjectTypeMetadata) {
  this._objectType = val;
  this.all.objectType.push(val);
}
```

So every class decorated with `@ObjectType()` (or `@ArgsType()`, which also pairs an eager + lazy registration) ended up listed twice in `getObjectTypesMetadata()`. The downstream `generateObjectTypeDefs` then ran the type-definition factory once per duplicate. `addObjectTypes` (`Map.set`) hid the resulting collision but the per-target metadata compilation, plugin metadata loading, and orphan walks still all ran twice.

The same shape applies to `@ArgsType()` (also eager + lazy) and to `@InputType()` once `PickType` (or other helpers) double-decorate a generated abstract class.

## Fix
The setters now look up the previous value in the canonical array and replace it in place, falling back to a push only when the target has not been registered yet:

```ts
private replaceOrPush<T>(list: T[], previous: T | undefined, next: T) {
  if (previous === undefined) { list.push(next); return; }
  const index = list.indexOf(previous);
  if (index === -1) list.push(next); else list[index] = next;
}
```

This keeps the `all.<kind>` arrays as a one-entry-per-target list while still exposing the most recent metadata reference. `interface` already uses `Map.set` keyed by `target` and is unchanged.

## Test plan
- [x] New regression test `tests/schema-builder/storages/target-metadata-set.spec.ts` (fails on master; passes after the fix) covers `@ObjectType` and `@ArgsType`.
- [x] `packages/graphql` Vitest run is green (the pre-existing `model-class-visitor` / `readonly-visitor` plugin snapshot failures already exist on master).
- [x] `packages/apollo` e2e run (`tests/e2e`) passes including `serialized-graph`.