### PR TITLE
feat(@nestjs/graphql): allow custom WebSocket server in subscriptions config

### DIFF
--- a/packages/graphql/lib/services/gql-subscription.service.ts
+++ b/packages/graphql/lib/services/gql-subscription.service.ts
@@ -28,6 +28,12 @@ export type GraphQLWsSubscriptionsConfig = Partial<
   >
 > & {
   path?: string;
+  /**
+   * A custom WebSocket server instance to use instead of the default
+   * `ws` WebSocketServer. When provided, the default WebSocket server
+   * will not be created for this protocol.
+   */
+  server?: WebSocketServer;
 };
 
 export type GraphQLSubscriptionTransportWsConfig = Partial<
@@ -37,6 +43,12 @@ export type GraphQLSubscriptionTransportWsConfig = Partial<
   >
 > & {
   path?: string;
+  /**
+   * A custom WebSocket server instance to use instead of the default
+   * `ws` WebSocketServer. When provided, the default WebSocket server
+   * will not be created for this protocol.
+   */
+  server?: WebSocketServer;
 };
 
 export type SubscriptionConfig = {
@@ -62,21 +74,25 @@ export class GqlSubscriptionService {
     private readonly options: GqlSubscriptionServiceOptions,
     private readonly httpServer: any,
   ) {
-    this.wss = new WebSocketServer({
-      path:
-        (this.options['graphql-ws'] as GraphQLWsSubscriptionsConfig)?.path ??
-        this.options.path,
-      noServer: true,
-    });
-    this.subTransWs = new WebSocketServer({
-      path:
-        (
-          this.options[
-            'subscriptions-transport-ws'
-          ] as GraphQLSubscriptionTransportWsConfig
-        )?.path ?? this.options.path,
-      noServer: true,
-    });
+    const graphqlWsConfig = this.options[
+      'graphql-ws'
+    ] as GraphQLWsSubscriptionsConfig;
+    this.wss =
+      (typeof graphqlWsConfig === 'object' && graphqlWsConfig?.server) ||
+      new WebSocketServer({
+        path: graphqlWsConfig?.path ?? this.options.path,
+        noServer: true,
+      });
+
+    const subTransWsConfig = this.options[
+      'subscriptions-transport-ws'
+    ] as GraphQLSubscriptionTransportWsConfig;
+    this.subTransWs =
+      (typeof subTransWsConfig === 'object' && subTransWsConfig?.server) ||
+      new WebSocketServer({
+        path: subTransWsConfig?.path ?? this.options.path,
+        noServer: true,
+      });
     this.initialize();
   }
 
@@ -86,8 +102,14 @@ export class GqlSubscriptionService {
       this.options;
 
     if ('graphql-ws' in this.options) {
-      const graphqlWsOptions =
-        this.options['graphql-ws'] === true ? {} : this.options['graphql-ws'];
+      const {
+        server: _wsServer,
+        path: _wsPath,
+        ...graphqlWsOptions
+      } =
+        this.options['graphql-ws'] === true
+          ? ({} as GraphQLWsSubscriptionsConfig)
+          : (this.options['graphql-ws'] as GraphQLWsSubscriptionsConfig);
       supportedProtocols.push(GRAPHQL_TRANSPORT_WS_PROTOCOL);
       this.wsGqlDisposable = useServer(
         {
@@ -102,10 +124,16 @@ export class GqlSubscriptionService {
     }
 
     if ('subscriptions-transport-ws' in this.options) {
-      const subscriptionsWsOptions =
+      const {
+        server: _subServer,
+        path: _subPath,
+        ...subscriptionsWsOptions
+      } =
         this.options['subscriptions-transport-ws'] === true
-          ? {}
-          : this.options['subscriptions-transport-ws'];
+          ? ({} as GraphQLSubscriptionTransportWsConfig)
+          : (this.options[
+              'subscriptions-transport-ws'
+            ] as GraphQLSubscriptionTransportWsConfig);
 
       supportedProtocols.push(GRAPHQL_WS);
       this.subServer = SubscriptionServer.create(
@@ -132,13 +160,23 @@ export class GqlSubscriptionService {
         supportedProtocols.includes(protocol),
       );
 
-      const wss =
+      const isSubTransWs =
         protocols?.includes(GRAPHQL_WS) && // subscriptions-transport-ws subprotocol
-        !protocols.includes(GRAPHQL_TRANSPORT_WS_PROTOCOL) // graphql-ws subprotocol
-          ? this.subTransWs
-          : this.wss;
+        !protocols.includes(GRAPHQL_TRANSPORT_WS_PROTOCOL); // graphql-ws subprotocol
 
-      if (req.url?.startsWith(wss.options.path)) {
+      const wss = isSubTransWs ? this.subTransWs : this.wss;
+      const subConfig = isSubTransWs
+        ? (this.options[
+            'subscriptions-transport-ws'
+          ] as GraphQLSubscriptionTransportWsConfig)
+        : (this.options['graphql-ws'] as GraphQLWsSubscriptionsConfig);
+
+      const path =
+        (typeof subConfig === 'object' && subConfig?.path) ||
+        this.options.path ||
+        wss?.options?.path;
+
+      if (!path || req.url?.startsWith(path)) {
         wss.handleUpgrade(req, socket, head, (ws) => {
           wss.emit('connection', ws, req);
         });

--- a/packages/graphql/tests/services/gql-subscription.service.spec.ts
+++ b/packages/graphql/tests/services/gql-subscription.service.spec.ts
@@ -1,0 +1,318 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GqlSubscriptionService,
+  GqlSubscriptionServiceOptions,
+} from '../../lib/services/gql-subscription.service';
+
+const { mockWsConstructor, mockUseServer, mockSubServerCreate } = vi.hoisted(
+  () => ({
+    mockWsConstructor: vi.fn(),
+    mockUseServer: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    mockSubServerCreate: vi.fn().mockReturnValue({ close: vi.fn() }),
+  }),
+);
+
+// Mock external dependencies
+vi.mock('graphql-ws/use/ws', () => ({
+  useServer: mockUseServer,
+}));
+
+vi.mock('subscriptions-transport-ws', () => ({
+  GRAPHQL_WS: 'graphql-ws',
+  SubscriptionServer: {
+    create: mockSubServerCreate,
+  },
+}));
+
+vi.mock('graphql-ws', () => ({
+  GRAPHQL_TRANSPORT_WS_PROTOCOL: 'graphql-transport-ws',
+}));
+
+vi.mock('ws', () => {
+  class MockWebSocketServer {
+    options: any;
+    handleUpgrade = vi.fn();
+    emit = vi.fn();
+    on = vi.fn();
+    constructor(opts: any) {
+      this.options = opts || {};
+      mockWsConstructor(opts);
+    }
+  }
+  return { WebSocketServer: MockWebSocketServer };
+});
+
+describe('GqlSubscriptionService', () => {
+  let mockHttpServer: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHttpServer = {
+      on: vi.fn(),
+    };
+  });
+
+  describe('constructor', () => {
+    it('should create default WebSocketServer instances when no custom server is provided', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {},
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      expect(mockWsConstructor).toHaveBeenCalledWith({
+        path: '/graphql',
+        noServer: true,
+      });
+    });
+
+    it('should use custom server for graphql-ws when provided', () => {
+      const customWss = {
+        options: { path: '/custom' },
+        handleUpgrade: vi.fn(),
+        emit: vi.fn(),
+        on: vi.fn(),
+      } as any;
+
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {
+          server: customWss,
+        },
+      };
+
+      const service = new GqlSubscriptionService(options, mockHttpServer);
+
+      expect((service as any).wss).toBe(customWss);
+    });
+
+    it('should use custom server for subscriptions-transport-ws when provided', () => {
+      const customSubWss = {
+        options: { path: '/custom-sub' },
+        handleUpgrade: vi.fn(),
+        emit: vi.fn(),
+        on: vi.fn(),
+      } as any;
+
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'subscriptions-transport-ws': {
+          server: customSubWss,
+        },
+      };
+
+      const service = new GqlSubscriptionService(options, mockHttpServer);
+
+      expect((service as any).subTransWs).toBe(customSubWss);
+    });
+
+    it('should handle boolean true for graphql-ws (default behavior)', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': true,
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      expect(mockWsConstructor).toHaveBeenCalled();
+    });
+
+    it('should handle boolean true for subscriptions-transport-ws', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'subscriptions-transport-ws': true,
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      expect(mockWsConstructor).toHaveBeenCalled();
+    });
+
+    it('should use custom path from graphql-ws config', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {
+          path: '/custom-ws-path',
+        },
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      expect(mockWsConstructor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/custom-ws-path',
+          noServer: true,
+        }),
+      );
+    });
+
+    it('should support mixed config — custom server for one, default for the other', () => {
+      const customWss = {
+        options: { path: '/custom' },
+        handleUpgrade: vi.fn(),
+        emit: vi.fn(),
+        on: vi.fn(),
+      } as any;
+
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {
+          server: customWss,
+        },
+        'subscriptions-transport-ws': {},
+      };
+
+      const service = new GqlSubscriptionService(options, mockHttpServer);
+
+      expect((service as any).wss).toBe(customWss);
+      expect((service as any).subTransWs).not.toBe(customWss);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should not pass server or path to useServer options', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {
+          path: '/ws',
+          connectionInitWaitTimeout: 5000,
+        },
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      const callArgs = mockUseServer.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('path');
+      expect(callArgs).not.toHaveProperty('server');
+      expect(callArgs).toHaveProperty('connectionInitWaitTimeout', 5000);
+    });
+
+    it('should not pass server or path to SubscriptionServer.create options', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'subscriptions-transport-ws': {
+          path: '/ws',
+          keepAlive: 10000,
+        },
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      const callArgs = mockSubServerCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('path');
+      expect(callArgs).not.toHaveProperty('server');
+      expect(callArgs).toHaveProperty('keepAlive', 10000);
+    });
+
+    it('should register upgrade handler on httpServer', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': true,
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+
+      expect(mockHttpServer.on).toHaveBeenCalledWith(
+        'upgrade',
+        expect.any(Function),
+      );
+    });
+
+    it('should handle upgrade when request url matches path', () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': true,
+      };
+
+      const service = new GqlSubscriptionService(options, mockHttpServer);
+      const upgradeHandler = mockHttpServer.on.mock.calls.find(
+        (call: any[]) => call[0] === 'upgrade',
+      )[1];
+
+      const mockReq = {
+        url: '/graphql/subscriptions',
+        headers: { 'sec-websocket-protocol': 'graphql-transport-ws' },
+      };
+      const mockSocket = {};
+      const mockHead = {};
+
+      upgradeHandler(mockReq, mockSocket, mockHead);
+
+      const wss = (service as any).wss;
+      expect(wss.handleUpgrade).toHaveBeenCalledWith(
+        mockReq,
+        mockSocket,
+        mockHead,
+        expect.any(Function),
+      );
+    });
+
+    it('should handle upgrade with custom server instance', () => {
+      const customWss = {
+        options: {},
+        handleUpgrade: vi.fn(),
+        emit: vi.fn(),
+        on: vi.fn(),
+      } as any;
+
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': {
+          server: customWss,
+        },
+      };
+
+      new GqlSubscriptionService(options, mockHttpServer);
+      const upgradeHandler = mockHttpServer.on.mock.calls.find(
+        (call: any[]) => call[0] === 'upgrade',
+      )[1];
+
+      const mockReq = {
+        url: '/graphql',
+        headers: { 'sec-websocket-protocol': 'graphql-transport-ws' },
+      };
+      const mockSocket = {};
+      const mockHead = {};
+
+      upgradeHandler(mockReq, mockSocket, mockHead);
+
+      expect(customWss.handleUpgrade).toHaveBeenCalledWith(
+        mockReq,
+        mockSocket,
+        mockHead,
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('stop', () => {
+    it('should dispose graphql-ws and close subscription server', async () => {
+      const options: GqlSubscriptionServiceOptions = {
+        schema: {} as any,
+        path: '/graphql',
+        'graphql-ws': true,
+        'subscriptions-transport-ws': true,
+      };
+
+      const service = new GqlSubscriptionService(options, mockHttpServer);
+
+      await service.stop();
+
+      expect((service as any).wsGqlDisposable.dispose).toHaveBeenCalled();
+      expect((service as any).subServer.close).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description
This PR adds support for passing a custom WebSocket server instance via the `server` option in both `graphql-ws` and `subscriptions-transport-ws` configurations.

When provided, `@nestjs/graphql` will use the provided custom server instance instead of instantiating the default `ws` WebSocketServer.

Closes #2653

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation (types documented with JSDoc).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
