### PR TITLE
fix(apollo): expose execution error status normalization

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -96,10 +96,13 @@ export abstract class ApolloBaseDriver<
     this.wrapContextResolver(options);
     this.wrapFormatErrorFn(options);
 
-    if (options.autoTransformHttpErrors !== false) {
+    if (
+      options.autoTransformHttpErrors !== false ||
+      options.forceHttpStatus200ForExecutionErrors === true
+    ) {
       (options as ApolloDriverConfig).plugins = [
         ...((options as ApolloDriverConfig).plugins || []),
-        this.createPreserveHttpStatusPlugin(),
+        this.createHttpStatusPlugin(options),
       ];
     }
     return options;
@@ -231,27 +234,34 @@ export abstract class ApolloBaseDriver<
     this.apolloServer = server;
   }
 
-  private createPreserveHttpStatusPlugin() {
-    // When a resolver throws an error whose `extensions.http.status` is set
-    // (either directly via GraphQLError or transitively via NestJS HTTP
-    // exceptions in user code), Apollo Server uses that value as the HTTP
-    // response status. Some GraphQL clients/UIs then refuse to parse the
-    // response as a normal `{ data, errors }` payload and instead wrap it as
-    // a transport-level error. Reset the HTTP status to 200 once execution
-    // has run so the response shape stays stable. Request-level failures
-    // (parse, validate) are unaffected because their body has no `data` key.
-    // @see https://github.com/nestjs/graphql/issues/2940
+  private createHttpStatusPlugin(options: ApolloDriverConfig) {
     return {
       async requestDidStart() {
         return {
           async willSendResponse(requestContext: any) {
             const body = requestContext.response?.body;
+            const singleResult = body?.singleResult;
+            const responseHttp = requestContext.response?.http;
             if (
-              body?.kind === 'single' &&
-              'data' in (body.singleResult ?? {}) &&
-              requestContext.response?.http
+              body?.kind !== 'single' ||
+              !('data' in (singleResult ?? {})) ||
+              !responseHttp
             ) {
+              return;
+            }
+
+            if (options.forceHttpStatus200ForExecutionErrors === true) {
               requestContext.response.http.status = 200;
+              return;
+            }
+
+            const originalStatusCode = singleResult.errors?.find(
+              (error: GraphQLFormattedError) =>
+                typeof error.extensions?.originalError?.['statusCode'] ===
+                'number',
+            )?.extensions?.originalError?.['statusCode'];
+            if (originalStatusCode) {
+              responseHttp.status = originalStatusCode;
             }
           },
         };

--- a/packages/apollo/lib/interfaces/apollo-driver-config.interface.ts
+++ b/packages/apollo/lib/interfaces/apollo-driver-config.interface.ts
@@ -55,6 +55,14 @@ export interface ApolloDriverConfig
    * @default true
    */
   autoTransformHttpErrors?: boolean;
+
+  /**
+   * If enabled, execution-level GraphQL errors will return HTTP 200 status.
+   * Request-level errors, such as parsing and validation failures, keep their
+   * original HTTP status code.
+   * @default false
+   */
+  forceHttpStatus200ForExecutionErrors?: boolean;
 }
 
 export type ApolloDriverConfigFactory = GqlOptionsFactory<ApolloDriverConfig>;

--- a/packages/apollo/tests/e2e/guards-filters.spec.ts
+++ b/packages/apollo/tests/e2e/guards-filters.spec.ts
@@ -23,7 +23,7 @@ describe('GraphQL - Guards', () => {
         variables: {},
         query: '{\n  recipe(id: "3") {\n    id\n  }\n}\n',
       })
-      .expect(200, {
+      .expect(401, {
         errors: [
           {
             message: 'Unauthorized error',

--- a/packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts
+++ b/packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, INestApplication, Module } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  INestApplication,
+  Module,
+} from '@nestjs/common';
 import { GraphQLModule, Query, Resolver } from '@nestjs/graphql';
 import { Test } from '@nestjs/testing';
 import { GraphQLError } from 'graphql';
@@ -13,6 +18,11 @@ class IssueResolver {
   }
 
   @Query(() => String)
+  throwForbiddenException(): string {
+    throw new ForbiddenException('bar');
+  }
+
+  @Query(() => String)
   throwGraphqlErrorWithHttpStatus(): string {
     throw new GraphQLError('boom', {
       extensions: {
@@ -23,14 +33,19 @@ class IssueResolver {
   }
 }
 
-function buildModule(autoTransformHttpErrors?: boolean) {
+type IssueOptions = Pick<
+  ApolloDriverConfig,
+  'autoTransformHttpErrors' | 'forceHttpStatus200ForExecutionErrors'
+>;
+
+function buildModule(options: IssueOptions = {}) {
   @Module({
     imports: [
       GraphQLModule.forRoot<ApolloDriverConfig>({
         driver: ApolloDriver,
         autoSchemaFile: true,
         includeStacktraceInErrorResponses: false,
-        autoTransformHttpErrors,
+        ...options,
       }),
     ],
     providers: [IssueResolver],
@@ -39,9 +54,9 @@ function buildModule(autoTransformHttpErrors?: boolean) {
   return Issue2940Module;
 }
 
-async function bootstrap(autoTransformHttpErrors?: boolean) {
+async function bootstrap(options?: IssueOptions) {
   const moduleRef = await Test.createTestingModule({
-    imports: [buildModule(autoTransformHttpErrors)],
+    imports: [buildModule(options)],
   }).compile();
 
   const app = moduleRef.createNestApplication();
@@ -50,7 +65,7 @@ async function bootstrap(autoTransformHttpErrors?: boolean) {
 }
 
 describe('Issue #2940 - GraphQL error formatting with HTTP status', () => {
-  describe('default (autoTransformHttpErrors enabled)', () => {
+  describe('default (autoTransformHttpErrors enabled, force flag disabled)', () => {
     let app: INestApplication;
 
     beforeEach(async () => {
@@ -61,31 +76,31 @@ describe('Issue #2940 - GraphQL error formatting with HTTP status', () => {
       await app.close();
     });
 
-    it('should return the standard {data, errors} response shape (HTTP 200) when a NestJS HttpException is thrown from a resolver', async () => {
+    it('should transform a NestJS HttpException without forcing the response to HTTP 200', async () => {
       const res = await request(app.getHttpServer())
         .post('/graphql')
-        .send({ query: '{ throwHttpException }' });
+        .send({ query: '{ throwForbiddenException }' });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(403);
       expect(res.body).toHaveProperty('data', null);
       expect(res.body).toHaveProperty('errors');
       expect(res.body).not.toHaveProperty('error');
       expect(res.body.errors[0].extensions).toMatchObject({
-        code: 'BAD_REQUEST',
+        code: 'FORBIDDEN',
         originalError: {
-          statusCode: 400,
-          message: 'foo',
+          statusCode: 403,
+          message: 'bar',
         },
       });
       expect(res.body.errors[0].extensions).not.toHaveProperty('http');
     });
 
-    it('should keep the response at HTTP 200 when a resolver throws a GraphQLError carrying extensions.http.status', async () => {
+    it('should keep the response at execution-derived status when a GraphQLError has extensions.http.status', async () => {
       const res = await request(app.getHttpServer())
         .post('/graphql')
         .send({ query: '{ throwGraphqlErrorWithHttpStatus }' });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(400);
       expect(res.body).toHaveProperty('data', null);
       expect(res.body).toHaveProperty('errors');
       expect(res.body).not.toHaveProperty('error');
@@ -108,14 +123,14 @@ describe('Issue #2940 - GraphQL error formatting with HTTP status', () => {
     let app: INestApplication;
 
     beforeEach(async () => {
-      app = await bootstrap(false);
+      app = await bootstrap({ autoTransformHttpErrors: false });
     });
 
     afterEach(async () => {
       await app.close();
     });
 
-    it('should preserve Apollo Server`s extensions.http.status response status when the user opts out', async () => {
+    it('should preserve Apollo Server`s extensions.http.status response status', async () => {
       const res = await request(app.getHttpServer())
         .post('/graphql')
         .send({ query: '{ throwGraphqlErrorWithHttpStatus }' });
@@ -123,6 +138,48 @@ describe('Issue #2940 - GraphQL error formatting with HTTP status', () => {
       expect(res.status).toBe(400);
       expect(res.body).toHaveProperty('data', null);
       expect(res.body).toHaveProperty('errors');
+    });
+  });
+
+  describe('with forceHttpStatus200ForExecutionErrors enabled', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+      app = await bootstrap({ forceHttpStatus200ForExecutionErrors: true });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should normalize execution-level error responses back to HTTP 200', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwGraphqlErrorWithHttpStatus }' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data', null);
+      expect(res.body).toHaveProperty('errors');
+      expect(res.body).not.toHaveProperty('error');
+    });
+
+    it('should still transform NestJS HttpExceptions while normalizing their response status', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: '{ throwHttpException }' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('data', null);
+      expect(res.body).toHaveProperty('errors');
+      expect(res.body).not.toHaveProperty('error');
+      expect(res.body.errors[0].extensions).toMatchObject({
+        code: 'BAD_REQUEST',
+        originalError: {
+          statusCode: 400,
+          message: 'foo',
+        },
+      });
+      expect(res.body.errors[0].extensions).not.toHaveProperty('http');
     });
   });
 });

--- a/packages/apollo/tests/e2e/pipes.spec.ts
+++ b/packages/apollo/tests/e2e/pipes.spec.ts
@@ -25,7 +25,7 @@ describe('GraphQL - Pipes', () => {
         query:
           'mutation {\n  addRecipe(newRecipeData: {title: "test", ingredients: []}) {\n    id\n  }\n}\n',
       })
-      .expect(200, {
+      .expect(400, {
         data: null,
         errors: [
           {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: Fixes #3997

`autoTransformHttpErrors` currently also enables HTTP 200 normalization for execution-level errors. This makes it impossible to keep Nest HTTP exception transformation enabled while preserving HTTP status codes for contracts that rely on 4xx signaling.

## What is the new behavior?

Execution-level status normalization is controlled by a dedicated Apollo driver option: `forceHttpStatus200ForExecutionErrors`.

By default, transformed Nest `HttpException`s preserve their mapped HTTP status while keeping the existing GraphQL error extensions. Enabling `forceHttpStatus200ForExecutionErrors` restores the HTTP 200 normalization behavior introduced for GraphQL clients that require `{ data, errors }` responses with a 2xx transport status. Request-level parse/validation errors are unaffected.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

This changes the default introduced by #3940 so execution-level errors are no longer forced to HTTP 200 unless `forceHttpStatus200ForExecutionErrors` is enabled.

## Other information

Targeted to `v14.0.0`, the active release branch.

Local checks:

- `yarn test:e2e:apollo`
- `yarn workspace @nestjs/apollo test:e2e tests/e2e/issue-2940-http-error-status.spec.ts`
- `yarn build`
- `yarn oxlint packages/apollo/lib/drivers/apollo-base.driver.ts packages/apollo/lib/interfaces/apollo-driver-config.interface.ts packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts packages/apollo/tests/e2e/guards-filters.spec.ts packages/apollo/tests/e2e/pipes.spec.ts`
- `yarn prettier packages/apollo/lib/drivers/apollo-base.driver.ts packages/apollo/lib/interfaces/apollo-driver-config.interface.ts packages/apollo/tests/e2e/issue-2940-http-error-status.spec.ts packages/apollo/tests/e2e/guards-filters.spec.ts packages/apollo/tests/e2e/pipes.spec.ts --check`
- `git diff --check`
