### PR TITLE
fix(@nestjs/apollo): expose schema transform hook on gateway driver

### DIFF
--- a/packages/apollo/lib/drivers/apollo-gateway.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-gateway.driver.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { ModulesContainer } from '@nestjs/core';
 import { extend } from '@nestjs/graphql';
+import { GraphQLSchema } from 'graphql';
 import { ApolloGatewayDriverConfig } from '../interfaces';
 import { PluginsExplorerService } from '../services/plugins-explorer.service';
 import { ApolloBaseDriver } from './apollo-base.driver';
@@ -30,13 +31,84 @@ export class ApolloGatewayDriver extends ApolloBaseDriver<ApolloGatewayDriverCon
       'ApolloGateway',
       () => require('@apollo/gateway'),
     );
-    const { server: serverOpts = {}, gateway: gatewayOpts = {} } = options;
+    const {
+      server: serverOpts = {},
+      gateway: gatewayOpts = {},
+      transformSchema,
+    } = options;
     const gateway = new ApolloGateway(gatewayOpts);
 
     await super.start({
       ...serverOpts,
-      gateway,
+      gateway: transformSchema
+        ? this.wrapGatewayWithSchemaTransform(gateway, transformSchema)
+        : gateway,
     });
+  }
+
+  private wrapGatewayWithSchemaTransform(
+    gateway: any,
+    transformSchema: (
+      schema: GraphQLSchema,
+    ) => GraphQLSchema | Promise<GraphQLSchema>,
+  ): any {
+    // Apollo Server consumes the gateway's schema via the synchronous
+    // `onSchemaLoadOrUpdate` callback that fires during `gateway.load()`,
+    // not via the schema returned from `load()` directly. The callback
+    // is registered before `load()` is invoked, which means a naïve
+    // wrapper around `load()` cannot intercept the schema in time.
+    //
+    // To support an async `transformSchema`, this wrapper queues every
+    // listener registered through it and only forwards the
+    // (synchronous) schema-update events once the user-supplied
+    // transform has resolved. The initial supergraph composed during
+    // `load()` is awaited and transformed before `load()` resolves so
+    // Apollo Server starts up with the transformed schema. Subsequent
+    // updates emitted by the gateway (e.g. supergraph polling) cannot
+    // be transformed asynchronously without dropping the synchronous
+    // contract Apollo Server expects, so they are forwarded
+    // untransformed.
+    type SchemaContext = {
+      apiSchema: GraphQLSchema;
+      coreSupergraphSdl: string;
+    };
+
+    const queuedListeners = new Set<(ctx: SchemaContext) => void>();
+    let initialContext: SchemaContext | undefined;
+    let initialEmitted = false;
+
+    gateway.onSchemaLoadOrUpdate((schemaContext: SchemaContext) => {
+      if (!initialEmitted) {
+        initialContext = schemaContext;
+        return;
+      }
+      queuedListeners.forEach((listener) => listener(schemaContext));
+    });
+
+    return {
+      load: async (loadOptions: any) => {
+        const result = await gateway.load(loadOptions);
+        if (initialContext) {
+          const transformedSchema = await transformSchema(
+            initialContext.apiSchema,
+          );
+          const transformedContext: SchemaContext = {
+            ...initialContext,
+            apiSchema: transformedSchema,
+          };
+          queuedListeners.forEach((listener) => listener(transformedContext));
+        }
+        initialEmitted = true;
+        return result;
+      },
+      onSchemaLoadOrUpdate: (callback: (ctx: SchemaContext) => void) => {
+        queuedListeners.add(callback);
+        return () => {
+          queuedListeners.delete(callback);
+        };
+      },
+      stop: () => gateway.stop(),
+    };
   }
 
   public async mergeDefaultOptions(

--- a/packages/apollo/lib/interfaces/apollo-gateway-driver-config.interface.ts
+++ b/packages/apollo/lib/interfaces/apollo-gateway-driver-config.interface.ts
@@ -5,6 +5,7 @@ import {
   GqlOptionsFactory,
   GraphQLDriver,
 } from '@nestjs/graphql';
+import { GraphQLSchema } from 'graphql';
 import { ApolloDriverConfig } from './apollo-driver-config.interface';
 
 /**
@@ -41,6 +42,20 @@ export interface ApolloGatewayDriverConfig<
     | 'fieldResolverEnhancers'
     | 'driver'
   >;
+  /**
+   * Function applied to the supergraph schema produced by the gateway
+   * before it is exposed to Apollo Server. Use this hook to register
+   * custom directive transformers (e.g. `@public`, Apollo Connectors)
+   * on the composed schema.
+   *
+   * Invoked once during the initial composition. Schema updates
+   * emitted by the gateway after startup (e.g. supergraph polling)
+   * are forwarded untransformed because the underlying Apollo Server
+   * listener is synchronous.
+   */
+  transformSchema?: (
+    schema: GraphQLSchema,
+  ) => GraphQLSchema | Promise<GraphQLSchema>;
 }
 
 export type ApolloGatewayDriverConfigFactory =

--- a/packages/apollo/tests/e2e/graphql-gateway-transform-schema.spec.ts
+++ b/packages/apollo/tests/e2e/graphql-gateway-transform-schema.spec.ts
@@ -1,0 +1,120 @@
+import { INestApplication } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { GraphQLSchema } from 'graphql';
+import request from 'supertest';
+import { ApolloGatewayDriver } from '../../lib/drivers';
+import { getSupergraphSdl } from '../graphql-federation/gateway/supergraph-sdl';
+import { AppModule as PostsModule } from '../graphql-federation/posts-service/federation-posts.module';
+import { AppModule as UsersModule } from '../graphql-federation/users-service/federation-users.module';
+
+describe('GraphQL Gateway transformSchema', () => {
+  let postsApp: INestApplication;
+  let usersApp: INestApplication;
+  let gatewayApp: INestApplication;
+
+  afterEach(async () => {
+    await postsApp?.close();
+    await usersApp?.close();
+    await gatewayApp?.close();
+  });
+
+  it('invokes the gateway-level transformSchema callback with the composed supergraph schema', async () => {
+    const usersModule = await Test.createTestingModule({
+      imports: [UsersModule],
+    }).compile();
+    usersApp = usersModule.createNestApplication();
+    await usersApp.listen(0);
+    const usersPort = usersApp.getHttpServer().address().port;
+
+    const postsModule = await Test.createTestingModule({
+      imports: [PostsModule],
+    }).compile();
+    postsApp = postsModule.createNestApplication();
+    await postsApp.listen(0);
+    const postsPort = postsApp.getHttpServer().address().port;
+
+    let receivedSchema: GraphQLSchema | undefined;
+    let invocationCount = 0;
+
+    const gatewayModule = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot({
+          driver: ApolloGatewayDriver,
+          gateway: {
+            includeStacktraceInErrorResponses: false,
+            supergraphSdl: getSupergraphSdl(usersPort, postsPort),
+          },
+          transformSchema: (schema: GraphQLSchema) => {
+            invocationCount += 1;
+            receivedSchema = schema;
+            return schema;
+          },
+        }),
+      ],
+    }).compile();
+
+    gatewayApp = gatewayModule.createNestApplication();
+    await gatewayApp.init();
+
+    expect(invocationCount).toBe(1);
+    expect(receivedSchema).toBeDefined();
+    // The composed supergraph must expose the federated `Post` type.
+    expect(receivedSchema!.getType('Post')).toBeDefined();
+    expect(receivedSchema!.getType('User')).toBeDefined();
+  }, 15000);
+
+  it('exposes the transformed schema to Apollo Server during query execution', async () => {
+    const usersModule = await Test.createTestingModule({
+      imports: [UsersModule],
+    }).compile();
+    usersApp = usersModule.createNestApplication();
+    await usersApp.listen(0);
+    const usersPort = usersApp.getHttpServer().address().port;
+
+    const postsModule = await Test.createTestingModule({
+      imports: [PostsModule],
+    }).compile();
+    postsApp = postsModule.createNestApplication();
+    await postsApp.listen(0);
+    const postsPort = postsApp.getHttpServer().address().port;
+
+    const gatewayModule = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot({
+          driver: ApolloGatewayDriver,
+          gateway: {
+            includeStacktraceInErrorResponses: false,
+            supergraphSdl: getSupergraphSdl(usersPort, postsPort),
+          },
+          // Identity transform: confirms the wrapper does not break the
+          // standard query path while still routing the schema through
+          // the user-supplied callback.
+          transformSchema: (schema: GraphQLSchema) => schema,
+        }),
+      ],
+    }).compile();
+
+    gatewayApp = gatewayModule.createNestApplication();
+    await gatewayApp.init();
+
+    return request(gatewayApp.getHttpServer())
+      .post('/graphql')
+      .send({
+        operationName: null,
+        variables: {},
+        query: `
+        {
+          getPosts {
+            id
+            title
+          }
+        }`,
+      })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.errors).toBeUndefined();
+        expect(res.body.data.getPosts).toBeDefined();
+      });
+  }, 15000);
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3296

User-supplied schema transforms are silently dropped when using `ApolloGatewayDriver`.

- Placing `transformSchema` on the `gateway` option does nothing — those options are forwarded verbatim to `new ApolloGateway()`, which silently ignores fields it does not recognize.
- Placing `transformSchema` on the `server` option is explicitly disallowed — the type definition `Omit`s `transformSchema` from the gateway server config.

The result is that there is no supported way to apply custom directives or otherwise transform the composed supergraph schema in a federated setup. Apollo Server consumes the gateway schema via the synchronous `gateway.onSchemaLoadOrUpdate` event fired during `gateway.load()`, so any transform has to be in place before that event reaches the server — which the current driver never does.

## What is the new behavior?

Adds an optional `transformSchema` callback at the top level of `ApolloGatewayDriverConfig` (sibling of `gateway` and `server`):

```ts
transformSchema?: (schema: GraphQLSchema) => GraphQLSchema | Promise<GraphQLSchema>;
```

When provided, the driver wraps the underlying `ApolloGateway` with a small adapter that:
1. Queues Apollo Server's `onSchemaLoadOrUpdate` listener instead of registering it directly on the real gateway.
2. Awaits the user's `transformSchema` during `gateway.load()`.
3. Emits the transformed schema to the queued listener before `load()` returns, so Apollo Server only ever sees the transformed version.

When `transformSchema` is omitted, the gateway is passed through unchanged — zero behavioral cost for existing users.

**Documented limitation:** post-startup gateway updates (e.g. supergraph polling) are forwarded untransformed; the JSDoc on the new option calls this out. The primary use case (registering custom directives at startup) is fully covered.

**Tests:** new e2e spec `packages/apollo/tests/e2e/graphql-gateway-transform-schema.spec.ts` covers two cases:
- `transformSchema` is invoked exactly once during gateway startup.
- An identity `transformSchema` still serves federated queries correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Additive, optional field with a backward-compatible default. Existing configurations behave identically.

## Other information

Files touched:
- `packages/apollo/lib/interfaces/apollo-gateway-driver-config.interface.ts` — new optional `transformSchema` field on the driver config.
- `packages/apollo/lib/drivers/apollo-gateway.driver.ts` — wraps the gateway with the transform adapter when the option is provided; passes through otherwise.
- `packages/apollo/tests/e2e/graphql-gateway-transform-schema.spec.ts` — regression coverage.

Closes #3296