### PR TITLE
fix(@nestjs/graphql): skip empty extensions in applyFieldDecorators

### DIFF
--- a/packages/graphql/lib/type-helpers/type-helpers.utils.ts
+++ b/packages/graphql/lib/type-helpers/type-helpers.utils.ts
@@ -5,11 +5,11 @@ export function applyFieldDecorators(
   targetClass: Function,
   item: PropertyMetadata,
 ) {
-  if (item.extensions) {
+  if (item.extensions && Object.keys(item.extensions).length > 0) {
     Extensions(item.extensions)(targetClass.prototype, item.name);
   }
   if (item.directives?.length) {
-    item.directives.map((directive) => {
+    item.directives.forEach((directive) => {
       Directive(directive.sdl)(targetClass.prototype, item.name);
     });
   }

--- a/packages/graphql/tests/type-helpers/apply-field-decorators.spec.ts
+++ b/packages/graphql/tests/type-helpers/apply-field-decorators.spec.ts
@@ -1,0 +1,66 @@
+import { applyFieldDecorators } from '../../lib/type-helpers/type-helpers.utils';
+import { TypeMetadataStorage } from '../../lib';
+import { LazyMetadataStorage } from '../../lib/schema-builder/storages/lazy-metadata.storage';
+
+class Holder {
+  field: string;
+}
+
+describe('applyFieldDecorators', () => {
+  afterEach(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should not register an Extensions metadata entry when item.extensions is empty', () => {
+    applyFieldDecorators(Holder, {
+      name: 'field',
+      schemaName: 'field',
+      typeFn: () => String,
+      target: Holder,
+      options: {},
+      extensions: {},
+    });
+    LazyMetadataStorage.load([Holder]);
+
+    const storage = TypeMetadataStorage as unknown as {
+      metadataByTargetCollection: {
+        get: (target: Function) => {
+          fieldExtensions: { getByName: (name: string) => unknown[] };
+        };
+      };
+    };
+    const entries = storage.metadataByTargetCollection
+      .get(Holder)
+      .fieldExtensions.getByName('field');
+    expect(entries).toEqual([]);
+  });
+
+  it('should register an Extensions metadata entry when item.extensions has keys', () => {
+    applyFieldDecorators(Holder, {
+      name: 'field',
+      schemaName: 'field',
+      typeFn: () => String,
+      target: Holder,
+      options: {},
+      extensions: { audit: true },
+    });
+    LazyMetadataStorage.load([Holder]);
+
+    const storage = TypeMetadataStorage as unknown as {
+      metadataByTargetCollection: {
+        get: (target: Function) => {
+          fieldExtensions: {
+            getByName: (
+              name: string,
+            ) => Array<{ value: Record<string, unknown> }>;
+          };
+        };
+      };
+    };
+    const entries = storage.metadataByTargetCollection
+      .get(Holder)
+      .fieldExtensions.getByName('field');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].value).toEqual({ audit: true });
+  });
+});


### PR DESCRIPTION
## Summary
- `applyFieldDecorators` re-applied `Extensions(item.extensions)` for every property even when the source field had no extensions, because `compileClassMetadata` defaults `extensions` to an empty object and `if (item.extensions)` treats `{}` as truthy.
- Switch to `Object.keys(item.extensions).length > 0` so type-helper-derived classes only register `PropertyExtensionsMetadata` for fields that actually carry extensions.
- Flip the directive loop to `forEach` since the `.map(...)` return value was discarded.

## Why this matters
Each `PartialType` / `PickType` / `OmitType` / `IntersectionType` call walked the parent's fields and ran `applyFieldDecorators` per field. That meant every cloned field accumulated an empty `PropertyExtensionsMetadata` entry on the lazy metadata storage; `compileClassMetadata`'s `fieldExtensions.getByName(...).reduce(...)` then iterates over those no-op entries every time a schema is built. The fix is a no-op for callers, just less noise / less work.

## Test plan
- [x] New regression test `tests/type-helpers/apply-field-decorators.spec.ts` asserts that an empty `extensions` object does not register a property-extensions entry while a populated one still does.
- [x] Existing `tests/plugin/type-helpers/**` and `tests/type-helpers/**` suites continue to pass.