### PR TITLE
fix(@nestjs/graphql): mirror unshift order in MetadataListByNameCollection.all

### DIFF
--- a/packages/graphql/lib/schema-builder/collections/metadata-list-by-name.collection.ts
+++ b/packages/graphql/lib/schema-builder/collections/metadata-list-by-name.collection.ts
@@ -34,7 +34,7 @@ export class MetadataListByNameCollection<T> extends MetadataByNameCollection<
     }
 
     arrayResult.unshift(value);
-    this.all.push(value);
+    this.all.unshift(value);
 
     if (this.globalArray) {
       this.globalArray.unshift(value);

--- a/packages/graphql/tests/schema-builder/collections/metadata-list-by-name.collection.spec.ts
+++ b/packages/graphql/tests/schema-builder/collections/metadata-list-by-name.collection.spec.ts
@@ -1,0 +1,36 @@
+import { MetadataListByNameCollection } from '../../../lib/schema-builder/collections/metadata-list-by-name.collection';
+
+describe('MetadataListByNameCollection', () => {
+  it('should keep getAll() in declaration order when items are added', () => {
+    const collection = new MetadataListByNameCollection<number>();
+    collection.add(1, 'a');
+    collection.add(2, 'b');
+    collection.add(3, 'c');
+
+    expect(collection.getAll()).toEqual([1, 2, 3]);
+  });
+
+  it('should keep getAll() in reverse-declaration order when items are unshifted, matching the per-name array', () => {
+    const collection = new MetadataListByNameCollection<number>();
+    collection.unshift(1, 'a');
+    collection.unshift(2, 'b');
+    collection.unshift(3, 'c');
+
+    expect(collection.getByName('a')).toEqual([1]);
+    expect(collection.getByName('b')).toEqual([2]);
+    expect(collection.getByName('c')).toEqual([3]);
+
+    expect(collection.getAll()).toEqual([3, 2, 1]);
+  });
+
+  it('should mirror unshift order into the optional global array', () => {
+    const globalArray: number[] = [];
+    const collection = new MetadataListByNameCollection<number>(globalArray);
+    collection.unshift(1, 'a');
+    collection.unshift(2, 'b');
+    collection.unshift(3, 'c');
+
+    expect(globalArray).toEqual([3, 2, 1]);
+    expect(collection.getAll()).toEqual([3, 2, 1]);
+  });
+});


### PR DESCRIPTION
## Summary
- `MetadataListByNameCollection#unshift` now prepends to the internal `this.all` cache instead of appending, matching the semantics already used for the per-name bucket and the optional `globalArray`.

## Bug
The collection backs `getAll()` with `this.all`. `add()` correctly pushes onto every backing store, but `unshift()` mismatched: the per-name array and global array were prepended, while `this.all` was *pushed*. `getAll()` therefore reported entries in chronological add order instead of the prepend order expected by the parameter-decorator metadata path (decorators evaluate right-to-left, hence the use of `unshift`). The mismatch is currently latent because nothing iterates the list-collection's `getAll()`, but the divergence is a foot-gun for future callers.

## Test plan
- [x] New `metadata-list-by-name.collection.spec.ts` covers add ordering, unshift ordering, and the optional global array mirror.