### PR TITLE
fix(@nestjs/graphql): allow string[] in browser shim Directive signature

### DIFF
--- a/packages/graphql/lib/extra/graphql-model-shim.ts
+++ b/packages/graphql/lib/extra/graphql-model-shim.ts
@@ -27,7 +27,7 @@ export function ArgsType(): ClassDecorator {
 }
 
 export function Directive(
-  sdl: string,
+  sdl: string | string[],
 ): MethodDecorator & PropertyDecorator & ClassDecorator {
   return (target: Function | object, key?: string | symbol) => {};
 }


### PR DESCRIPTION
## Summary
- Update the browser/react-native shim's `Directive` signature to accept `string | string[]`, matching the real decorator after #3951.

## Bug
`@Directive(...)` was widened to also accept `string[]` so callers can batch tags in a single decorator. The shim used by the `browser` / `react-native` conditional exports still typed the parameter as `string` only, so frontend code that imports the decorator through the shim failed to type-check even though the no-op implementation accepts any value.

## Test plan
- [x] `tsc --noEmit -p tsconfig.build.json` is green.