### PR TITLE
fix(@nestjs/graphql): clearer error when a union member is not an @ObjectType

### DIFF
--- a/packages/graphql/lib/schema-builder/errors/union-member-not-object-type.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/union-member-not-object-type.error.ts
@@ -1,0 +1,12 @@
+import { Type } from '@nestjs/common';
+
+export class UnionMemberNotObjectTypeError extends Error {
+  constructor(unionName: string, memberRef: Type<unknown>) {
+    const memberName =
+      (memberRef && (memberRef as Function).name) || String(memberRef);
+    super(
+      `Cannot build the "${unionName}" union: its member "${memberName}" is not registered as a @ObjectType(). ` +
+        `Make sure every class returned from the union's "types" function is decorated with @ObjectType().`,
+    );
+  }
+}

--- a/packages/graphql/lib/schema-builder/factories/union-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/union-definition.factory.ts
@@ -1,6 +1,7 @@
 import { Injectable, Type } from '@nestjs/common';
 import { GraphQLUnionType } from 'graphql';
 import { ReturnTypeCannotBeResolvedError } from '../errors/return-type-cannot-be-resolved.error';
+import { UnionMemberNotObjectTypeError } from '../errors/union-member-not-object-type.error';
 import { UnionMetadata } from '../metadata';
 import { TypeDefinitionsStorage } from '../storages/type-definitions.storage';
 import { AstDefinitionNodeFactory } from './ast-definition-node.factory';
@@ -20,8 +21,14 @@ export class UnionDefinitionFactory {
   ) {}
 
   public create(metadata: UnionMetadata): UnionDefinition {
-    const getObjectType = (item: Type<unknown>) =>
-      this.typeDefinitionsStorage.getObjectTypeByTarget(item).type;
+    const getObjectType = (item: Type<unknown>) => {
+      const definition =
+        this.typeDefinitionsStorage.getObjectTypeByTarget(item);
+      if (!definition) {
+        throw new UnionMemberNotObjectTypeError(metadata.name, item);
+      }
+      return definition.type;
+    };
     const types = () => metadata.typesFn().map((item) => getObjectType(item));
 
     return {

--- a/packages/graphql/tests/schema-builder/factories/union-member-not-object-type.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/union-member-not-object-type.spec.ts
@@ -1,0 +1,57 @@
+import { Test } from '@nestjs/testing';
+import {
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+  createUnionType,
+} from '../../../lib';
+
+@ObjectType()
+class RegisteredCat {
+  @Field(() => ID)
+  id: string;
+}
+
+class StrayDog {
+  @Field(() => ID)
+  id: string;
+}
+
+const Pet = createUnionType({
+  name: 'Pet',
+  types: () => [RegisteredCat, StrayDog as any] as const,
+});
+
+@Resolver()
+class PetResolver {
+  @Query(() => Pet)
+  pet(): typeof Pet {
+    return null;
+  }
+}
+
+describe('UnionDefinitionFactory error path', () => {
+  let schemaFactory: GraphQLSchemaFactory;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+    schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should throw a descriptive error when a union member is not an @ObjectType', async () => {
+    await expect(schemaFactory.create([PetResolver])).rejects.toThrowError(
+      /Cannot build the "Pet" union: its member "StrayDog" is not registered as a @ObjectType\(\)\./,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Detect missing object-type registrations in `UnionDefinitionFactory#create` and throw a `UnionMemberNotObjectTypeError` that names both the union and the offending member instead of the cryptic `Cannot read properties of undefined (reading 'type')` from inside graphql-js.

## Bug
\`\`\`ts
@ObjectType()
class Cat { @Field(() => ID) id: string }

// Dog is *not* decorated with @ObjectType()
class Dog { @Field(() => ID) id: string }

const Pet = createUnionType({ name: 'Pet', types: () => [Cat, Dog] as const });
\`\`\`

Today this throws `TypeError: Cannot read properties of undefined (reading 'type')` deep inside `new GraphQLUnionType(...)` with no indication that `Dog` is the problem or that the user forgot `@ObjectType()`.

## Fix
\`getObjectType\` now looks up the definition once, throws \`UnionMemberNotObjectTypeError\` with the union name and the missing member's class name if the lookup misses, and only otherwise reads \`.type\`.

## Test plan
- [x] New `union-member-not-object-type.spec.ts` asserts the friendly error message.
- [x] `tests/schema-builder/**` continues to pass.