### PR TITLE
fix(@nestjs/graphql): validate registerEnumType/createUnionType options eagerly

### DIFF
--- a/packages/graphql/lib/type-factories/create-union-type.factory.ts
+++ b/packages/graphql/lib/type-factories/create-union-type.factory.ts
@@ -50,6 +50,16 @@ export type Union<T extends readonly any[]> = InstanceType<ArrayElement<T>>;
 export function createUnionType<
   T extends readonly Type<unknown>[] = Type<unknown>[],
 >(options: UnionOptions<T>): Union<T> {
+  if (!options || typeof options.name !== 'string' || options.name === '') {
+    throw new Error(
+      `createUnionType requires an "options" object with a non-empty "name" (e.g. createUnionType({ name: 'MyUnion', types: () => [TypeA, TypeB] })).`,
+    );
+  }
+  if (typeof options.types !== 'function') {
+    throw new Error(
+      `createUnionType requires "options.types" to be a function returning the union member classes (e.g. types: () => [TypeA, TypeB]).`,
+    );
+  }
   const { name, description, types, resolveType, directives } = options;
   const id = Symbol(name);
 

--- a/packages/graphql/lib/type-factories/register-enum-type.factory.ts
+++ b/packages/graphql/lib/type-factories/register-enum-type.factory.ts
@@ -40,6 +40,11 @@ export function registerEnumType<T extends object = any>(
   enumRef: T,
   options?: EnumOptions<T>,
 ) {
+  if (!options || typeof options.name !== 'string' || options.name === '') {
+    throw new Error(
+      `registerEnumType requires an "options" object with a non-empty "name" (e.g. registerEnumType(MyEnum, { name: 'MyEnum' })).`,
+    );
+  }
   LazyMetadataStorage.store(() =>
     TypeMetadataStorage.addEnumMetadata({
       ref: enumRef,

--- a/packages/graphql/tests/type-factories/enum-union-options-validation.spec.ts
+++ b/packages/graphql/tests/type-factories/enum-union-options-validation.spec.ts
@@ -1,0 +1,72 @@
+import { ObjectType, Field, ID } from '../../lib';
+import { createUnionType, registerEnumType } from '../../lib/type-factories';
+
+@ObjectType()
+class MemberA {
+  @Field(() => ID)
+  id: string;
+}
+
+@ObjectType()
+class MemberB {
+  @Field(() => ID)
+  id: string;
+}
+
+enum SampleEnum {
+  A = 'A',
+  B = 'B',
+}
+
+describe('registerEnumType / createUnionType options validation', () => {
+  it('should throw a descriptive error when registerEnumType is called without options', () => {
+    expect(() =>
+      (registerEnumType as unknown as (ref: object) => void)(SampleEnum),
+    ).toThrowError(/registerEnumType requires an "options" object/);
+  });
+
+  it('should throw a descriptive error when registerEnumType is called without a name', () => {
+    expect(() =>
+      registerEnumType(SampleEnum, {} as unknown as { name: string }),
+    ).toThrowError(/non-empty "name"/);
+  });
+
+  it('should throw a descriptive error when createUnionType is called without options', () => {
+    expect(() =>
+      (
+        createUnionType as unknown as () => unknown
+      )(),
+    ).toThrowError(/createUnionType requires an "options" object/);
+  });
+
+  it('should throw a descriptive error when createUnionType is called without a name', () => {
+    expect(() =>
+      createUnionType({
+        types: () => [MemberA, MemberB] as const,
+      } as unknown as { name: string; types: () => readonly [typeof MemberA] }),
+    ).toThrowError(/non-empty "name"/);
+  });
+
+  it('should throw a descriptive error when createUnionType is called without a types function', () => {
+    expect(() =>
+      createUnionType({
+        name: 'BadUnion',
+      } as unknown as {
+        name: string;
+        types: () => readonly [typeof MemberA];
+      }),
+    ).toThrowError(/"options\.types" to be a function/);
+  });
+
+  it('should accept a fully formed options object', () => {
+    expect(() =>
+      registerEnumType(SampleEnum, { name: 'SampleEnum' }),
+    ).not.toThrow();
+    expect(() =>
+      createUnionType({
+        name: 'SampleUnion',
+        types: () => [MemberA, MemberB] as const,
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Throw a descriptive error when `registerEnumType` or `createUnionType` are called without an options object, without a non-empty `name`, or (for unions) without a `types` function.
- Validation runs at registration time so the stack trace points at the offending call site instead of `LazyMetadataStorage.load` -> `addEnumMetadata` deep in the schema-builder pipeline.

## Bug
The TypeScript signatures mark these inputs as optional/permissive but the lazy callbacks dereference them unguarded. Calling `registerEnumType(MyEnum)` therefore blew up with:

```
TypeError: Cannot read properties of undefined (reading 'name')
  at LazyMetadataStorage.load
  at GraphQLSchemaFactory.create
  ...
```

`createUnionType({ types: () => [...] })` (no name) silently registered a `Symbol(undefined)` and surfaced as a "Schema must have a name" failure inside graphql-js much later.

## Fix
- `registerEnumType`: require `options` and require `options.name` to be a non-empty string.
- `createUnionType`: same name check, plus `typeof options.types === 'function'`.
- Both errors now identify the failing API and show a corrected example in the message.

## Test plan
- [x] New spec `tests/type-factories/enum-union-options-validation.spec.ts` covers each missing-input branch and the happy path.
- [x] `tests/schema-builder/**`, `tests/type-helpers/**`, `tests/type-factories/**` continue to pass.