### PR TITLE
chore(deps): replace fast-glob with tinyglobby

### DIFF
--- a/packages/graphql/lib/graphql-definitions.factory.ts
+++ b/packages/graphql/lib/graphql-definitions.factory.ts
@@ -1,7 +1,6 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { isEmpty } from '@nestjs/common/utils/shared.utils';
 import chokidar from 'chokidar';
-import { glob } from 'fast-glob';
 import { printSchema } from 'graphql';
 import { gql } from 'graphql-tag';
 import {
@@ -10,6 +9,7 @@ import {
 } from './graphql-ast.explorer';
 import { GraphQLTypesLoader } from './graphql-types.loader';
 import { extend, removeTempField } from './utils';
+import { globPaths } from './utils/glob.util';
 
 export type GenerateOptions = DefinitionsGeneratorOptions & {
   typePaths: string[];
@@ -47,7 +47,7 @@ export class GraphQLDefinitionsFactory {
         'GraphQL factory is watching your files...',
         isDebugEnabled,
       );
-      const watcher = chokidar.watch(await glob(options.typePaths));
+      const watcher = chokidar.watch(await globPaths(options.typePaths));
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       watcher.on('change', async (file) => {
         this.printMessage(

--- a/packages/graphql/lib/graphql-types.loader.ts
+++ b/packages/graphql/lib/graphql-types.loader.ts
@@ -1,9 +1,9 @@
 import { mergeTypeDefs } from '@graphql-tools/merge';
 import { Injectable } from '@nestjs/common';
-import glob from 'fast-glob';
 import * as fs from 'fs';
 import { flatten } from 'lodash';
 import * as util from 'util';
+import { globPaths } from './utils/glob.util';
 
 const normalize = require('normalize-path');
 const readFile = util.promisify(fs.readFile);
@@ -31,7 +31,7 @@ export class GraphQLTypesLoader {
       ? paths.map((path) => normalize(path))
       : normalize(paths);
 
-    const filePaths = await glob(paths, {
+    const filePaths = await globPaths(paths, {
       ignore: includeNodeModules ? [] : ['node_modules'],
     });
     if (filePaths.length === 0) {

--- a/packages/graphql/lib/utils/glob.util.ts
+++ b/packages/graphql/lib/utils/glob.util.ts
@@ -1,0 +1,42 @@
+import { isAbsolute, win32 } from 'path';
+import { glob } from 'tinyglobby';
+import type { GlobOptions } from 'tinyglobby';
+
+type GlobPattern = string | string[];
+
+export async function globPaths(
+  patterns: GlobPattern,
+  options: Omit<
+    GlobOptions,
+    'absolute' | 'expandDirectories' | 'patterns'
+  > = {},
+): Promise<string[]> {
+  const patternsArray = Array.isArray(patterns) ? patterns : [patterns];
+  const negativePatterns = patternsArray.filter(isNegativePattern);
+  const positivePatterns = patternsArray.filter(
+    (pattern) => !isNegativePattern(pattern),
+  );
+  const globOptions = {
+    ...options,
+    expandDirectories: false,
+  };
+
+  const matches = await Promise.all(
+    positivePatterns.map((pattern) =>
+      glob([pattern, ...negativePatterns], {
+        ...globOptions,
+        absolute: isAbsoluteGlob(pattern),
+      }),
+    ),
+  );
+
+  return [...new Set(matches.flat())];
+}
+
+function isNegativePattern(pattern: string): boolean {
+  return pattern[0] === '!' && pattern[1] !== '(';
+}
+
+function isAbsoluteGlob(pattern: string): boolean {
+  return isAbsolute(pattern) || win32.isAbsolute(pattern);
+}

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -48,12 +48,12 @@
     "@graphql-tools/utils": "11.1.0",
     "@nestjs/mapped-types": "2.1.1",
     "chokidar": "4.0.3",
-    "fast-glob": "3.3.3",
     "graphql-tag": "2.12.6",
     "graphql-ws": "6.0.8",
     "lodash": "4.18.1",
     "normalize-path": "3.0.0",
     "subscriptions-transport-ws": "0.11.0",
+    "tinyglobby": "0.2.17",
     "tslib": "2.8.1",
     "ws": "8.20.1"
   },

--- a/packages/graphql/tests/graphql-definitions.factory.spec.ts
+++ b/packages/graphql/tests/graphql-definitions.factory.spec.ts
@@ -1,0 +1,50 @@
+import chokidar from 'chokidar';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GraphQLDefinitionsFactory } from '../lib/graphql-definitions.factory';
+
+const watchMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    on: vi.fn(),
+  })),
+);
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: watchMock,
+  },
+}));
+
+describe('GraphQLDefinitionsFactory', () => {
+  let directory: string;
+
+  beforeEach(async () => {
+    watchMock.mockClear();
+    directory = await mkdtemp(join(tmpdir(), 'nestjs-graphql-definitions-'));
+  });
+
+  afterEach(async () => {
+    await rm(directory, { force: true, recursive: true });
+  });
+
+  it('watches files resolved from type path glob patterns', async () => {
+    await writeFile(
+      join(directory, 'schema.graphql'),
+      'type Query { ok: Boolean }',
+    );
+
+    const factory = new GraphQLDefinitionsFactory();
+    await factory.generate({
+      typePaths: [join(directory, '*.graphql')],
+      path: join(directory, 'graphql.ts'),
+      outputAs: 'class',
+      watch: true,
+      debug: false,
+    });
+
+    expect(chokidar.watch).toHaveBeenCalledWith([
+      join(directory, 'schema.graphql'),
+    ]);
+  });
+});

--- a/packages/graphql/tests/graphql-types.loader.spec.ts
+++ b/packages/graphql/tests/graphql-types.loader.spec.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GraphQLTypesLoader } from '../lib/graphql-types.loader';
+
+describe('GraphQLTypesLoader', () => {
+  let directory: string;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'nestjs-graphql-types-'));
+  });
+
+  afterEach(async () => {
+    await rm(directory, { force: true, recursive: true });
+  });
+
+  it('loads type definitions from glob patterns', async () => {
+    await writeFile(
+      join(directory, 'cat.graphql'),
+      'type Cat { id: ID!, name: String! }',
+    );
+    await writeFile(
+      join(directory, 'query.graphql'),
+      'type Query { cat: Cat }',
+    );
+
+    const loader = new GraphQLTypesLoader();
+    const typeDefs = await loader.mergeTypesByPaths(
+      join(directory, '*.graphql'),
+    );
+
+    expect(typeDefs).toContain('type Query');
+    expect(typeDefs).toContain('type Cat');
+  });
+});

--- a/packages/graphql/tests/utils/glob.util.spec.ts
+++ b/packages/graphql/tests/utils/glob.util.spec.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join, relative } from 'path';
+import { globPaths } from '../../lib/utils/glob.util';
+
+describe('globPaths', () => {
+  let directory: string;
+  let absoluteDirectory: string;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(process.cwd(), 'tmp-glob-'));
+    await writeFile(
+      join(directory, 'schema.graphql'),
+      'type Query { ok: Boolean }',
+    );
+    absoluteDirectory = await mkdtemp(join(process.cwd(), 'tmp-abs-glob-'));
+    await writeFile(
+      join(absoluteDirectory, 'schema.graphql'),
+      'type Query { absolute: Boolean }',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(directory, { force: true, recursive: true });
+    await rm(absoluteDirectory, { force: true, recursive: true });
+  });
+
+  it('preserves absolute matches for absolute patterns', async () => {
+    await expect(globPaths(join(directory, '*.graphql'))).resolves.toEqual([
+      join(directory, 'schema.graphql'),
+    ]);
+  });
+
+  it('preserves relative matches for relative patterns', async () => {
+    const relativePattern = relative(
+      process.cwd(),
+      join(directory, '*.graphql'),
+    );
+    const relativeSchemaPath = relative(
+      process.cwd(),
+      join(directory, 'schema.graphql'),
+    );
+
+    await expect(globPaths(relativePattern)).resolves.toEqual([
+      relativeSchemaPath,
+    ]);
+  });
+
+  it('preserves pattern order when absolute and relative patterns are mixed', async () => {
+    const relativePattern = relative(
+      process.cwd(),
+      join(directory, '*.graphql'),
+    );
+    const relativeSchemaPath = relative(
+      process.cwd(),
+      join(directory, 'schema.graphql'),
+    );
+    const absolutePattern = join(absoluteDirectory, '*.graphql');
+    const absoluteSchemaPath = join(absoluteDirectory, 'schema.graphql');
+
+    await expect(
+      globPaths([relativePattern, absolutePattern]),
+    ).resolves.toEqual([relativeSchemaPath, absoluteSchemaPath]);
+  });
+
+  it('applies negative patterns', async () => {
+    await writeFile(
+      join(directory, 'skip.graphql'),
+      'type Query { skip: Boolean }',
+    );
+    const relativePattern = relative(
+      process.cwd(),
+      join(directory, '*.graphql'),
+    );
+    const relativeSchemaPath = relative(
+      process.cwd(),
+      join(directory, 'schema.graphql'),
+    );
+    const relativeSkipPath = relative(
+      process.cwd(),
+      join(directory, 'skip.graphql'),
+    );
+
+    await expect(
+      globPaths([relativePattern, `!${relativeSkipPath}`]),
+    ).resolves.toEqual([relativeSchemaPath]);
+  });
+
+  it('deduplicates matches from repeated patterns', async () => {
+    const relativePattern = relative(
+      process.cwd(),
+      join(directory, '*.graphql'),
+    );
+    const relativeSchemaPath = relative(
+      process.cwd(),
+      join(directory, 'schema.graphql'),
+    );
+
+    await expect(
+      globPaths([relativePattern, relativePattern]),
+    ).resolves.toEqual([relativeSchemaPath]);
+  });
+
+  it('does not expand directory patterns', async () => {
+    await expect(globPaths(directory)).resolves.toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,27 +1260,6 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
-"@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
-  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
-  dependencies:
-    "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
-
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
-  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
-  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
-  dependencies:
-    "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
-
 "@npmcli/agent@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-3.0.0.tgz#1685b1fbd4a1b7bb4f930cbb68ce801edfe7aa44"
@@ -2800,13 +2779,6 @@ brace-expansion@^5.0.5:
   dependencies:
     balanced-match "^4.0.2"
 
-braces@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
-  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
-  dependencies:
-    fill-range "^7.1.1"
-
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -3976,17 +3948,6 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4135,7 +4096,7 @@ fastparallel@^2.4.1:
     reusify "^1.0.4"
     xtend "^4.0.2"
 
-fastq@^1.17.1, fastq@^1.6.0:
+fastq@^1.17.1:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.18.0.tgz#d631d7e25faffea81887fe5ea8c9010e1b36fee0"
   integrity sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==
@@ -4183,13 +4144,6 @@ file-type@21.3.4:
     strtok3 "^10.3.4"
     token-types "^6.1.1"
     uint8array-extras "^1.4.0"
-
-fill-range@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
-  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
-  dependencies:
-    to-regex-range "^5.0.1"
 
 finalhandler@^2.1.0:
   version "2.1.0"
@@ -4484,13 +4438,6 @@ git-url-parse@16.1.0:
   integrity sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==
   dependencies:
     git-up "^8.1.0"
-
-glob-parent@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob@^10.2.2:
   version "10.4.5"
@@ -5011,22 +4958,10 @@ is-docker@3.0.0, is-docker@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
   integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
 
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
-
 is-fullwidth-code-point@3.0.0, is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
-
-is-glob@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
-  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
-  dependencies:
-    is-extglob "^2.1.1"
 
 is-in-ssh@^1.0.0:
   version "1.0.0"
@@ -5067,11 +5002,6 @@ is-number-object@^1.1.1:
   dependencies:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
-
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-obj@^4.1.0:
   version "4.1.0"
@@ -5884,23 +5814,10 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
 methods@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
-
-micromatch@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
-  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
-  dependencies:
-    braces "^3.0.3"
-    picomatch "^2.3.1"
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -7013,11 +6930,6 @@ picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
 picomatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
@@ -7237,11 +7149,6 @@ qs@^6.14.0, qs@^6.14.1:
   integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
   dependencies:
     side-channel "^1.1.0"
-
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
-  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 quick-format-unescaped@^4.0.3:
   version "4.0.4"
@@ -7520,13 +7427,6 @@ run-async@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-4.0.6.tgz#d53b86acb71f42650fe23de2b3c1b6b6b34b9294"
   integrity sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==
-
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
-  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
-  dependencies:
-    queue-microtask "^1.2.2"
 
 rxjs@7.8.2, rxjs@^7.8.2:
   version "7.8.2"
@@ -8255,13 +8155,6 @@ to-buffer@^1.2.0:
     isarray "^2.0.5"
     safe-buffer "^5.2.1"
     typed-array-buffer "^1.0.3"
-
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  dependencies:
-    is-number "^7.0.0"
 
 toad-cache@^3.7.0:
   version "3.7.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no docs change needed


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3731

`@nestjs/graphql` uses `fast-glob` for GraphQL type path lookups.

## What is the new behavior?

Uses `tinyglobby` instead.

There are a few small differences between the two packages, so I added a small helper to keep `typePaths` working the same way as before.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Ran `yarn lint` and `yarn test:e2e:graphql`.