### PR TITLE
fix(@nestjs/graphql): drop "null" leak from CannotDetermineInputType error

### DIFF
--- a/packages/graphql/lib/schema-builder/errors/cannot-determine-input-type.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/cannot-determine-input-type.error.ts
@@ -20,8 +20,8 @@ export class CannotDetermineInputTypeError extends Error {
     }
 
     super(
-      `Cannot determine a GraphQL input type ${
-        inputObjectName ? `("${inputObjectName}")` : null
+      `Cannot determine a GraphQL input type${
+        inputObjectName ? ` ("${inputObjectName}")` : ''
       } for the "${hostType}". Make sure your class is decorated with an appropriate decorator.`,
     );
   }

--- a/packages/graphql/tests/schema-builder/errors/cannot-determine-input-type.error.spec.ts
+++ b/packages/graphql/tests/schema-builder/errors/cannot-determine-input-type.error.spec.ts
@@ -30,4 +30,12 @@ describe('CannotDetermineInputTypeError', () => {
     const error = new CannotDetermineInputTypeError('field', undefined, true);
     expect(error.message).toContain('Cannot determine a GraphQL input type');
   });
+
+  it('should not embed the literal string "null" when no type reference is provided', () => {
+    const error = new CannotDetermineInputTypeError('field', undefined);
+    expect(error.message).not.toContain('null');
+    expect(error.message).toBe(
+      'Cannot determine a GraphQL input type for the "field". Make sure your class is decorated with an appropriate decorator.',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Stop interpolating the literal string \`null\` in the generic branch of `CannotDetermineInputTypeError`.

## Bug
When the offending type reference was undefined (or unnamed), the message rendered as:

```
Cannot determine a GraphQL input type null for the "field". Make sure your class is decorated with an appropriate decorator.
```

The `null` came from the ternary's false branch (`inputObjectName ? ... : null`), which was then template-interpolated as the word "null".

## Fix
Use an empty string for the falsy branch and move the leading space into the truthy branch so the message reads cleanly with or without a type reference.

## Test plan
- [x] Existing `cannot-determine-input-type.error.spec.ts` extended with a regression case asserting no `null` substring and the exact expected message.