### PR TITLE
fix(graphql): preserve PickType fields for dual-decorated inputs

### DIFF
--- a/packages/graphql/lib/type-helpers/pick-type.helper.ts
+++ b/packages/graphql/lib/type-helpers/pick-type.helper.ts
@@ -26,7 +26,8 @@ export function PickType<T, K extends keyof T>(
       inheritPropertyInitializers(this, classRef, isInheritedPredicate);
     }
   }
-  if (decorator) {
+  if (decorator && decorator !== decoratorFactory) {
+    decoratorFactory({ isAbstract: true })(PickObjectType);
     decorator({ isAbstract: true })(PickObjectType);
   } else {
     decoratorFactory({ isAbstract: true })(PickObjectType);

--- a/packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts
+++ b/packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts
@@ -1,4 +1,16 @@
-import { Field, InputType, TypeMetadataStorage } from '../../lib';
+import { Test } from '@nestjs/testing';
+import { GraphQLInputObjectType } from 'graphql';
+import {
+  Args,
+  Field,
+  GraphQLSchemaBuilderModule,
+  GraphQLSchemaFactory,
+  InputType,
+  ObjectType,
+  Query,
+  Resolver,
+  TypeMetadataStorage,
+} from '../../lib';
 import { PickType } from '../../lib/type-helpers';
 import { LazyMetadataStorage } from '../../lib/schema-builder/storages/lazy-metadata.storage';
 
@@ -28,5 +40,62 @@ describe('PickType duplicate registration regression', () => {
     const pickAbstract = Object.getPrototypeOf(PickedInput) as Function;
     const matches = inputs.filter((item) => item.target === pickAbstract);
     expect(matches).toHaveLength(1);
+  });
+});
+
+describe('PickType with dual-decorated source and target', () => {
+  let schemaFactory: GraphQLSchemaFactory;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [GraphQLSchemaBuilderModule],
+    }).compile();
+
+    schemaFactory = moduleRef.get(GraphQLSchemaFactory);
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  it('should preserve picked fields when the generated type is also used as input', async () => {
+    @InputType()
+    @ObjectType('PickTypeDualDecoratedParentObject')
+    class PickTypeDualDecoratedParent {
+      @Field(() => String, { nullable: true })
+      nullableField?: string;
+    }
+
+    @InputType()
+    @ObjectType('PickTypeDualDecoratedChildObject')
+    class PickTypeDualDecoratedChild extends PickType(
+      PickTypeDualDecoratedParent,
+      ['nullableField'] as const,
+      ObjectType,
+    ) {}
+
+    @Resolver()
+    class PickTypeDualDecoratedResolver {
+      @Query(() => String)
+      pickTypeDualDecorated(
+        @Args('filter', {
+          type: () => PickTypeDualDecoratedChild,
+          nullable: true,
+        })
+        filter?: PickTypeDualDecoratedChild,
+      ): string {
+        return filter?.nullableField ?? '';
+      }
+    }
+
+    LazyMetadataStorage.load([PickTypeDualDecoratedChild]);
+
+    const schema = await schemaFactory.create([PickTypeDualDecoratedResolver]);
+    const inputType = schema.getType(
+      'PickTypeDualDecoratedChild',
+    ) as GraphQLInputObjectType;
+
+    expect(inputType).toBeDefined();
+    expect(inputType.getFields().nullableField).toBeDefined();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`PickType()` can lose input fields when it is created from a dual-decorated source class with an explicit `ObjectType` decorator and the resulting class is also used as an input type. This produces an empty generated input type during schema generation.

Issue Number: Fixes #4006


## What is the new behavior?
When `PickType()` receives an explicit decorator that differs from the source type decorator, the generated abstract class is registered with both decorators. This preserves the source input metadata for input inheritance while keeping the requested object metadata for object-type usage.

A regression test now covers a dual-decorated parent and child where `PickType(..., ObjectType)` is used as a GraphQL argument input and the generated input type keeps the picked nullable field.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Docs are not updated because this is a narrow regression fix for existing `PickType()` behavior.

Validated with:

```bash
yarn workspace @nestjs/graphql test:e2e tests/type-helpers/pick-type-double-register.spec.ts
yarn build
yarn oxlint packages/graphql/lib/type-helpers/pick-type.helper.ts packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts
yarn prettier packages/graphql/lib/type-helpers/pick-type.helper.ts packages/graphql/tests/type-helpers/pick-type-double-register.spec.ts --check
git diff --check
```
