### PR TITLE
fix(@nestjs/graphql): run plugin refresh hooks in registration order

### DIFF
--- a/packages/graphql/lib/plugin/metadata-loader.ts
+++ b/packages/graphql/lib/plugin/metadata-loader.ts
@@ -4,7 +4,10 @@ export class MetadataLoader {
   private static readonly refreshHooks = new Array<() => void>();
 
   static addRefreshHook(hook: () => void) {
-    return MetadataLoader.refreshHooks.unshift(hook);
+    // Hooks must run in registration (insertion) order so that nested mapped
+    // type compositions (e.g. PartialType(OmitType(Foo))) refresh their inner
+    // wrappers before the outer wrappers read fields from them.
+    return MetadataLoader.refreshHooks.push(hook);
   }
 
   async load(metadata: Record<string, any>) {

--- a/packages/graphql/tests/plugin/type-helpers/nested-mapped-types.spec.ts
+++ b/packages/graphql/tests/plugin/type-helpers/nested-mapped-types.spec.ts
@@ -1,0 +1,68 @@
+import { MetadataLoader } from '../../../lib/plugin/metadata-loader';
+import { getFieldsAndDecoratorForType } from '../../../lib/schema-builder/utils/get-fields-and-decorator.util';
+import {
+  IntersectionType,
+  OmitType,
+  PartialType,
+  PickType,
+} from '../../../lib/type-helpers';
+import { CreateUserDto } from './fixtures/create-user-dto.fixture';
+import { SERIALIZED_METADATA } from './fixtures/serialized-metadata.fixture';
+
+// Regression coverage for issue #3313 — when mapped type helpers are nested
+// (e.g. PartialType(OmitType(...))) the SWC plugin's metadata refresh hooks
+// must run from the innermost wrapper outwards so plugin-only fields
+// (those declared without a `@Field()` decorator and emitted via
+// `metadata.ts`) get propagated through every wrapper.
+
+class PartialOmitUserDto extends PartialType(
+  OmitType(CreateUserDto, ['login']),
+) {}
+
+class PartialPickUserDto extends PartialType(
+  PickType(CreateUserDto, ['active', 'password']),
+) {}
+
+class IntersectionPickUserDto extends IntersectionType(
+  PickType(CreateUserDto, ['active']),
+  PickType(CreateUserDto, ['login']),
+) {}
+
+describe('Nested mapped types (issue #3313)', () => {
+  const metadataLoader = new MetadataLoader();
+
+  beforeAll(async () => {
+    await metadataLoader.load(SERIALIZED_METADATA);
+  });
+
+  it('should propagate plugin-only fields through PartialType(OmitType(...))', () => {
+    const prototype = Object.getPrototypeOf(PartialOmitUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
+
+    const fieldNames = fields.map((f) => f.name).sort();
+    // CreateUserDto fields: login, password, _id, active. After OmitType
+    // strips "login" and PartialType nullablises everything we should still
+    // see "active" (which is plugin-only) propagated through.
+    expect(fieldNames).toEqual(['_id', 'active', 'password']);
+    const active = fields.find((f) => f.name === 'active');
+    expect(active).toBeDefined();
+    expect(active?.options.nullable).toEqual(true);
+  });
+
+  it('should propagate plugin-only fields through PartialType(PickType(...))', () => {
+    const prototype = Object.getPrototypeOf(PartialPickUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
+
+    const fieldNames = fields.map((f) => f.name).sort();
+    expect(fieldNames).toEqual(['active', 'password']);
+    expect(fields.every((f) => f.options.nullable === true)).toBe(true);
+  });
+
+  it('should propagate plugin-only fields through IntersectionType(PickType(...), PickType(...))', () => {
+    const prototype = Object.getPrototypeOf(IntersectionPickUserDto);
+    const { fields } = getFieldsAndDecoratorForType(prototype);
+
+    const fieldNames = fields.map((f) => f.name).sort();
+    expect(fieldNames).toEqual(['active', 'login']);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3313

Composing mapped-type helpers (e.g. `PartialType(OmitType(Foo, ['x']))`) loses every field that comes from the SWC plugin's `SERIALIZED_METADATA` emission (i.e. fields declared without an explicit `@Field()` decorator). The resulting GraphQL type ends up empty or partial. The legacy TS plugin is unaffected.

**Root cause:** `MetadataLoader.addRefreshHook` was using `Array.unshift`, so refresh hooks ran in reverse-of-registration order. Each mapped-type helper (`PartialType`, `OmitType`, `PickType`, `IntersectionType`) registers a hook that re-reads its source class's fields and re-applies them to its wrapper class. When nested — e.g. `PartialType(OmitType(CreateInput, ['x']))` — the inner helper's hook is registered first, the outer's second. With `unshift`, the outer hook fired before the inner wrapper had propagated the SWC plugin's emitted fields, so plugin-only fields disappeared from the composed type. The legacy TS plugin was unaffected because it injects per-class `__SCHEMA_METADATA_FACTORY` synchronously at class-declaration time, before the helpers run.

## What is the new behavior?

`MetadataLoader.addRefreshHook` now appends with `Array.push` instead of prepending with `Array.unshift`, so refresh hooks run in registration order (innermost first). The outer wrapper now reads the inner wrapper's fields after they've been refreshed by the SWC plugin's metadata, and nested compositions correctly carry every plugin-emitted field through to the composed GraphQL type.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This change reverses an internal hook execution order that was incorrect for nested compositions; non-nested usage was already correct because there's only one hook to fire. No public API change.

## Other information

3 new regression tests added under `packages/graphql/tests/plugin/type-helpers/nested-mapped-types.spec.ts` covering:

- `PartialType(OmitType(...))`
- `PartialType(PickType(...))`
- `IntersectionType(PickType(...), PickType(...))`

All three fail without the fix and pass with it. Verified locally with `yarn test:e2e:graphql` — 210 passed; the 2 unrelated CRLF Windows snapshot failures (`readonly-visitor`, `model-class-visitor`) are pre-existing on master and unrelated to this change.

Closes #3313