### PR TITLE
fix(schema): map incoming field data back to property name (#1096)

### DIFF
--- a/packages/apollo/tests/e2e/renamed-args.spec.ts
+++ b/packages/apollo/tests/e2e/renamed-args.spec.ts
@@ -1,0 +1,463 @@
+import { ApolloServer } from '@apollo/server';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import {
+  Args,
+  ArgsType,
+  Field,
+  Float,
+  GraphQLModule,
+  ID,
+  InputType,
+  Int,
+  ObjectType,
+  Query,
+  ResolveField,
+  Resolver,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { Test } from '@nestjs/testing';
+import { MinLength } from 'class-validator';
+import { gql } from 'graphql-tag';
+import { ApolloDriver, ApolloDriverConfig } from '../../lib/index.js';
+import { expectSingleResult } from '../utils/assertion-utils.js';
+
+@InputType()
+class FiltersInput {
+  @Field(() => String, { name: 'and', nullable: true })
+  $and?: string;
+
+  @Field(() => [FiltersInput], { nullable: true })
+  nested?: FiltersInput[];
+}
+
+@ArgsType()
+class BaseArgs {
+  @Field(() => String, { name: 'inherited_arg', nullable: true })
+  inheritedArg?: string;
+}
+
+@ArgsType()
+class SomeArgsClass extends BaseArgs {
+  @Field(() => String, { name: 'some_arg' })
+  someArg: string;
+
+  @Field(() => String, { nullable: true })
+  untouchedArg?: string;
+
+  @Field(() => FiltersInput, { nullable: true })
+  filters?: FiltersInput;
+}
+
+@ObjectType()
+class AnotherObject {
+  @Field(() => [String])
+  keys: string[];
+
+  @Field(() => String, { nullable: true })
+  someArg?: string;
+
+  @Field(() => String, { nullable: true })
+  inheritedArg?: string;
+
+  @Field(() => String, { nullable: true })
+  untouchedArg?: string;
+
+  @Field(() => [String], { nullable: true })
+  filtersKeys?: string[];
+
+  @Field(() => String, { nullable: true })
+  filtersAnd?: string;
+
+  @Field(() => String, { nullable: true })
+  nestedAnd?: string;
+
+  @Field(() => String, { nullable: true })
+  resolvedField?: string;
+}
+
+enum SomeEnum {
+  A = 'A',
+  B = 'B',
+}
+registerEnumType(SomeEnum, { name: 'SomeEnum' });
+
+@ArgsType()
+class ScalarArgs {
+  @Field(() => Int, { name: 'int_arg' })
+  intArg: number;
+
+  @Field(() => Float, { name: 'float_arg' })
+  floatArg: number;
+
+  @Field(() => Boolean, { name: 'bool_arg' })
+  boolArg: boolean;
+
+  @Field(() => ID, { name: 'id_arg' })
+  idArg: string;
+
+  @Field(() => SomeEnum, { name: 'enum_arg' })
+  enumArg: SomeEnum;
+
+  @Field(() => [Int], { name: 'list_arg' })
+  listArg: number[];
+
+  @Field(() => String, { name: 'null_arg', nullable: true })
+  nullArg?: string;
+}
+
+@InputType()
+class ValidatedInput {
+  @Field(() => String, { name: 'and' })
+  @MinLength(2)
+  $and: string;
+}
+
+@InputType()
+class ChainedInput {
+  // the schema name of one property is the class name of another
+  @Field(() => String, { name: 'a', nullable: true })
+  b?: string;
+
+  @Field(() => String, { name: 'b', nullable: true })
+  c?: string;
+}
+
+@InputType()
+class NestingInput {
+  // no renamed field of its own, only the nested type has one
+  @Field(() => FiltersInput, { nullable: true })
+  filters?: FiltersInput;
+}
+
+@ObjectType()
+class Probe {
+  @Field(() => String)
+  json: string;
+}
+
+@Resolver(() => AnotherObject)
+class AnotherObjectResolver {
+  @Query(() => AnotherObject)
+  getAnotherObject(@Args() args: SomeArgsClass): AnotherObject {
+    return {
+      keys: Object.keys(args).sort(),
+      someArg: args.someArg,
+      inheritedArg: args.inheritedArg,
+      untouchedArg: args.untouchedArg,
+      ...this.describeFilters(args.filters),
+    };
+  }
+
+  @Query(() => AnotherObject)
+  getByFilters(@Args('filters') filters: FiltersInput): AnotherObject {
+    return {
+      keys: Object.keys(filters).sort(),
+      ...this.describeFilters(filters),
+    };
+  }
+
+  @Query(() => AnotherObject)
+  validate(
+    @Args('input', new ValidationPipe({ transform: true }))
+    input: ValidatedInput,
+  ): AnotherObject {
+    return { keys: Object.keys(input).sort(), filtersAnd: input.$and };
+  }
+
+  @ResolveField(() => String, { nullable: true })
+  resolvedField(@Args() args: SomeArgsClass): string {
+    return args.someArg;
+  }
+
+  @Query(() => String)
+  scalars(@Args() args: ScalarArgs): string {
+    // the replacer keeps the output order stable
+    return JSON.stringify(args, Object.keys(args).sort());
+  }
+
+  @Query(() => String)
+  chained(@Args('input') input: ChainedInput): string {
+    return JSON.stringify(input, Object.keys(input).sort());
+  }
+
+  @Query(() => String)
+  listOfFilters(
+    @Args('filters', { type: () => [FiltersInput] }) filters: FiltersInput[],
+  ): string {
+    return JSON.stringify(filters.map((filter) => Object.keys(filter).sort()));
+  }
+
+  private describeFilters(filters?: FiltersInput) {
+    return {
+      filtersKeys: filters && Object.keys(filters).sort(),
+      filtersAnd: filters?.$and,
+      nestedAnd: filters?.nested?.[0]?.$and,
+    };
+  }
+}
+
+describe('Renamed args (@Field({ name }) on @ArgsType/@InputType classes)', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServer;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot<ApolloDriverConfig>({
+          driver: ApolloDriver,
+          autoSchemaFile: true,
+        }),
+      ],
+      providers: [AnotherObjectResolver],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+    apolloClient =
+      app.get<GraphQLModule<ApolloDriver>>(GraphQLModule).graphQlAdapter
+        ?.instance;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should hand the resolver the property names declared by the args class', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          getAnotherObject(
+            some_arg: "a"
+            inherited_arg: "b"
+            untouchedArg: "c"
+            filters: { and: "d", nested: [{ and: "e" }] }
+          ) {
+            keys
+            someArg
+            inheritedArg
+            untouchedArg
+            filtersKeys
+            filtersAnd
+            nestedAnd
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      getAnotherObject: {
+        keys: ['filters', 'inheritedArg', 'someArg', 'untouchedArg'],
+        someArg: 'a',
+        inheritedArg: 'b',
+        untouchedArg: 'c',
+        filtersKeys: ['$and', 'nested'],
+        filtersAnd: 'd',
+        nestedAnd: 'e',
+      },
+    });
+  });
+
+  it('should map nested input types of a named argument as well', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          getByFilters(filters: { and: "d", nested: [{ and: "e" }] }) {
+            keys
+            filtersAnd
+            nestedAnd
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      getByFilters: {
+        keys: ['$and', 'nested'],
+        filtersAnd: 'd',
+        nestedAnd: 'e',
+      },
+    });
+  });
+
+  it('should map the args of a field resolver too', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          getAnotherObject(some_arg: "a") {
+            resolvedField(some_arg: "b")
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      getAnotherObject: { resolvedField: 'b' },
+    });
+  });
+
+  it('should map every scalar kind, falsy values and nulls included', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          scalars(
+            int_arg: 0
+            float_arg: 1.5
+            bool_arg: false
+            id_arg: "7"
+            enum_arg: B
+            list_arg: [1, 2]
+            null_arg: null
+          )
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      scalars: JSON.stringify({
+        boolArg: false,
+        enumArg: 'B',
+        floatArg: 1.5,
+        idArg: '7',
+        intArg: 0,
+        listArg: [1, 2],
+        nullArg: null,
+      }),
+    });
+  });
+
+  it('should run before the user pipes, so validation sees the class properties', async () => {
+    const valid = await apolloClient.executeOperation({
+      query: gql`
+        {
+          validate(input: { and: "ok" }) {
+            keys
+            filtersAnd
+          }
+        }
+      `,
+    });
+    expectSingleResult(valid).toEqual({
+      validate: { keys: ['$and'], filtersAnd: 'ok' },
+    });
+
+    const invalid: any = await apolloClient.executeOperation({
+      query: gql`
+        {
+          validate(input: { and: "x" }) {
+            filtersAnd
+          }
+        }
+      `,
+    });
+    expect(
+      invalid.body.singleResult.errors[0].extensions.originalError.message,
+    ).toEqual(['$and must be longer than or equal to 2 characters']);
+  });
+
+  it('should not let a chained rename overwrite another property', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          chained(input: { a: "one", b: "two" })
+        }
+      `,
+    });
+
+    // "a" belongs to property "b" and "b" belongs to property "c"
+    expectSingleResult(response).toEqual({
+      chained: JSON.stringify({ b: 'one', c: 'two' }),
+    });
+  });
+
+  it('should map a list-typed named argument', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          listOfFilters(filters: [{ and: "d" }, { and: "e" }])
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      listOfFilters: JSON.stringify([['$and'], ['$and']]),
+    });
+  });
+});
+
+@Resolver(() => Probe)
+class GlobalPipeResolver {
+  @Query(() => Probe)
+  validateGlobally(@Args('input') input: ValidatedInput): Probe {
+    return { json: JSON.stringify({ keys: Object.keys(input).sort() }) };
+  }
+
+  @Query(() => Probe)
+  keepInstance(@Args('input') input: NestingInput): Probe {
+    return {
+      json: JSON.stringify({
+        isInstance: input instanceof NestingInput,
+        and: input.filters?.$and,
+      }),
+    };
+  }
+}
+
+describe('Renamed args behind a globally registered pipe', () => {
+  let app: INestApplication;
+  let apolloClient: ApolloServer;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        GraphQLModule.forRoot<ApolloDriverConfig>({
+          driver: ApolloDriver,
+          autoSchemaFile: true,
+        }),
+      ],
+      providers: [GlobalPipeResolver],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    await app.init();
+    apolloClient =
+      app.get<GraphQLModule<ApolloDriver>>(GraphQLModule).graphQlAdapter
+        ?.instance;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should map the args before a global ValidationPipe validates them', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          validateGlobally(input: { and: "ok" }) {
+            json
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      validateGlobally: { json: JSON.stringify({ keys: ['$and'] }) },
+    });
+  });
+
+  it('should keep the instance produced by a transforming global pipe', async () => {
+    const response = await apolloClient.executeOperation({
+      query: gql`
+        {
+          keepInstance(input: { filters: { and: "d" } }) {
+            json
+          }
+        }
+      `,
+    });
+
+    expectSingleResult(response).toEqual({
+      keepInstance: { json: JSON.stringify({ isInstance: true, and: 'd' }) },
+    });
+  });
+});

--- a/packages/graphql/lib/decorators/args.decorator.ts
+++ b/packages/graphql/lib/decorators/args.decorator.ts
@@ -9,7 +9,9 @@ import { GqlParamtype } from '../enums/gql-paramtype.enum.js';
 import { BaseTypeOptions } from '../interfaces/index.js';
 import { LazyMetadataStorage } from '../schema-builder/storages/lazy-metadata.storage.js';
 import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.storage.js';
+import { ARGS_TYPE_METADATA } from '../graphql.constants.js';
 import { isPipe } from '../utils/is-pipe.util.js';
+import { ArgsTypeMetadata } from '../utils/map-args-to-props.util.js';
 import { reflectTypeFromMetadata } from '../utils/reflection.utilts.js';
 import { addPipesMetadata } from './param.utils.js';
 
@@ -112,6 +114,23 @@ export function Args(
 
   return (target: object, key: string, index: number) => {
     addPipesMetadata(GqlParamtype.ARGS, property, argPipes, target, key, index);
+
+    // Arguments arrive keyed by their schema names. Record what each parameter
+    // expects so that the resolvers explorer can map them back to the property
+    // names declared by the `@ArgsType()`/`@InputType()` class before any pipe
+    // (global ones included) gets to see the value.
+    const argsTypes: ArgsTypeMetadata[] =
+      Reflect.getOwnMetadata(ARGS_TYPE_METADATA, target.constructor, key) ?? [];
+    Reflect.defineMetadata(
+      ARGS_TYPE_METADATA,
+      argsTypes.concat({
+        index,
+        property: isString(property) ? property : undefined,
+        typeFn: argOptions.type,
+      }),
+      target.constructor,
+      key,
+    );
 
     LazyMetadataStorage.store(target.constructor as Type<unknown>, () => {
       const { typeFn: reflectedTypeFn, options } = reflectTypeFromMetadata({

--- a/packages/graphql/lib/graphql.constants.ts
+++ b/packages/graphql/lib/graphql.constants.ts
@@ -7,6 +7,7 @@ export const RESOLVER_DELEGATE_METADATA = 'graphql:delegate_property';
 export const SCALAR_NAME_METADATA = 'graphql:scalar_name';
 export const SCALAR_TYPE_METADATA = 'graphql:scalar_type';
 export const PARAM_ARGS_METADATA = '__routeArguments__';
+export const ARGS_TYPE_METADATA = 'graphql:args_type';
 export const SUBSCRIPTION_OPTIONS_METADATA = 'graphql:subscription_options;';
 export const CLASS_TYPE_METADATA = 'graphql:class_type';
 

--- a/packages/graphql/lib/services/resolvers-explorer.service.ts
+++ b/packages/graphql/lib/services/resolvers-explorer.service.ts
@@ -40,6 +40,8 @@ import { GqlEntrypointMetadata } from '../interfaces/gql-entrypoint-metadata.int
 import { ResolverMetadata } from '../interfaces/resolver-metadata.interface.js';
 import { decorateFieldResolverWithMiddleware } from '../utils/decorate-field-resolver.util.js';
 import { extractMetadata } from '../utils/extract-metadata.util.js';
+import { createArgsMapper } from '../utils/map-args-to-props.util.js';
+import { normalizeResolverArgs } from '../utils/normalize-resolver-args.js';
 import { BaseExplorerService } from './base-explorer.service.js';
 import { GqlContextType } from './gql-execution-context.js';
 
@@ -179,6 +181,7 @@ export class ResolversExplorerService extends BaseExplorerService {
   ) {
     const paramsFactory = this.gqlParamsFactory;
     const isPropertyResolver = !ROOT_RESOLVER_TYPES.has(resolver.type);
+    const mapArgs = createArgsMapper(instance.constructor, resolver.methodName);
 
     if (this.fieldResolverEnhancersLookup === null) {
       const enhancers = this.gqlOptions.fieldResolverEnhancers || [];
@@ -223,13 +226,14 @@ export class ResolversExplorerService extends BaseExplorerService {
         );
         return callback(...args);
       };
+      const wrappedCallback = this.withMappedArgs(resolverCallback, mapArgs);
       return isPropertyResolver
         ? this.registerFieldMiddlewareIfExists(
-            resolverCallback,
+            wrappedCallback,
             instance,
             resolver.methodName,
           )
-        : resolverCallback;
+        : wrappedCallback;
     }
 
     if (
@@ -260,14 +264,43 @@ export class ResolversExplorerService extends BaseExplorerService {
       contextOptions,
       'graphql',
     );
+    const wrappedCallback = this.withMappedArgs(resolverCallback, mapArgs);
 
     return isPropertyResolver
       ? this.registerFieldMiddlewareIfExists(
-          resolverCallback,
+          wrappedCallback,
           instance,
           resolver.methodName,
         )
-      : resolverCallback;
+      : wrappedCallback;
+  }
+
+  /**
+   * Rewrites the incoming arguments object onto the property names declared by
+   * the `@ArgsType()`/`@InputType()` classes of the method before the resolver
+   * context (and therefore any pipe, global ones included) runs.
+   */
+  private withMappedArgs<T extends (...args: any[]) => any>(
+    resolverFn: T,
+    mapArgs: ((args: any) => any) | null,
+  ): T {
+    if (!mapArgs) {
+      return resolverFn;
+    }
+    return ((...args: any[]) => {
+      // Reference resolvers and "resolveType" callbacks receive no arguments
+      // object, which is exactly what normalizeResolverArgs() detects.
+      if (args.length < 2 || normalizeResolverArgs(args) !== args) {
+        return resolverFn(...args);
+      }
+      const mappedArgs = mapArgs(args[1]);
+      if (mappedArgs === args[1]) {
+        return resolverFn(...args);
+      }
+      const nextArgs = [...args];
+      nextArgs[1] = mappedArgs;
+      return resolverFn(...nextArgs);
+    }) as T;
   }
 
   createSubscriptionMetadata(

--- a/packages/graphql/lib/utils/map-args-to-props.util.ts
+++ b/packages/graphql/lib/utils/map-args-to-props.util.ts
@@ -1,0 +1,229 @@
+import { isUndefined } from '@nestjs/common/utils/shared.utils.js';
+import { ARGS_TYPE_METADATA } from '../graphql.constants.js';
+import { PropertyMetadata } from '../schema-builder/metadata/index.js';
+import { TypeMetadataStorage } from '../schema-builder/storages/type-metadata.storage.js';
+
+/**
+ * What a single `@Args()` parameter declared, recorded at decoration time.
+ */
+export interface ArgsTypeMetadata {
+  index: number;
+  /**
+   * Name of the single argument the parameter binds to, or `undefined` when the
+   * parameter receives the whole arguments object.
+   */
+  property?: string;
+  /**
+   * Explicit `type` option passed to `@Args()`, if any.
+   */
+  typeFn?: () => any;
+}
+
+interface MappedProp {
+  schemaName: string;
+  name: string;
+  typeRef?: Function;
+}
+
+interface ArgsMapperEntry {
+  property?: string;
+  classRef: Function;
+}
+
+const propsCache = new WeakMap<object, PropertyMetadata[]>();
+const hasRenamedPropsCache = new WeakMap<object, boolean>();
+const mappedPropsCache = new WeakMap<object, MappedProp[]>();
+
+function getProps(classRef: Function): PropertyMetadata[] {
+  if (propsCache.has(classRef)) {
+    return propsCache.get(classRef);
+  }
+  const classesMetadata = [
+    ...TypeMetadataStorage.getArgumentsMetadata(),
+    ...TypeMetadataStorage.getInputTypesMetadata(),
+  ];
+  const properties: PropertyMetadata[] = [];
+
+  let target = classRef;
+  while (!isUndefined(target?.prototype)) {
+    const classMetadata = classesMetadata.find(
+      (item) => item.target === target,
+    );
+    if (classMetadata?.properties) {
+      properties.push(...classMetadata.properties);
+    }
+    target = Object.getPrototypeOf(target);
+  }
+  propsCache.set(classRef, properties);
+  return properties;
+}
+
+function hasRenamedProps(classRef: Function): boolean {
+  if (hasRenamedPropsCache.has(classRef)) {
+    return hasRenamedPropsCache.get(classRef);
+  }
+  // iterative instead of recursive, input types are allowed to reference each other
+  const visited = new Set<Function>();
+  const queue = [classRef];
+  let hasRenamed = false;
+
+  while (queue.length && !hasRenamed) {
+    const current = queue.pop();
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    for (const { name, schemaName, typeFn } of getProps(current)) {
+      if (schemaName !== name) {
+        hasRenamed = true;
+        break;
+      }
+      const typeRef = typeFn?.();
+      if (typeof typeRef === 'function') {
+        queue.push(typeRef);
+      }
+    }
+  }
+  hasRenamedPropsCache.set(classRef, hasRenamed);
+  return hasRenamed;
+}
+
+function getMappedProps(classRef: Function): MappedProp[] {
+  if (mappedPropsCache.has(classRef)) {
+    return mappedPropsCache.get(classRef);
+  }
+  const mappedProps: MappedProp[] = [];
+  getProps(classRef).forEach(({ name, schemaName, typeFn }) => {
+    const typeRef = typeFn?.();
+    const nestedTypeRef =
+      typeof typeRef === 'function' && hasRenamedProps(typeRef)
+        ? typeRef
+        : undefined;
+
+    if (schemaName !== name || nestedTypeRef) {
+      mappedProps.push({ schemaName, name, typeRef: nestedTypeRef });
+    }
+  });
+  mappedPropsCache.set(classRef, mappedProps);
+  return mappedProps;
+}
+
+/**
+ * Rewrites `value` so that every field renamed through `@Field({ name: '...' })`
+ * is keyed by the property name its class declares instead of its schema name.
+ *
+ * The result is always a fresh object: reading the renamed fields from the
+ * original `value` keeps chained renames (a property whose schema name is
+ * another property's class name) from overwriting each other.
+ */
+export function mapArgsToProps(value: any, classRef: Function): any {
+  const mappedProps = getMappedProps(classRef);
+  if (!mappedProps.length || !value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => mapArgsToProps(item, classRef));
+  }
+  const renamed = new Set(
+    mappedProps
+      .filter(({ schemaName, name }) => schemaName !== name)
+      .map(({ schemaName }) => schemaName),
+  );
+  const mapped: Record<string, any> = {};
+
+  for (const key of Object.keys(value)) {
+    if (!renamed.has(key)) {
+      mapped[key] = value[key];
+    }
+  }
+  for (const { schemaName, name, typeRef } of mappedProps) {
+    if (!(schemaName in value)) {
+      continue;
+    }
+    mapped[name] = typeRef
+      ? mapArgsToProps(value[schemaName], typeRef)
+      : value[schemaName];
+  }
+  return mapped;
+}
+
+function resolveArgClass(
+  { index, typeFn }: ArgsTypeMetadata,
+  target: Function,
+  methodName: string,
+): Function | undefined {
+  // The explicit `type` option wins: a list argument reflects as `Array`, which
+  // tells us nothing about the element type.
+  let typeRef = typeFn?.();
+  while (Array.isArray(typeRef)) {
+    typeRef = typeRef[0];
+  }
+  if (!typeRef) {
+    const paramtypes: Function[] =
+      Reflect.getMetadata('design:paramtypes', target.prototype, methodName) ??
+      [];
+    typeRef = paramtypes[index];
+  }
+  return typeof typeRef === 'function' ? typeRef : undefined;
+}
+
+/**
+ * Builds the function that maps the raw GraphQL arguments of a single resolver
+ * method onto the property names its `@Args()` classes declare, or `null` when
+ * the method takes no arguments at all.
+ *
+ * The classes involved are resolved lazily, on the first call, because the
+ * metadata this relies on is only complete once the schema has been built.
+ */
+export function createArgsMapper(
+  target: Function,
+  methodName: string,
+): ((args: any) => any) | null {
+  const argsTypes: ArgsTypeMetadata[] = Reflect.getMetadata(
+    ARGS_TYPE_METADATA,
+    target,
+    methodName,
+  );
+  if (!argsTypes?.length) {
+    return null;
+  }
+  let entries: ArgsMapperEntry[] | undefined;
+
+  return (args: any) => {
+    if (!entries) {
+      entries = argsTypes
+        .map((argsType) => ({
+          property: argsType.property,
+          classRef: resolveArgClass(argsType, target, methodName),
+        }))
+        .filter(
+          ({ classRef }) => classRef && hasRenamedProps(classRef),
+        ) as ArgsMapperEntry[];
+
+      // Named arguments read from the incoming, schema-keyed object, so they
+      // have to be mapped before a whole-object `@Args()` renames their keys.
+      entries.sort((a, b) => Number(!a.property) - Number(!b.property));
+    }
+    if (!entries.length || !args || typeof args !== 'object') {
+      return args;
+    }
+    let result = args;
+
+    for (const { property, classRef } of entries) {
+      if (!property) {
+        result = mapArgsToProps(result, classRef);
+        continue;
+      }
+      if (!(property in result)) {
+        continue;
+      }
+      const mappedValue = mapArgsToProps(result[property], classRef);
+      if (mappedValue !== result[property]) {
+        result = result === args ? { ...result } : result;
+        result[property] = mappedValue;
+      }
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: #1096

When using `FieldOptions.name` on a `@Field()` decorator (e.g. `@Field(() => String, { name: 'and' })` on a property `$and`), the data resolved in the resolver uses the GraphQL schema-level name (`and`) instead of the original class property name (`$and`), making custom-named fields effectively unusable when working with the resolved args object.

## What is the new behavior?
Field data resolved from GraphQL arguments is now mapped back to the original class property name instead of the schema-level name set via `FieldOptions.name`. For example, a field declared as `@Field(() => String, { name: 'and' })` on property `$and` will now correctly appear as `$and` in the resolved object passed to resolver logic, rather than `and`.

Closes #1096

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information