### PR TITLE
fix: replace CJS require() calls with ESM syntax for ESM compatibility

### DIFF
--- a/packages/apollo/lib/drivers/apollo-base.driver.ts
+++ b/packages/apollo/lib/drivers/apollo-base.driver.ts
@@ -145,7 +145,7 @@ export abstract class ApolloBaseDriver<
     const { expressMiddleware } = loadPackage(
       '@as-integrations/express5',
       'GraphQLModule',
-      () => require('@as-integrations/express5'),
+      () => import('@as-integrations/express5'),
     );
 
     const { path, typeDefs, resolvers, schema } = options;
@@ -198,7 +198,7 @@ export abstract class ApolloBaseDriver<
     const { fastifyApolloDrainPlugin, fastifyApolloHandler } = loadPackage(
       '@as-integrations/fastify',
       'GraphQLModule',
-      () => require('@as-integrations/fastify'),
+      () => import('@as-integrations/fastify'),
     );
 
     const httpAdapter = this.httpAdapterHost.httpAdapter;

--- a/packages/graphql/lib/graphql-types.loader.ts
+++ b/packages/graphql/lib/graphql-types.loader.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import lodash from 'lodash';
 import * as util from 'util';
 
-const normalize = require('normalize-path');
+import normalize from 'normalize-path';
 const readFile = util.promisify(fs.readFile);
 const { flatten } = lodash;
 


### PR DESCRIPTION
The `chore/esm-migration` branch added `"type": "module"` to `package.json` but three `require()` calls were overlooked:

1. `packages/graphql/lib/graphql-types.loader.ts:8` — static `require()` at module scope, changed to `import` statement
2. `packages/apollo/lib/drivers/apollo-base.driver.ts:148` — `require()` inside `loadPackage` callback, changed to dynamic `import()`
3. `packages/apollo/lib/drivers/apollo-base.driver.ts:201` — same pattern for fastify integration

These cause `ERR_REQUIRE_ESM` at runtime when Node.js encounters CommonJS `require()` in a package declared as ES module.