### PR TITLE
fix(package): add exports field for esm resolution support

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -6,6 +6,15 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/packages/mercurius/package.json
+++ b/packages/mercurius/package.json
@@ -6,6 +6,15 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a consumer project sets `"type": "module"` in its `package.json` and imports from `@nestjs/apollo` or `@nestjs/mercurius`, Node.js ESM resolution can fail with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@nestjs/apollo' imported from /path/to/dist/main.js
Did you mean to import "@nestjs/apollo/dist/index.js"?
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader)
    at packageResolve (node:internal/modules/esm/resolve)
    ...
```

Both packages currently ship without a top-level `"exports"` field, so Node's ESM resolver cannot consistently locate the entry — the same class of failure that nestjs/swagger#3591 documented for `@nestjs/swagger`. The reproduction is identical: a `"type": "module"` Nest project plus `import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo'` (or the mercurius equivalent) — fails on Node 22 and Node 24 regardless of `moduleResolution` (`NodeNext`, `Node16`, `Bundler`, `Node`).

`@nestjs/graphql` itself already gained an `"exports"` map in 13.x (covering `.`, `./plugin`, and the `browser`/`react-native` shim conditions), so it is unaffected. These two sibling packages were missed.

This is the same fix as nestjs/swagger#3866 — applied here per maintainer request to open the corresponding PR on this repo.

## What is the new behavior?

Adds a minimal `"exports"` map to both `packages/apollo/package.json` and `packages/mercurius/package.json`:

- `.` — the library entry (`./dist/index.js` + `./dist/index.d.ts`)
- `./package.json` — explicit metadata access for tooling that reads it

Each subpath declares `types`, `import`, `require`, and `default` conditions. Both packages only expose a single root entry today (no subpath like `@nestjs/apollo/plugin`), so the map intentionally stays small. The compiled output is still CommonJS, so both `import` and `require` conditions point at the same `./dist/index.js` — there is no dual-package hazard and no source or build changes are required. Existing CJS consumers continue to resolve the package exactly as before because `main` and `types` are preserved alongside `exports`.

## Additional context

- Verified locally with `npm run build` (clean) and `npm run lint` (0 warnings, 0 errors).
- `npm pack`-ed both patched packages and confirmed the `exports` field is present in the published tarballs.
- Resolved both `@nestjs/apollo` and `@nestjs/mercurius` from a `"type": "module"` sandbox via `import.meta.resolve(...)` — both succeed and point at `dist/index.js`.
- The mirrored fix for `@nestjs/swagger` is in nestjs/swagger#3866 (same author, same approach).