### PR TITLE
fix(@nestjs/graphql): preserve federation directives in autoschemafile

### DIFF
--- a/packages/apollo/tests/code-first-federation/federation-auto-schema-file.module.ts
+++ b/packages/apollo/tests/code-first-federation/federation-auto-schema-file.module.ts
@@ -1,0 +1,30 @@
+import { ApolloServerPluginInlineTraceDisabled } from '@apollo/server/plugin/disabled';
+import { Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriverConfig } from '../../lib';
+import { ApolloFederationDriver } from '../../lib/drivers';
+import { HumanModule } from './human/human.module';
+import { PostModule } from './post/post.module';
+import { RecipeModule } from './recipe/recipe.module';
+import { User } from './user/user.entity';
+import { UserModule } from './user/user.module';
+
+@Module({
+  imports: [
+    UserModule,
+    PostModule,
+    RecipeModule,
+    HumanModule,
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      inheritResolversFromInterfaces: true,
+      driver: ApolloFederationDriver,
+      includeStacktraceInErrorResponses: false,
+      autoSchemaFile: 'federation-schema.graphql',
+      buildSchemaOptions: {
+        orphanedTypes: [User],
+      },
+      plugins: [ApolloServerPluginInlineTraceDisabled()],
+    }),
+  ],
+})
+export class FederationAutoSchemaFileModule {}

--- a/packages/apollo/tests/e2e/federation-auto-schema-file.spec.ts
+++ b/packages/apollo/tests/e2e/federation-auto-schema-file.spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from '@nestjs/common';
+import { FileSystemHelper } from '@nestjs/graphql/schema-builder/helpers/file-system.helper';
+import { Test } from '@nestjs/testing';
+import { FederationAutoSchemaFileModule } from '../code-first-federation/federation-auto-schema-file.module';
+
+describe('Federation - autoSchemaFile generation (issue #3722)', () => {
+  let app: INestApplication;
+
+  const writeFileMock = vi.fn().mockImplementation(() => Promise.resolve());
+
+  beforeEach(async () => {
+    writeFileMock.mockClear();
+
+    const module = await Test.createTestingModule({
+      imports: [FederationAutoSchemaFileModule],
+    })
+      .overrideProvider(FileSystemHelper)
+      .useValue({ writeFile: writeFileMock })
+      .compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it('should write the federated SDL file once with the configured filename', () => {
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock.mock.calls[0][0]).toBe('federation-schema.graphql');
+  });
+
+  it('should preserve federation directives (@key, @external, @extends) in the generated SDL', () => {
+    const fileContent: string = writeFileMock.mock.calls[0][1];
+
+    // Object types decorated with @Directive('@key(...)') must keep the directive
+    // when emitted via autoSchemaFile. Before the fix, graphql's printSchema stripped
+    // these federation directives entirely.
+    expect(fileContent).toMatch(/type\s+Post[^{]*@key\(fields:\s*"id"\)/);
+    expect(fileContent).toMatch(/type\s+User[^{]*@key\(fields:\s*"id"\)/);
+    expect(fileContent).toMatch(/type\s+User[^{]*@extends/);
+    expect(fileContent).toMatch(/@external/);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/graphql/lib/federation/graphql-federation.factory.ts
+++ b/packages/graphql/lib/federation/graphql-federation.factory.ts
@@ -360,6 +360,7 @@ export class GraphQLFederationFactory {
         },
         options.sortSchema,
         options.transformAutoSchemaFile && options.transformSchema,
+        await this.getFederationSchemaPrinter(),
       );
     } catch (err) {
       if (err && err.details) {
@@ -367,6 +368,25 @@ export class GraphQLFederationFactory {
       }
       throw err;
     }
+  }
+
+  private async getFederationSchemaPrinter(): Promise<
+    (schema: GraphQLSchema) => string
+  > {
+    const apolloSubgraph = loadPackage(
+      '@apollo/subgraph',
+      'ApolloFederation',
+      () => require('@apollo/subgraph'),
+    );
+    const apolloSubgraphVersion = (
+      await import('@apollo/subgraph/package.json')
+    ).version;
+    const apolloSubgraphMajorVersion = Number(
+      apolloSubgraphVersion.split('.')[0],
+    );
+    return apolloSubgraphMajorVersion >= 2
+      ? (schema) => printSchemaWithDirectives(schema)
+      : apolloSubgraph.printSubgraphSchema;
   }
 
   private getFederationVersionAndConfig(

--- a/packages/graphql/lib/graphql-schema.builder.ts
+++ b/packages/graphql/lib/graphql-schema.builder.ts
@@ -66,6 +66,7 @@ export class GraphQLSchemaBuilder {
     transformSchema?: (
       schema: GraphQLSchema,
     ) => GraphQLSchema | Promise<GraphQLSchema>,
+    printSchemaFn?: (schema: GraphQLSchema) => string,
   ): Promise<GraphQLSchema> {
     const schema = await this.gqlSchemaFactory.create(resolvers, options);
     const filename = getPathForAutoSchemaFile(autoSchemaFile);
@@ -74,13 +75,11 @@ export class GraphQLSchemaBuilder {
       const transformedSchema = transformSchema
         ? await transformSchema(schema)
         : schema;
-      let fileContent =
-        GRAPHQL_SDL_FILE_HEADER +
-        printSchema(
-          sortSchema
-            ? lexicographicSortSchema(transformedSchema)
-            : transformedSchema,
-        );
+      const finalSchema = sortSchema
+        ? lexicographicSortSchema(transformedSchema)
+        : transformedSchema;
+      const print = printSchemaFn ?? printSchema;
+      let fileContent = GRAPHQL_SDL_FILE_HEADER + print(finalSchema);
 
       if (options.addNewlineAtEnd) {
         fileContent = fileContent.concat(GRAPHQL_SDL_FILE_END);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — not applicable, internal API only

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3722

When using `autoSchemaFile` with Apollo Federation, the emitted SDL file is missing federation directives (`@key`, `@external`, `@extends`, `@requires`, `@provides`). This happens because `GraphQLSchemaBuilder.generateSchema` writes the file using `graphql`'s default `printSchema`, which strips non-standard directives.

Note that the runtime `_service { sdl }` query path was already correct — it uses `printSchemaWithDirectives` (subgraph v2+) or `printSubgraphSchema` (v1) — so the bug only manifests in the build-time SDL emission. This breaks tooling (e.g. rover, schema registries) that reads the generated file.

A prior PR #2059 proposed the same shape of fix in 2021 against an older code layout; it has been blocked since then. This PR is a modernized, minimal-scope version aligned with the current code.

## What is the new behavior?

`GraphQLSchemaBuilder.generateSchema` now accepts an optional `printSchemaFn` parameter. `GraphQLFederationFactory.buildFederatedSchema` passes the federation-aware printer to it, reusing the exact same selection logic the file already uses for runtime SDL:

- `printSchemaWithDirectives` from `@graphql-tools/utils` for `@apollo/subgraph` v2+
- `printSubgraphSchema` from `@apollo/subgraph` for v1

Non-federation users see no behavior change — the printer argument is optional and defaults to `printSchema`.

A new e2e regression spec (`packages/apollo/tests/e2e/federation-auto-schema-file.spec.ts`) asserts that `@key`, `@extends`, and `@external` appear in the SDL written via `autoSchemaFile` in federation mode.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

The new parameter is optional with a backward-compatible default (`printSchema`). No public API surface changes for non-federation consumers.

## Other information

- Reference: closes #3722; supersedes the long-blocked #2059 with a smaller, current-code-aligned diff.
- Test results: new spec passes; full apollo + graphql suites pass aside from known flakes (CRLF on Windows, occasional gateway/federation timeouts) unrelated to this change.
- Files changed:
  - `packages/graphql/lib/graphql-schema.builder.ts` — added optional `printSchemaFn` parameter
  - `packages/graphql/lib/federation/graphql-federation.factory.ts` — pass federation-aware printer
  - `packages/apollo/tests/code-first-federation/federation-auto-schema-file.module.ts` — new test fixture
  - `packages/apollo/tests/e2e/federation-auto-schema-file.spec.ts` — regression spec

(Note: as an external contributor I cannot apply labels on this repo; happy for a maintainer to apply `bug` / `scope: federation` as appropriate.)