### PR TITLE
perf(graphql): avoid re-mapping resolver metadata per ancestor (90%+ performance gain on compileExtendedResolversMetadata function)

### DIFF
--- a/packages/graphql/lib/schema-builder/storages/resolver-implementation.map.ts
+++ b/packages/graphql/lib/schema-builder/storages/resolver-implementation.map.ts
@@ -1,0 +1,179 @@
+import { Logger } from '@nestjs/common';
+
+import {
+  BaseResolverMetadata,
+  FieldResolverMetadata,
+  ResolverClassMetadata,
+  ResolverTypeMetadata,
+} from '../metadata';
+import { isThrowing } from '../utils/is-throwing.util';
+
+/**
+ * Resolves which resolver class implements the handlers declared on a base class.
+ *
+ * A handler is recorded against the class it is declared on, but Nest instantiates the class
+ * registered as a provider. When a resolver extends a base class, every handler declared on that
+ * base therefore has to be reassigned to the derived class:
+ *
+ *   class BaseUserResolver { @Query(() => User) user() {} }    // target: BaseUserResolver
+ *   @Resolver() class UserResolver extends BaseUserResolver {} // the class Nest instantiates
+ *
+ * so `user` has to end up targeting `UserResolver`. Note that the base class need not be a resolver
+ * itself - `@Query` records whichever class the method is written on, decorated or not.
+ */
+export class ResolverImplementationMap {
+  private readonly resolverByBaseClass = new Map<
+    Function,
+    ResolverClassMetadata
+  >();
+  private readonly logger = new Logger(ResolverImplementationMap.name);
+
+  /**
+   * @param resolvers every registered resolver class, in registration order.
+   * @param handlerGroups the handler arrays, kept as groups rather than a flattened set so they are
+   * only scanned when an ambiguity actually has to be reported.
+   */
+  constructor(
+    resolvers: readonly ResolverClassMetadata[],
+    private readonly handlerGroups: readonly BaseResolverMetadata[][],
+  ) {
+    this.collectExtendedResolversMap(resolvers);
+  }
+
+  /** True when no resolver extends anything, so there is nothing to reassign. */
+  get isEmpty() {
+    return this.resolverByBaseClass.size === 0;
+  }
+
+  /**
+   * The resolver that ends up serving handlers declared on `baseClass`, following the full chain.
+   * `resolverByBaseClass` is keyed by base class and holds the resolver extending it, so a lookup
+   * steps one level *down* the chain. Keep stepping until nothing extends the class just landed on.
+   * Adding `class AdminUserResolver extends UserResolver` to the example above:
+   *
+   *   BaseUserResolver -> UserResolver -> AdminUserResolver
+   *
+   * and `AdminUserResolver` serves it. Intermediate classes are stepped through, not selected.
+   */
+  getResolverImplementationForBaseClass(baseClass: Function) {
+    let resolver = this.resolverByBaseClass.get(baseClass);
+    while (resolver && this.resolverByBaseClass.has(resolver.target)) {
+      resolver = this.resolverByBaseClass.get(resolver.target);
+    }
+    return resolver;
+  }
+
+  /** Rewrites every metadata entry to target the resolver class that implements it, if any. */
+  collectAllMetadata(baseMetadatas: ResolverTypeMetadata[]) {
+    return baseMetadatas.map((baseMetadata) =>
+      this.getImplementationMetadataForBaseClass(baseMetadata),
+    );
+  }
+
+  /**
+   * Rewrites every field resolver metadata entry to target the resolver class that implements it,
+   * if any. A field resolver whose own `objectTypeFn` cannot resolve its host type falls back to
+   * the `typeFn` of the resolver that now owns it.
+   */
+  collectFieldResolversMetadata(fieldResolvers: FieldResolverMetadata[]) {
+    return fieldResolvers.map((metadata) => {
+      const classMetadata = this.getResolverImplementationForBaseClass(
+        metadata.target,
+      );
+      if (!classMetadata) {
+        return metadata;
+      }
+      return {
+        ...metadata,
+        target: classMetadata.target,
+        classMetadata,
+        objectTypeFn: isThrowing(metadata.objectTypeFn)
+          ? classMetadata.typeFn
+          : metadata.objectTypeFn,
+      };
+    });
+  }
+
+  /** The same handler, reattributed to the resolver class that implements it. */
+  private getImplementationMetadataForBaseClass(
+    baseClassMetadata: ResolverTypeMetadata,
+  ): ResolverTypeMetadata {
+    const classMetadata = this.getResolverImplementationForBaseClass(
+      baseClassMetadata.target,
+    );
+
+    return classMetadata
+      ? { ...baseClassMetadata, target: classMetadata.target, classMetadata }
+      : baseClassMetadata;
+  }
+
+  /** Maps every base class to the resolver that inherits its handlers. First registration wins. */
+  private collectExtendedResolversMap(
+    resolvers: readonly ResolverClassMetadata[],
+  ) {
+    for (const resolver of resolvers) {
+      let baseClass = Object.getPrototypeOf(resolver.target);
+
+      while (baseClass.prototype) {
+        const claimedBy = this.resolverByBaseClass.get(baseClass);
+        if (claimedBy) {
+          this.warnOnAmbiguousBaseClass(baseClass, claimedBy, resolver);
+        } else {
+          this.resolverByBaseClass.set(baseClass, resolver);
+        }
+        baseClass = Object.getPrototypeOf(baseClass);
+      }
+    }
+  }
+
+  /**
+   * Reached only when a base class is claimed twice. When both resolvers sit on one inheritance
+   * chain that is expected, and following the chain attributes the handlers correctly. When they
+   * sit on different branches only one can inherit the base, so the other silently misses out -
+   * worth reporting, but only if the base declares anything to miss out on.
+   */
+  private warnOnAmbiguousBaseClass(
+    baseClass: Function,
+    claimedBy: ResolverClassMetadata,
+    resolver: ResolverClassMetadata,
+  ) {
+    if (
+      this.sharesInheritanceChain(claimedBy.target, resolver.target) ||
+      !this.declaresHandler(baseClass)
+    ) {
+      return;
+    }
+
+    this.logger.warn(
+      `${baseClass.name} is extended by both ${claimedBy.target.name} and ` +
+        `${resolver.target.name}, but its handlers can only be served by one class. They will be ` +
+        `resolved by ${claimedBy.target.name} because it was registered first, so ` +
+        `${resolver.target.name} will never serve them, and reordering imports can silently swap ` +
+        `which class wins. Detecting this also adds work to every schema build; declare these ` +
+        `handlers on a base class that only one resolver extends.`,
+    );
+  }
+
+  /** True when the class declares at least one handler, i.e. there is something to miss out on. */
+  private declaresHandler(target: Function) {
+    return this.handlerGroups.some((handlers) =>
+      handlers.some((handler) => handler.target === target),
+    );
+  }
+
+  /** True when either class derives from the other, i.e. they sit on a single inheritance chain. */
+  private sharesInheritanceChain(a: Function, b: Function) {
+    return this.isDerivedFrom(a, b) || this.isDerivedFrom(b, a);
+  }
+
+  private isDerivedFrom(derived: Function, base: Function) {
+    let current = Object.getPrototypeOf(derived);
+    while (current?.prototype) {
+      if (current === base) {
+        return true;
+      }
+      current = Object.getPrototypeOf(current);
+    }
+    return false;
+  }
+}

--- a/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
+++ b/packages/graphql/lib/schema-builder/storages/type-metadata.storage.ts
@@ -23,7 +23,7 @@ import {
 } from '../metadata';
 import { InterfaceMetadata } from '../metadata/interface.metadata';
 import { ObjectTypeMetadata } from '../metadata/object-type.metadata';
-import { isThrowing } from '../utils/is-throwing.util';
+import { ResolverImplementationMap } from './resolver-implementation.map';
 
 export class TypeMetadataStorageHost {
   private readonly logger = new Logger(TypeMetadataStorageHost.name);
@@ -559,86 +559,33 @@ export class TypeMetadataStorageHost {
     ];
   }
 
+  /**
+   * Reassigns every handler declared on a base class to the resolver class that implements it. See
+   * {@link ResolverImplementationMap} for why that is necessary.
+   */
   private compileExtendedResolversMetadata() {
-    let queries = this.queries,
-      mutations = this.mutations,
-      subscriptions = this.subscriptions;
-
-    this.metadataByTargetCollection.all.resolver.forEach((item) => {
-      let parentClass = Object.getPrototypeOf(item.target);
-
-      while (parentClass.prototype) {
-        const parentMetadata = this.metadataByTargetCollection.get(
-          item.target,
-        ).resolver;
-
-        if (parentMetadata) {
-          queries = this.mergeParentResolverHandlers(
-            queries,
-            parentClass,
-            item,
-          );
-          mutations = this.mergeParentResolverHandlers(
-            mutations,
-            parentClass,
-            item,
-          );
-          subscriptions = this.mergeParentResolverHandlers(
-            subscriptions,
-            parentClass,
-            item,
-          );
-          this.fieldResolvers = this.mergeParentFieldHandlers(
-            this.fieldResolvers,
-            parentClass,
-            item,
-          );
-        }
-        parentClass = Object.getPrototypeOf(parentClass);
-      }
-    });
-
-    return { queries, mutations, subscriptions };
-  }
-
-  private mergeParentResolverHandlers<
-    T extends ResolverTypeMetadata | FieldResolverMetadata,
-  >(
-    metadata: T[],
-    parentClass: Function,
-    classMetadata: ResolverClassMetadata,
-  ): T[] {
-    return metadata.map((metadata) => {
-      return metadata.target !== parentClass
-        ? metadata
-        : {
-            ...metadata,
-            target: classMetadata.target,
-            classMetadata,
-          };
-    });
-  }
-
-  private mergeParentFieldHandlers(
-    metadata: FieldResolverMetadata[],
-    parentClass: Function,
-    classMetadata: ResolverClassMetadata,
-  ) {
-    const parentMetadata = this.mergeParentResolverHandlers(
-      metadata,
-      parentClass,
-      classMetadata,
+    const implementations = new ResolverImplementationMap(
+      this.metadataByTargetCollection.all.resolver,
+      [this.queries, this.mutations, this.subscriptions, this.fieldResolvers],
     );
-    return parentMetadata.map((metadata) => {
-      return metadata.target === parentClass
-        ? metadata
-        : {
-            ...metadata,
-            objectTypeFn: isThrowing(metadata.objectTypeFn)
-              ? classMetadata.typeFn
-              : metadata.objectTypeFn,
-          };
-    });
+
+    if (implementations.isEmpty) {
+      return {
+        queries: this.queries,
+        mutations: this.mutations,
+        subscriptions: this.subscriptions,
+      };
+    }
+
+    this.fieldResolvers = implementations.collectFieldResolversMetadata(
+      this.fieldResolvers,
+    );
+
+    return {
+      queries: implementations.collectAllMetadata(this.queries),
+      mutations: implementations.collectAllMetadata(this.mutations),
+      subscriptions: implementations.collectAllMetadata(this.subscriptions),
+    };
   }
 }
 

--- a/packages/graphql/tests/schema-builder/storages/resolver-implementation.map.spec.ts
+++ b/packages/graphql/tests/schema-builder/storages/resolver-implementation.map.spec.ts
@@ -1,0 +1,203 @@
+import { Logger } from '@nestjs/common';
+
+import {
+  FieldResolverMetadata,
+  ResolverClassMetadata,
+} from '../../../lib/schema-builder/metadata';
+import { ResolverImplementationMap } from '../../../lib/schema-builder/storages/resolver-implementation.map';
+
+const resolverFor = (target: Function): ResolverClassMetadata => ({
+  target,
+  typeFn: () => target,
+});
+
+const throwingResolverFor = (target: Function): ResolverClassMetadata => ({
+  target,
+  typeFn: () => {
+    throw new Error(`cannot resolve type for ${target.name}`);
+  },
+});
+
+const fieldResolverOn = (
+  target: Function,
+  objectTypeFn?: FieldResolverMetadata['objectTypeFn'],
+): FieldResolverMetadata => ({
+  target,
+  methodName: 'field',
+  schemaName: 'field',
+  kind: 'internal',
+  objectTypeFn,
+});
+
+const throwingObjectTypeFn = () => {
+  throw new Error('cannot determine host type');
+};
+
+describe('ResolverImplementationMap', () => {
+  describe('isEmpty', () => {
+    it('should be true when no resolver extends anything', () => {
+      class Standalone {}
+
+      const map = new ResolverImplementationMap(
+        [resolverFor(Standalone)],
+        [[]],
+      );
+
+      expect(map.isEmpty).toBe(true);
+    });
+  });
+
+  describe('getResolverImplementationForBaseClass', () => {
+    it('should follow the chain down to the most derived resolver', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      class AdminUserResolver extends UserResolver {}
+
+      const map = new ResolverImplementationMap(
+        [resolverFor(UserResolver), resolverFor(AdminUserResolver)],
+        [[]],
+      );
+
+      expect(
+        map.getResolverImplementationForBaseClass(BaseUserResolver)?.target,
+      ).toBe(AdminUserResolver);
+    });
+
+    it('should return undefined when nothing extends the class', () => {
+      class UserResolver {}
+
+      const map = new ResolverImplementationMap(
+        [resolverFor(UserResolver)],
+        [[]],
+      );
+
+      expect(
+        map.getResolverImplementationForBaseClass(UserResolver),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('collectFieldResolversMetadata', () => {
+    it('should replace a throwing objectTypeFn with the owning resolver typeFn', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      const owner = resolverFor(UserResolver);
+
+      const [compiled] = new ResolverImplementationMap(
+        [owner],
+        [[]],
+      ).collectFieldResolversMetadata([
+        fieldResolverOn(BaseUserResolver, throwingObjectTypeFn),
+      ]);
+
+      // the fallback comes from the resolver that now owns the handler, not from an unrelated one
+      expect(compiled.objectTypeFn).toBe(owner.typeFn);
+      expect(compiled.target).toBe(UserResolver);
+    });
+
+    it('should not borrow a typeFn from a resolver in an unrelated hierarchy', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      class BaseOrgResolver {}
+      class OrgResolver extends BaseOrgResolver {}
+
+      const userOwner = throwingResolverFor(UserResolver);
+      const orgOwner = resolverFor(OrgResolver);
+
+      const [compiled] = new ResolverImplementationMap(
+        [userOwner, orgOwner],
+        [[]],
+      ).collectFieldResolversMetadata([
+        fieldResolverOn(BaseUserResolver, throwingObjectTypeFn),
+      ]);
+
+      expect(compiled.objectTypeFn).toBe(userOwner.typeFn);
+      expect(compiled.objectTypeFn).not.toBe(orgOwner.typeFn);
+    });
+
+    it('should keep an objectTypeFn that resolves, by reference', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      const objectTypeFn = () => BaseUserResolver;
+
+      const [compiled] = new ResolverImplementationMap(
+        [resolverFor(UserResolver)],
+        [[]],
+      ).collectFieldResolversMetadata([
+        fieldResolverOn(BaseUserResolver, objectTypeFn),
+      ]);
+
+      expect(compiled.objectTypeFn).toBe(objectTypeFn);
+    });
+
+    it('should leave a handler with no owning resolver untouched', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      class Unrelated {}
+      const entry = fieldResolverOn(Unrelated, throwingObjectTypeFn);
+
+      const [compiled] = new ResolverImplementationMap(
+        [resolverFor(UserResolver)],
+        [[]],
+      ).collectFieldResolversMetadata([entry]);
+
+      expect(compiled).toBe(entry);
+    });
+  });
+
+  describe('ambiguous base class warning', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warn = vi
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => warn.mockRestore());
+
+    it('should warn when two resolvers on different branches share a declaring base', () => {
+      class SharedBase {}
+      class First extends SharedBase {}
+      class Second extends SharedBase {}
+
+      new ResolverImplementationMap(
+        [resolverFor(First), resolverFor(Second)],
+        [[fieldResolverOn(SharedBase)]],
+      );
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain('SharedBase');
+    });
+
+    it('should stay silent for a chain where every class is a resolver', () => {
+      class BaseUserResolver {}
+      class UserResolver extends BaseUserResolver {}
+      class AdminUserResolver extends UserResolver {}
+
+      new ResolverImplementationMap(
+        [
+          resolverFor(BaseUserResolver),
+          resolverFor(UserResolver),
+          resolverFor(AdminUserResolver),
+        ],
+        [[fieldResolverOn(BaseUserResolver)]],
+      );
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('should stay silent when the shared base declares no handlers', () => {
+      class LoggingBase {}
+      class First extends LoggingBase {}
+      class Second extends LoggingBase {}
+
+      new ResolverImplementationMap(
+        [resolverFor(First), resolverFor(Second)],
+        [[]],
+      );
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/graphql/tests/schema-builder/storages/type-metadata-storage.extended-resolvers-conflict.spec.ts
+++ b/packages/graphql/tests/schema-builder/storages/type-metadata-storage.extended-resolvers-conflict.spec.ts
@@ -1,0 +1,65 @@
+import { Logger } from '@nestjs/common';
+
+import { Query, Resolver, TypeMetadataStorage } from '../../../lib';
+import { LazyMetadataStorage } from '../../../lib/schema-builder/storages/lazy-metadata.storage';
+
+/**
+ * Two resolvers on separate branches extending the same base is ambiguous: the base's handlers can
+ * only be attributed to one of them. That resolves by registration order, so warn about the one
+ * that silently misses out.
+ */
+
+@Resolver()
+class SharedBaseResolver {
+  @Query(() => String)
+  sharedQuery(): string {
+    return 'shared';
+  }
+}
+
+@Resolver()
+class FirstDerivedResolver extends SharedBaseResolver {}
+
+@Resolver()
+class SecondDerivedResolver extends SharedBaseResolver {}
+
+describe('TypeMetadataStorage extended resolvers - shared base class', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    warn = vi
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    LazyMetadataStorage.load([
+      SharedBaseResolver,
+      FirstDerivedResolver,
+      SecondDerivedResolver,
+    ]);
+    TypeMetadataStorage.compile();
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+    TypeMetadataStorage.clear();
+  });
+
+  it('should attribute the handlers to the resolver registered first', () => {
+    const query = TypeMetadataStorage.getQueriesMetadata().find(
+      (item) => item.schemaName === 'sharedQuery',
+    );
+
+    expect(query?.target).toBe(FirstDerivedResolver);
+  });
+
+  it('should warn that the other resolver never serves the handlers', () => {
+    const messages = warn.mock.calls.map(([message]) => String(message));
+    const message = messages.find((text) =>
+      text.includes('SharedBaseResolver'),
+    );
+
+    expect(message).toBeDefined();
+    expect(message).toContain('FirstDerivedResolver');
+    expect(message).toContain('SecondDerivedResolver');
+  });
+});

--- a/packages/graphql/tests/schema-builder/storages/type-metadata-storage.extended-resolvers.spec.ts
+++ b/packages/graphql/tests/schema-builder/storages/type-metadata-storage.extended-resolvers.spec.ts
@@ -1,0 +1,58 @@
+import { Query, Resolver, TypeMetadataStorage } from '../../../lib';
+import { LazyMetadataStorage } from '../../../lib/schema-builder/storages/lazy-metadata.storage';
+
+/**
+ * Handlers declared on a base resolver are re-attributed to the class that extends it, so that the
+ * resolvers explorer instantiates the derived class. The rewrite is applied in registration order
+ * and can move the same handler more than once, which is what these cases pin down.
+ */
+
+@Resolver()
+class BaseResolver {
+  @Query(() => String)
+  inheritedQuery(): string {
+    return 'base';
+  }
+}
+
+@Resolver()
+class MidResolver extends BaseResolver {
+  @Query(() => String)
+  midQuery(): string {
+    return 'mid';
+  }
+}
+
+@Resolver()
+class LeafResolver extends MidResolver {}
+
+describe('TypeMetadataStorage extended resolvers', () => {
+  beforeAll(() => {
+    LazyMetadataStorage.load([BaseResolver, MidResolver, LeafResolver]);
+    TypeMetadataStorage.compile();
+  });
+
+  afterAll(() => {
+    TypeMetadataStorage.clear();
+  });
+
+  const queryFor = (schemaName: string) =>
+    TypeMetadataStorage.getQueriesMetadata().find(
+      (query) => query.schemaName === schemaName,
+    );
+
+  it('should re-attribute a query declared on a base resolver to the derived resolver', () => {
+    const query = queryFor('midQuery');
+
+    expect(query?.target).toBe(LeafResolver);
+    expect(query?.classMetadata?.target).toBe(LeafResolver);
+  });
+
+  it('should follow the whole chain when a resolver is extended more than once', () => {
+    // inheritedQuery starts on BaseResolver, moves to MidResolver, then on to LeafResolver.
+    const query = queryFor('inheritedQuery');
+
+    expect(query?.target).toBe(LeafResolver);
+    expect(query?.classMetadata?.target).toBe(LeafResolver);
+  });
+});


### PR DESCRIPTION
Disclosure - I used Claude Opus to investigate and fix this performance issue.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
I went looking for why our schema build was slow, expecting to find it in our own code. Instead ~13s
of it was in `compileExtendedResolversMetadata`.

For every `(resolver, ancestor)` pair it re-`map`s all four metadata arrays — so
`O(resolvers × depth × handlers)`. On our biggest service (6,281 resolvers, ~13.5 avg depth) that's
~1.06B array-element visits, and nearly all of them copy an entry unchanged.

It's invisible until you have thousands of resolvers with deep inheritance; we only hit it because we
lean on generated base resolver classes.

Issue Number: N/A


## What is the new behavior?


Walk the prototype chains once, record which resolver inherits each base class, then apply it with one
`map` per array. Extracted into `ResolverImplementationMap`; `mergeParentResolverHandlers` and
`mergeParentFieldHandlers` are now unused and removed.

| resolvers | before | after |
| --------: | -----: | ----: |
| 750 | 8.0 ms | 0.6 ms |
| 3,600 | 202.0 ms | 2.2 ms |
| 6,000 | 538.7 ms | 4.0 ms |

Our own schema generation went from ~22.5s to ~7.6s per pass.

I wrote the new unit tests against the **existing** implementation first and confirmed they pass. I also diff-tested the two implementations
over 240 randomly generated hierarchies (~120k entries, shuffled registration order) - identical
everywhere except the change described below.

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

In `mergeParentFieldHandlers`, the second `map`'s `metadata.target === parentClass` guard can never be
true — the call above it has just moved every such entry. I checked: 0 hits in 452,280 visits.

So the `objectTypeFn` fallback currently applies to *every* field resolver on *every* pair, and
converges on one shared value: the first non-throwing `typeFn` in registration order, which can come
from an unrelated hierarchy. Now it falls back to the `typeFn` of the resolver that actually owns it.

Only affects field resolvers whose `objectTypeFn` throws. Anyone depending on the old value was
depending on import order. **If you'd rather this PR were purely a perf change, say so and I'll
restore the old semantics.**


## Other information

A new warning was added when two resolvers on different branches extend the same base class
that declares handlers - only one can inherit them, and which one depends on import order. It's
lazily evaluated, and skips same-chain cases (otherwise every 3-level chain warns) and bases with no
handlers.

Happy to split this into three commits or drop the warning into its own PR — the perf change doesn't
depend on either of the others.

