### PR TITLE
fix(@nestjs/graphql): clearer error when "implements" lists a non-interface

### DIFF
--- a/packages/graphql/lib/schema-builder/errors/interface-not-registered.error.ts
+++ b/packages/graphql/lib/schema-builder/errors/interface-not-registered.error.ts
@@ -1,0 +1,11 @@
+export class InterfaceNotRegisteredError extends Error {
+  constructor(hostTypeName: string, interfaceRef: unknown) {
+    const interfaceName =
+      (interfaceRef && (interfaceRef as Function).name) || String(interfaceRef);
+    super(
+      `"${hostTypeName}" lists "${interfaceName}" in its "implements" option, but ` +
+        `"${interfaceName}" is not registered as an @InterfaceType(). ` +
+        `Make sure every class referenced from "implements" is decorated with @InterfaceType().`,
+    );
+  }
+}

--- a/packages/graphql/lib/schema-builder/factories/interface-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/interface-definition.factory.ts
@@ -6,6 +6,7 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 import { BuildSchemaOptions } from '../../interfaces';
+import { InterfaceNotRegisteredError } from '../errors/interface-not-registered.error';
 import { ReturnTypeCannotBeResolvedError } from '../errors/return-type-cannot-be-resolved.error';
 import { InterfaceMetadata } from '../metadata/interface.metadata';
 import { OrphanedReferenceRegistry } from '../services/orphaned-reference.registry';
@@ -188,10 +189,14 @@ export class InterfaceDefinitionFactory {
     return () => {
       const interfaces: GraphQLInterfaceType[] = getInterfacesArray(
         metadata.interfaces,
-      ).map(
-        (item: Function) =>
-          this.typeDefinitionsStorage.getInterfaceByTarget(item).type,
-      );
+      ).map((item: Function) => {
+        const definition =
+          this.typeDefinitionsStorage.getInterfaceByTarget(item);
+        if (!definition) {
+          throw new InterfaceNotRegisteredError(metadata.name, item);
+        }
+        return definition.type;
+      });
       if (!isUndefined(prototype)) {
         const parentClass = getParentType();
         if (!parentClass) {

--- a/packages/graphql/lib/schema-builder/factories/object-type-definition.factory.ts
+++ b/packages/graphql/lib/schema-builder/factories/object-type-definition.factory.ts
@@ -7,6 +7,7 @@ import {
 } from 'graphql';
 import { BuildSchemaOptions } from '../../interfaces';
 import { decorateFieldResolverWithMiddleware } from '../../utils/decorate-field-resolver.util';
+import { InterfaceNotRegisteredError } from '../errors/interface-not-registered.error';
 import { PropertyMetadata } from '../metadata';
 import { ObjectTypeMetadata } from '../metadata/object-type.metadata';
 import { OrphanedReferenceRegistry } from '../services/orphaned-reference.registry';
@@ -78,10 +79,14 @@ export class ObjectTypeDefinitionFactory {
     return () => {
       const interfaces: GraphQLInterfaceType[] = getInterfacesArray(
         metadata.interfaces,
-      ).map(
-        (item: Function) =>
-          this.typeDefinitionsStorage.getInterfaceByTarget(item).type,
-      );
+      ).map((item: Function) => {
+        const definition =
+          this.typeDefinitionsStorage.getInterfaceByTarget(item);
+        if (!definition) {
+          throw new InterfaceNotRegisteredError(metadata.name, item);
+        }
+        return definition.type;
+      });
       if (!isUndefined(prototype)) {
         const parentClass = getParentType();
         if (!parentClass) {

--- a/packages/graphql/tests/schema-builder/factories/implements-missing-interface.spec.ts
+++ b/packages/graphql/tests/schema-builder/factories/implements-missing-interface.spec.ts
@@ -1,0 +1,58 @@
+import { Test } from '@nestjs/testing';
+import {
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  ID,
+  InterfaceType,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../../lib';
+
+@InterfaceType()
+abstract class RegisteredEntity {
+  @Field(() => ID)
+  id: string;
+}
+
+abstract class NotRegisteredEntity {
+  @Field(() => ID)
+  id: string;
+}
+
+@ObjectType({ implements: () => [RegisteredEntity, NotRegisteredEntity] })
+class Hybrid extends RegisteredEntity {
+  @Field()
+  label: string;
+}
+
+@Resolver()
+class HybridResolver {
+  @Query(() => Hybrid)
+  hybrid(): Hybrid {
+    return null;
+  }
+}
+
+describe('ObjectType / InterfaceType "implements" error path', () => {
+  let schemaFactory: GraphQLSchemaFactory;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+    schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should throw a descriptive error when implements references a class without @InterfaceType', async () => {
+    await expect(schemaFactory.create([HybridResolver])).rejects.toThrowError(
+      /"Hybrid" lists "NotRegisteredEntity" in its "implements" option, but "NotRegisteredEntity" is not registered as an @InterfaceType\(\)\./,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `ObjectTypeDefinitionFactory#generateInterfaces` and `InterfaceDefinitionFactory#generateInterfaces` now throw a `InterfaceNotRegisteredError` when an entry in `metadata.interfaces` lacks a matching `@InterfaceType()` registration, instead of letting graphql-js crash on `undefined.type`.

## Bug
\`\`\`ts
@InterfaceType()
abstract class Node { @Field(() => ID) id: string }

// missing @InterfaceType()
abstract class Owned { @Field(() => ID) ownerId: string }

@ObjectType({ implements: () => [Node, Owned] })
class Post extends Node { @Field() title: string }
\`\`\`

Compiling this surfaced as `TypeError: Cannot read properties of undefined (reading 'type')` from inside `new GraphQLObjectType({ interfaces: ... })`, with no hint that `Owned` was the missing piece or that it needed `@InterfaceType()`.

## Fix
Both factories now look the interface definition up first and throw a `InterfaceNotRegisteredError` that names the host type and the offending member.

## Test plan
- [x] New `implements-missing-interface.spec.ts` builds a schema that lists an undecorated class in `implements` and asserts the friendly error message.
- [x] Existing `tests/schema-builder/**` suite passes.