### PR TITLE
feat(graphql): support explicit args type names

### DIFF
--- a/packages/graphql/lib/decorators/args-type.decorator.ts
+++ b/packages/graphql/lib/decorators/args-type.decorator.ts
@@ -1,3 +1,4 @@
+import { isString } from '@nestjs/common/utils/shared.utils.js';
 import { ClassType } from '../enums/class-type.enum.js';
 import { RegisterInOption } from '../schema-builder/metadata/index.js';
 import { LazyMetadataStorage } from '../schema-builder/storages/lazy-metadata.storage.js';
@@ -36,10 +37,26 @@ export function ArgsType(options: ArgsTypeOptions): ClassDecorator;
  *
  * @publicApi
  */
-export function ArgsType(options?: ArgsTypeOptions): ClassDecorator {
+export function ArgsType(
+  name: string,
+  options?: ArgsTypeOptions,
+): ClassDecorator;
+/**
+ * Decorator that marks a class as a resolver arguments type.
+ *
+ * @publicApi
+ */
+export function ArgsType(
+  nameOrOptions?: string | ArgsTypeOptions,
+  argsTypeOptions?: ArgsTypeOptions,
+): ClassDecorator {
+  const [name, options = {}] = isString(nameOrOptions)
+    ? [nameOrOptions, argsTypeOptions]
+    : [undefined, nameOrOptions];
+
   return (target: Function) => {
     const metadata = {
-      name: target.name,
+      name: name || target.name,
       target,
       registerIn: options?.registerIn,
     };

--- a/packages/graphql/lib/decorators/args-type.decorator.ts
+++ b/packages/graphql/lib/decorators/args-type.decorator.ts
@@ -35,6 +35,10 @@ export function ArgsType(options: ArgsTypeOptions): ClassDecorator;
 /**
  * Decorator that marks a class as a resolver arguments type.
  *
+ * Note: arguments classes are flattened into the individual arguments of every
+ * field they are used in, so the explicit name is only reflected in the type
+ * metadata and does not appear in the generated schema.
+ *
  * @publicApi
  */
 export function ArgsType(
@@ -58,7 +62,7 @@ export function ArgsType(
     const metadata = {
       name: name || target.name,
       target,
-      registerIn: options?.registerIn,
+      registerIn: options.registerIn,
     };
     LazyMetadataStorage.store(() =>
       TypeMetadataStorage.addArgsMetadata(metadata),

--- a/packages/graphql/lib/extra/graphql-model-shim.ts
+++ b/packages/graphql/lib/extra/graphql-model-shim.ts
@@ -6,6 +6,7 @@
 // any additional configuration.
 /* eslint @typescript-eslint/no-empty-function: 0 */
 import {
+  ArgsTypeOptions,
   FieldOptions,
   InputTypeOptions,
   InterfaceTypeOptions,
@@ -22,7 +23,10 @@ import * as typeFactories from '../type-factories/index.js';
 //     }
 // }
 
-export function ArgsType(): ClassDecorator {
+export function ArgsType(
+  nameOrOptions?: string | ArgsTypeOptions,
+  argsTypeOptions?: ArgsTypeOptions,
+): ClassDecorator {
   return (target: Function) => {};
 }
 

--- a/packages/graphql/tests/decorators/args-type.decorator.spec.ts
+++ b/packages/graphql/tests/decorators/args-type.decorator.spec.ts
@@ -1,0 +1,69 @@
+import { Type } from '@nestjs/common';
+import { ArgsType, Field, TypeMetadataStorage } from '../../lib/index.js';
+import { LazyMetadataStorage } from '../../lib/schema-builder/storages/lazy-metadata.storage.js';
+
+class FeatureModule {}
+
+describe('@ArgsType decorator', () => {
+  afterEach(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  function getMetadata(target: Type<unknown>) {
+    LazyMetadataStorage.load([target]);
+    TypeMetadataStorage.compile();
+
+    return TypeMetadataStorage.getArgumentsMetadataByTarget(target);
+  }
+
+  it('should fall back to the class name when called without arguments', () => {
+    @ArgsType()
+    class TestArgs {
+      @Field(() => String)
+      query!: string;
+    }
+
+    const metadata = getMetadata(TestArgs);
+    expect(metadata).toBeDefined();
+    expect(metadata!.name).toBe('TestArgs');
+  });
+
+  it('should fall back to the class name when called with options only', () => {
+    @ArgsType({ registerIn: () => FeatureModule })
+    class TestArgs {
+      @Field(() => String)
+      query!: string;
+    }
+
+    const metadata = getMetadata(TestArgs);
+    expect(metadata).toBeDefined();
+    expect(metadata!.name).toBe('TestArgs');
+    expect((metadata!.registerIn as () => Function)()).toBe(FeatureModule);
+  });
+
+  it('should use the explicit name when called with a name only', () => {
+    @ArgsType('CustomArgs')
+    class TestArgs {
+      @Field(() => String)
+      query!: string;
+    }
+
+    const metadata = getMetadata(TestArgs);
+    expect(metadata).toBeDefined();
+    expect(metadata!.name).toBe('CustomArgs');
+    expect(metadata!.registerIn).toBeUndefined();
+  });
+
+  it('should use the explicit name when called with a name and options', () => {
+    @ArgsType('CustomArgs', { registerIn: () => FeatureModule })
+    class TestArgs {
+      @Field(() => String)
+      query!: string;
+    }
+
+    const metadata = getMetadata(TestArgs);
+    expect(metadata).toBeDefined();
+    expect(metadata!.name).toBe('CustomArgs');
+    expect((metadata!.registerIn as () => Function)()).toBe(FeatureModule);
+  });
+});

--- a/packages/graphql/tests/decorators/register-in.decorator.spec.ts
+++ b/packages/graphql/tests/decorators/register-in.decorator.spec.ts
@@ -171,6 +171,23 @@ describe('registerIn decorator option', () => {
       expect(metadata).toBeDefined();
       expect((metadata!.registerIn as () => Function)()).toBe(AppModule);
     });
+
+    it('should work with name and registerIn option', () => {
+      @ArgsType('CustomArgs', { registerIn: () => FeatureModule })
+      class TestArgs {
+        @Field(() => String)
+        query!: string;
+      }
+
+      LazyMetadataStorage.load([TestArgs]);
+      TypeMetadataStorage.compile();
+
+      const metadata =
+        TypeMetadataStorage.getArgumentsMetadataByTarget(TestArgs);
+      expect(metadata).toBeDefined();
+      expect(metadata!.name).toBe('CustomArgs');
+      expect((metadata!.registerIn as () => Function)()).toBe(FeatureModule);
+    });
   });
 
   describe('registerEnumType function', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@ObjectType()` and `@InputType()` support explicit GraphQL type names through `@ObjectType(name, options?)` and `@InputType(name, options?)`, but `@ArgsType()` only accepts `ArgsTypeOptions` and always uses the TypeScript class name for metadata.

Issue Number: #4023


## What is the new behavior?

`@ArgsType()` now supports the same explicit-name overload shape:

```ts
@ArgsType()
@ArgsType(options)
@ArgsType(name, options?)
```

The implementation follows the existing `ObjectType` and `InputType` decorator pattern, preserving `ArgsTypeOptions` such as `registerIn` and falling back to `target.name` when no explicit name is provided. The browser/react-native model shim accepts the same arguments.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Verified with:

```bash
COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn workspace @nestjs/graphql test:e2e tests/decorators/register-in.decorator.spec.ts
COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn build
COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn lint
COREPACK_ENABLE_PROJECT_SPEC=0 corepack yarn format --check
git diff --check
```
